### PR TITLE
Fix faulty location mapping for paths with repeated substrings

### DIFF
--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -125,6 +125,13 @@ describe('Source-to-source offset mapping', () => {
       expectTokenMapping(module, 'bar');
       expectTokenMapping(module, 'this');
     });
+
+    test('paths with repeated subsequences', () => {
+      let module = rewriteTestModule({ contents: '{{this.tabState.tab}}' });
+      expectTokenMapping(module, 'this');
+      expectTokenMapping(module, 'tabState');
+      expectTokenMapping(module, 'tab', { occurrence: 1 });
+    });
   });
 
   describe('keys', () => {

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -814,6 +814,8 @@ export function templateToTypescript(
         emit.identifier(head, start);
       }
 
+      start += head.length;
+
       for (let i = 1; i < parts.length; i++) {
         let part = parts[i];
         start = template.indexOf(part, start);
@@ -825,6 +827,7 @@ export function templateToTypescript(
           emit.identifier(JSON.stringify(part), start, part.length);
           emit.text(']');
         }
+        start += part.length;
       }
     }
 


### PR DESCRIPTION
Since `@glimmer/syntax` doesn't give location information for path segments, we have to reverse engineer where they fall in the source, and we weren't being quite careful enough with offset tracking.

Given a path like `{{this.foolish.foo}}`, the `foo` segment would be incorrectly mapped to the first three characters of `foolish` in the output. This change ensures we walk forward completely past the previous segment before searching for the location of the next one.