### PR TITLE
Ensure moved files don't result in broken imports

### DIFF
--- a/packages/tsserver-plugin/__tests__/test-server.ts
+++ b/packages/tsserver-plugin/__tests__/test-server.ts
@@ -116,6 +116,7 @@ export class Project {
 
       if (!this.openFiles.has(file)) {
         if (!fs.existsSync(file)) {
+          fs.mkdirSync(path.dirname(file), { recursive: true });
           fs.writeFileSync(file, fileContent ?? '');
         }
 

--- a/packages/tsserver-plugin/src/index.ts
+++ b/packages/tsserver-plugin/src/index.ts
@@ -14,9 +14,10 @@ const init: ts.server.PluginModuleFactory = ({ typescript: ts }) => {
   return {
     create(info) {
       let logger = loggerFor(info);
-      let config = loadConfig(path.dirname(info.project.projectName));
+      let projectDir = path.dirname(info.project.projectName);
+      let config = loadConfig(projectDir);
 
-      logger.log('\nStarting @glint/tsserver-plugin at', new Date().toString());
+      logger.log('\nStarting @glint/tsserver-plugin in', projectDir, 'at', new Date().toString());
 
       modules.addProject(config, info.project);
 

--- a/packages/tsserver-plugin/src/language-service.ts
+++ b/packages/tsserver-plugin/src/language-service.ts
@@ -355,14 +355,7 @@ export default class GlintLanguageService implements Partial<ts.LanguageService>
     formatOptions: ts.FormatCodeSettings,
     preferences: ts.UserPreferences | undefined
   ): readonly ts.FileTextChanges[] {
-    let oldTransformedPath = isTransformablePath(oldFilePath)
-      ? getTransformedPath(oldFilePath)
-      : oldFilePath;
-
-    let edits = [
-      ...this.ls.getEditsForFileRename(oldTransformedPath, newFilePath, formatOptions, preferences),
-      ...this.ls.getEditsForFileRename(oldFilePath, newFilePath, formatOptions, preferences),
-    ];
+    let edits = this.ls.getEditsForFileRename(oldFilePath, newFilePath, formatOptions, preferences);
 
     return edits.filter((edit) => !isTransformedPath(edit.fileName));
   }


### PR DESCRIPTION
This fixes #14, which actually only required deletion of code since #17 landed, except it turned out there was no testing for file renames.