### PR TITLE
Improve error reporting when failing to associate a companion template

### DIFF
--- a/packages/transform/src/transformed-module.ts
+++ b/packages/transform/src/transformed-module.ts
@@ -81,7 +81,10 @@ export default class TransformedModule {
     let startInfo = this.determineOriginalOffsetAndSpan(transformedStart);
     let endInfo = this.determineOriginalOffsetAndSpan(transformedEnd);
 
-    assert(startInfo.correlatedSpan.originalFile === endInfo.correlatedSpan.originalFile);
+    assert(
+      startInfo.correlatedSpan.originalFile === endInfo.correlatedSpan.originalFile,
+      'Attempted to transform a range across two different files'
+    );
 
     let source = startInfo.correlatedSpan.originalFile;
     let start = startInfo.originalOffset;


### PR DESCRIPTION
Quick bugfix for something I ran into working on typesafe reexports. The "you need a default export" error message was only being generated inside the traversal callback _for_ an `ExportDefaultDeclaration`, which obviously caused issues.

This error is now split in two: one when no default export is present at all, and one when it's not a syntactic form we know how to deal with.