### PR TITLE
Transform `{{unless}}` as `if (!...)`

### DIFF
--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -89,6 +89,24 @@ describe('rewriteTemplate', () => {
       });
     });
 
+    describe('{{unless}}', () => {
+      test('without an alternate', () => {
+        let template = '{{unless @foo "ok"}}';
+
+        expect(templateBody(template)).toMatchInlineSnapshot(
+          `"!(𝚪.args.foo) ? (\\"ok\\") : (undefined);"`
+        );
+      });
+
+      test('with an alternate', () => {
+        let template = '{{unless @foo "ok" "nope"}}';
+
+        expect(templateBody(template)).toMatchInlineSnapshot(
+          `"!(𝚪.args.foo) ? (\\"ok\\") : (\\"nope\\");"`
+        );
+      });
+    });
+
     describe('{{#if}}', () => {
       test('without an {{else}}', () => {
         let template = stripIndent`
@@ -170,6 +188,40 @@ describe('rewriteTemplate', () => {
               },
             });
             χ.Globals[\\"doAThing\\"];
+          }"
+        `);
+      });
+    });
+
+    describe('{{#unless}}', () => {
+      test('without an {{else}}', () => {
+        let template = stripIndent`
+          {{#unless @foo}}
+            {{@ok}}
+          {{/unless}}
+        `;
+
+        expect(templateBody(template)).toMatchInlineSnapshot(`
+          "if (!(𝚪.args.foo)) {
+            χ.invokeEmit(χ.resolveOrReturn(𝚪.args.ok)({}));
+          }"
+        `);
+      });
+
+      test('with an {{else}}', () => {
+        let template = stripIndent`
+          {{#unless @foo}}
+            {{@ok}}
+          {{else}}
+            {{@noGood}}
+          {{/unless}}
+        `;
+
+        expect(templateBody(template)).toMatchInlineSnapshot(`
+          "if (!(𝚪.args.foo)) {
+            χ.invokeEmit(χ.resolveOrReturn(𝚪.args.ok)({}));
+          } else {
+            χ.invokeEmit(χ.resolveOrReturn(𝚪.args.noGood)({}));
           }"
         `);
       });


### PR DESCRIPTION
This change updates `@glint/transform` to handle `{{unless}}` as a built-in keyword translated as `if (!...)`, rather than implementing it as a `DirectInvokable`.

This allows type narrowing information to propagate down into the arms of the conditional, which is useful for simple things today and potentially much more so once the logical operators RFC is implemented and we can treat `(and)`, `(or)` and `(not)` as directly translatable to their TS equivalents.