### PR TITLE
Ensure non-identifier hash keys are mapped correctly

### DIFF
--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -24,7 +24,7 @@ describe('Language Server: Completions', () => {
         \`;
       }
 
-      class Inner extends Component<{ Args: { foo?: string; bar?: number } }> {}
+      class Inner extends Component<{ Args: { foo?: string; 'bar-baz'?: number } }> {}
     `;
 
     project.write('index.ts', code);
@@ -42,13 +42,13 @@ describe('Language Server: Completions', () => {
       },
       {
         kind: CompletionItemKind.Field,
-        label: 'bar',
+        label: 'bar-baz',
       },
     ]);
 
     let details = server.getCompletionDetails(completions![1]);
 
-    expect(details.detail).toEqual('(property) bar?: number | undefined');
+    expect(details.detail).toEqual("(property) 'bar-baz'?: number | undefined");
   });
 
   test('referencing class properties', () => {

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -210,7 +210,7 @@ describe('Source-to-source offset mapping', () => {
           contents: '{{foo bar-baz=hello}}',
         });
         expectTokenMapping(module, 'foo');
-        expectTokenMapping(module, 'bar-baz', { transformedToken: '"bar-baz"' });
+        expectTokenMapping(module, 'bar-baz');
         expectTokenMapping(module, 'hello');
       });
 
@@ -230,7 +230,7 @@ describe('Source-to-source offset mapping', () => {
           contents: '<Foo @bar-baz={{hello}} />',
         });
         expectTokenMapping(module, 'Foo');
-        expectTokenMapping(module, 'bar-baz', { transformedToken: '"bar-baz"' });
+        expectTokenMapping(module, 'bar-baz');
         expectTokenMapping(module, 'hello');
       });
 
@@ -249,7 +249,7 @@ describe('Source-to-source offset mapping', () => {
           contents: '<Foo><:block-name>hi</:block-name></Foo>',
         });
         expectTokenMapping(module, 'Foo');
-        expectTokenMapping(module, 'block-name', { transformedToken: '"block-name"' });
+        expectTokenMapping(module, 'block-name');
       });
     });
 

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -792,16 +792,22 @@ export function templateToTypescript(
         if (isSafeKey(part)) {
           emit.identifier(part, start);
         } else {
-          emit.text('[');
-          emit.identifier(JSON.stringify(part), start, part.length);
-          emit.text(']');
+          emit.text('["');
+          emit.identifier(JSON.stringify(part).slice(1, -1), start, part.length);
+          emit.text('"]');
         }
         start += part.length;
       }
     }
 
     function emitHashKey(name: string, start: number): void {
-      emit.identifier(isSafeKey(name) ? name : JSON.stringify(name), start, name.length);
+      if (isSafeKey(name)) {
+        emit.identifier(name, start);
+      } else {
+        emit.text('"');
+        emit.identifier(JSON.stringify(name).slice(1, -1), start, name.length);
+        emit.text('"');
+      }
     }
 
     function emitLiteral(node: AST.Literal): void {


### PR DESCRIPTION
This is similar to the bug that revealed the larger issue identified in #61, but in reverse. For arg names that aren't identifier-safe (such as the spinal-case event names used by `<Input />`, we were mapping the full string rather than only its contents to the HBS identifier.

This would cause TypeScript to suggest string keys when completing those arguments, which doesn't give the result we'd want.

![image](https://user-images.githubusercontent.com/108688/111037887-6733be00-8426-11eb-8a6e-94873f15baae.png)
