### PR TITLE
Interpret functions that accept `unknown` in GlimmerX as helpers, not modifiers

### DIFF
--- a/packages/environment-glimmerx/-private/dsl/index.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/index.d.ts
@@ -35,6 +35,9 @@ export declare function resolve<Args extends unknown[], Instance extends Invokab
 export declare function resolve<Value, Args extends unknown[], T extends Value>(
   item: (value: Value, ...args: Args) => value is T
 ): (named: EmptyObject, value: Value, ...args: Args) => value is T;
+export declare function resolve<Args extends unknown[], T>(
+  item: (arg: unknown, ...args: Args) => T
+): (named: EmptyObject, arg: unknown, ...args: Args) => T;
 export declare function resolve<El extends Element, Args extends unknown[]>(
   item: (element: El, ...args: Args) => void | (() => void)
 ): (named: EmptyObject, ...args: Args) => BoundModifier<El>;

--- a/packages/environment-glimmerx/__tests__/helper.test.ts
+++ b/packages/environment-glimmerx/__tests__/helper.test.ts
@@ -1,4 +1,4 @@
-import { resolve } from '@glint/environment-glimmerx/-private/dsl';
+import { invokeEmit, resolve } from '@glint/environment-glimmerx/-private/dsl';
 import { helper, fn as fnDefinition } from '@glint/environment-glimmerx/helper';
 import { EmptyObject } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
@@ -107,4 +107,18 @@ import { expectTypeOf } from 'expect-type';
   } else {
     expectTypeOf(x).toEqualTypeOf<number>();
   }
+}
+
+// Custom helper that accepts `unknown`
+// (and therefore plausibly could be interpreted as a modifier, but shouldn't be)
+{
+  let definition = (_arg: unknown, callback: () => void): void => callback();
+
+  let hackyOnChange = resolve(definition);
+
+  expectTypeOf(hackyOnChange).toEqualTypeOf<
+    (named: EmptyObject, arg: unknown, callback: () => void) => void
+  >();
+
+  invokeEmit(hackyOnChange({}, 'hello', () => console.log('change!')));
 }

--- a/packages/environment-glimmerx/__tests__/modifier.test.ts
+++ b/packages/environment-glimmerx/__tests__/modifier.test.ts
@@ -24,3 +24,19 @@ import { expectTypeOf } from 'expect-type';
 
   expectTypeOf(applyModifier(on({}, 'click', () => {}))).toEqualTypeOf<void>();
 }
+
+// Custom modifier with a specific element type
+{
+  const fetchImageData = resolve(
+    (element: HTMLImageElement, callback: (data: ImageData | undefined) => void): void => {
+      let context = document.createElement('canvas').getContext('2d');
+      context?.drawImage(element, 0, 0);
+      callback(context?.getImageData(0, 0, element.naturalWidth, element.naturalHeight));
+    }
+  );
+
+  applyModifier<HTMLImageElement>(fetchImageData({}, (data) => console.log(data)));
+
+  // @ts-expect-error: invalid element type
+  applyModifier<HTMLDivElement>(fetchImageData({}, (data) => console.log(data)));
+}


### PR DESCRIPTION
I caught this in my RealWorld demo app—because functions that accept `unknown` as their first argument are technically functions that accept an `Element`, they were being resolved as modifiers. In that scenario, though, you almost certainly want the function to be treated as a helper instead.

This change fixes GlimmerX's resolution there and adds some missing test coverage.