### PR TITLE
Fix TS nightly typechecking

### DIFF
--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -42,7 +42,8 @@ export function rewriteDiagnostic<
 
   let length = end - start;
   let diagnostic: T = {
-    ...transformedDiagnostic,
+    // This cast is safe (it's the declared parameter type), but needed as of 4.3.0-dev.20210322
+    ...(transformedDiagnostic as T),
     start,
     length,
     file: tsImpl.createSourceFile(source.filename, source.contents, tsImpl.ScriptTarget.Latest),


### PR DESCRIPTION
The `@glint/transform` source had a sudden type error crop up with the latest TS nightly. It's not clear whether this is a bug upstream or catching some baroque edge case in the type system, but either way we need a (AFAICT safe and redundant) cast to make it happy.

Closes #75