### PR TITLE
Fix `each` not working with a `readonly` array

### DIFF
--- a/packages/template/-private/keywords/each.d.ts
+++ b/packages/template/-private/keywords/each.d.ts
@@ -1,7 +1,7 @@
 import { AcceptsBlocks, DirectInvokable } from '../integration';
 
 export type EachKeyword = DirectInvokable<{
-  <T>(args: { key?: string }, items: T[]): AcceptsBlocks<{
+  <T>(args: { key?: string }, items: readonly T[]): AcceptsBlocks<{
     default: [T, number];
     inverse?: [];
   }>;

--- a/packages/template/__tests__/keywords/each.test.ts
+++ b/packages/template/__tests__/keywords/each.test.ts
@@ -13,6 +13,15 @@ invokeBlock(eachKeyword({}, ['a', 'b', 'c']), {
   },
 });
 
+// Works for `readonly` arrays
+
+invokeBlock(eachKeyword({}, ['a', 'b', 'c'] as readonly string[]), {
+  default(value, index) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  },
+});
+
 // Accept a `key` string
 invokeBlock(eachKeyword({ key: 'id' }, [{ id: 1 }]), {
   default() {


### PR DESCRIPTION
I can't seem to run tests locally (i.e. most of them fail) so let's see what the CI says.