### PR TITLE
Performance improvements

### DIFF
--- a/packages/core/src/language-server/index.ts
+++ b/packages/core/src/language-server/index.ts
@@ -13,9 +13,16 @@ const ts = loadTypeScript();
 const glintConfig = findConfig(process.cwd());
 const tsconfigPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists);
 const { fileNames, options } = parseConfigFile(ts, tsconfigPath);
+
 const tsFileNames = fileNames.filter((fileName) => /\.ts$/.test(fileName));
+const baseProjectRoots = new Set(tsFileNames);
 const getRootFileNames = (): Array<string> => {
-  return tsFileNames.concat(documents.all().map((doc) => uriToFilePath(doc.uri)));
+  return tsFileNames.concat(
+    documents
+      .all()
+      .map((doc) => uriToFilePath(doc.uri))
+      .filter((path) => path.endsWith('.ts') && !baseProjectRoots.has(path))
+  );
 };
 
 if (glintConfig) {

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -93,6 +93,8 @@ export function rewriteModule(
   let scriptAST: t.File | t.Program | null = null;
   try {
     scriptAST = parseSync(input.script.contents, {
+      babelrc: false,
+      configFile: false,
       filename: input.script.filename,
       code: false,
       presets: [require.resolve('@babel/preset-typescript')],

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -24,7 +24,7 @@ export function rewriteDiagnostic<
 >(
   tsImpl: typeof ts,
   transformedDiagnostic: T,
-  locateTransformedModule: (fileName: string) => TransformedModule | undefined
+  locateTransformedModule: (fileName: string) => TransformedModule | null | undefined
 ): T {
   assert(transformedDiagnostic.file);
   assert(transformedDiagnostic.start);


### PR DESCRIPTION
I spent a bit of time profiling with Glint open in a non-toy-sized project and found a few pieces of low-hanging fruit for speeding things up:

1. **Keep Babel from doing unnecessary work**: `@babel/core`'s `parseSync` was doing a file system crawl looking for configuration files for every _single_ parse. Even assuming the OS was smart about caching those results, we were spending a lot of time in there. That behavior is now disabled (and is something we can consider doing once ourselves in the future if we have the need to support more exotic `.js` syntaxes).

2. **Cache negative transform results**: we now cache the result of transforming a file even if that result is "we didn't need to transform it", since just doing the analysis to see if we might need to check is more expensive than the quick document version comparison we can do if the result is cached.

3. **Don't thwart TypeScript's own bookkeeping**: in order to account for newly-created files that may be open in the editor but not exist on disk yet, the `rootFileNames` we supply can change over time. Since adding a new file can change module resolution results, changing `rootFileNames` causes TypeScript to discard all its internal program state. This is the correct behavior, but we were previously triggering it _any_ time a file was opened.

In a codebase with ~15k `.ts` and ~6k `.hbs` lines of code, this makes a night-and-day difference to editor feedback:

| Before | After |
|-|-|
|![before](https://user-images.githubusercontent.com/108688/113013767-45ec0500-917c-11eb-871d-167ee3c71628.gif) | ![after](https://user-images.githubusercontent.com/108688/113013783-48e6f580-917c-11eb-88ec-98113717f745.gif) |
