### PR TITLE
build before launch in Debug Extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
       "name": "Debug Extension",
       "type": "pwa-extensionHost",
       "request": "launch",
+      "preLaunchTask": "npm: build",
       "autoAttachChildProcesses": true,
       "runtimeExecutable": "${execPath}",
       "args": [


### PR DESCRIPTION
This adds a preLaunchTask to run `build` before launching the extension development host.