### PR TITLE
Type primary elements properly for built-in components

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/input.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/input.d.ts
@@ -1,4 +1,4 @@
-import { AcceptsBlocks, DirectInvokable, EmptyObject } from '@glint/template/-private/integration';
+import { AcceptsBlocks, ElementInvokable, EmptyObject } from '@glint/template/-private/integration';
 
 export interface CheckboxInputArgs {
   type: 'checkbox';
@@ -18,6 +18,7 @@ export interface TextInputArgs {
   'key-up'?: (value: string, event: KeyboardEvent) => void;
 }
 
-export type InputComponent = DirectInvokable<{
-  (args: CheckboxInputArgs | TextInputArgs): AcceptsBlocks<EmptyObject>;
-}>;
+export type InputComponent = new () => ElementInvokable<
+  HTMLInputElement,
+  (args: CheckboxInputArgs | TextInputArgs) => AcceptsBlocks<EmptyObject>
+>;

--- a/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
@@ -1,4 +1,9 @@
-import { AcceptsBlocks, DirectInvokable, EmptyObject } from '@glint/template/-private/integration';
+import {
+  AcceptsBlocks,
+  DirectInvokable,
+  ElementInvokable,
+  EmptyObject,
+} from '@glint/template/-private/integration';
 
 export type LinkToKeyword = DirectInvokable<{
   (args: EmptyObject, route: string, ...params: unknown[]): AcceptsBlocks<{
@@ -17,6 +22,7 @@ export interface LinkToArgs {
   query?: Record<string, unknown>;
 }
 
-export type LinkToComponent = DirectInvokable<{
-  (args: LinkToArgs): AcceptsBlocks<{ default: [] }>;
-}>;
+export type LinkToComponent = new () => ElementInvokable<
+  HTMLAnchorElement,
+  (args: LinkToArgs) => AcceptsBlocks<{ default: [] }>
+>;

--- a/packages/environment-ember-loose/-private/intrinsics/textarea.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/textarea.d.ts
@@ -1,4 +1,4 @@
-import { AcceptsBlocks, DirectInvokable, EmptyObject } from '@glint/template/-private/integration';
+import { AcceptsBlocks, ElementInvokable, EmptyObject } from '@glint/template/-private/integration';
 
 export interface TextareaArgs {
   value?: string;
@@ -10,6 +10,7 @@ export interface TextareaArgs {
   'key-press'?: (value: string, event: KeyboardEvent) => void;
 }
 
-export type TextareaComponent = DirectInvokable<{
-  (args: TextareaArgs): AcceptsBlocks<EmptyObject>;
-}>;
+export type TextareaComponent = new () => ElementInvokable<
+  HTMLTextAreaElement,
+  (args: TextareaArgs) => AcceptsBlocks<EmptyObject>
+>;

--- a/packages/environment-ember-loose/__tests__/intrinsics/component.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/component.test.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf } from 'expect-type';
-import { resolve, invokeBlock } from '@glint/environment-ember-loose/-private/dsl';
+import {
+  resolve,
+  invokeBlock,
+  applySplattributes,
+  ElementForComponent,
+} from '@glint/environment-ember-loose/-private/dsl';
 import Component from '@glint/environment-ember-loose/ember-component';
 import { ComponentKeyword } from '@glint/environment-ember-loose/-private/intrinsics/component';
 
@@ -11,6 +16,7 @@ type LocalRegistry = {
 };
 
 class StringComponent extends Component<{
+  Element: HTMLFormElement;
   Args: { value: string };
   Yields: { default?: [string] };
 }> {}
@@ -20,6 +26,9 @@ const ValueCurriedStringComponent = componentKeyword({ value: 'hello' }, 'string
 
 // Invoking the noop-curried component
 invokeBlock(resolve(NoopCurriedStringComponent)({ value: 'hello' }), {});
+
+// Applying attributes/modifiers to the noop-curried component
+applySplattributes<HTMLFormElement, ElementForComponent<typeof NoopCurriedStringComponent>>();
 
 // @ts-expect-error: Invoking the curried component but forgetting `value`
 resolve(NoopCurriedStringComponent)({});
@@ -51,6 +60,9 @@ invokeBlock(resolve(ValueCurriedStringComponent)({}), {});
 // Invoking the curried-with-value component with a valid value
 invokeBlock(resolve(ValueCurriedStringComponent)({ value: 'hi' }), {});
 
+// Applying attributes/modifiers to the noop-curried component
+applySplattributes<HTMLFormElement, ElementForComponent<typeof ValueCurriedStringComponent>>();
+
 // @ts-expect-error: Invoking the curred-with-value component with an invalid value
 invokeBlock(resolve(ValueCurriedStringComponent)({ value: 123 }), {});
 
@@ -61,6 +73,7 @@ componentKeyword({ foo: true }, StringComponent);
 componentKeyword({ value: 123 }, StringComponent);
 
 class ParametricComponent<T> extends Component<{
+  Element: HTMLFormElement;
   Args: { values: Array<T>; optional?: string };
   Yields: { default?: [T, number] };
 }> {}
@@ -94,6 +107,9 @@ invokeBlock(resolve(NoopCurriedParametricComponent)({ values: ['hello'] }), {
     expectTypeOf(value).toEqualTypeOf<string>();
   },
 });
+
+// Applying attributes/modifiers to the parametric component
+applySplattributes<HTMLFormElement, ElementForComponent<typeof NoopCurriedParametricComponent>>();
 
 invokeBlock(
   resolve(NoopCurriedParametricComponent)(

--- a/packages/environment-ember-loose/__tests__/intrinsics/input.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/input.test.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf } from 'expect-type';
-import { Globals, resolve } from '@glint/environment-ember-loose/-private/dsl';
+import {
+  applySplattributes,
+  ElementForComponent,
+  Globals,
+  resolve,
+} from '@glint/environment-ember-loose/-private/dsl';
 
 let input = resolve(Globals['input']);
 let Input = resolve(Globals['Input']);
@@ -11,6 +16,9 @@ Input({}), {};
 Input({ value: 'hello' });
 Input({ type: 'string', value: 'hello' });
 Input({ type: 'checkbox', checked: true });
+
+// Ensure we can apply <input>-specific attributes
+applySplattributes<HTMLInputElement, ElementForComponent<Globals['Input']>>();
 
 // @ts-expect-error: `checked` only works with `@type=checkbox`
 Input({ checked: true });

--- a/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
@@ -1,9 +1,18 @@
-import { Globals, resolve, invokeBlock } from '@glint/environment-ember-loose/-private/dsl';
+import {
+  Globals,
+  resolve,
+  invokeBlock,
+  applySplattributes,
+  ElementForComponent,
+} from '@glint/environment-ember-loose/-private/dsl';
 
 let linkTo = resolve(Globals['link-to']);
 let LinkTo = resolve(Globals['LinkTo']);
 
 invokeBlock(linkTo({}, 'index', 123), {});
+
+// Ensure we can apply <a>-specific attributes
+applySplattributes<HTMLAnchorElement, ElementForComponent<Globals['LinkTo']>>();
 
 // @ts-expect-error: bad type for route name
 linkTo({}, 123);

--- a/packages/environment-ember-loose/__tests__/intrinsics/textarea.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/textarea.test.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf } from 'expect-type';
-import { Globals, resolve } from '@glint/environment-ember-loose/-private/dsl';
+import {
+  applySplattributes,
+  ElementForComponent,
+  Globals,
+  resolve,
+} from '@glint/environment-ember-loose/-private/dsl';
 
 let textarea = resolve(Globals['textarea']);
 let Textarea = resolve(Globals['Textarea']);
@@ -9,6 +14,9 @@ expectTypeOf(textarea).toEqualTypeOf(Textarea);
 
 Textarea({}), {};
 Textarea({ value: 'hello' });
+
+// Ensure we can apply <textarea>-specific attributes
+applySplattributes<HTMLTextAreaElement, ElementForComponent<Globals['Textarea']>>();
 
 // Event handlers
 Textarea({

--- a/packages/template/-private/integration.d.ts
+++ b/packages/template/-private/integration.d.ts
@@ -20,6 +20,12 @@ export type Invokable<T extends AnyFunction = AnyFunction> = { [Invoke]: T };
 export declare const Context: unique symbol;
 export type HasContext<T extends AnyContext = AnyContext> = { [Context]: T };
 
+/** Denotes a component-like item that is both invokable and may accept attributes/modifiers */
+export type ElementInvokable<
+  El extends Element | null | undefined,
+  T extends AnyFunction
+> = HasElement<El> & Invokable<T>;
+
 // These shenanigans are necessary to get TS to report when named args
 // are passed to a signature that doesn't expect any, because `{}` is
 // special-cased in the type system not to trigger EPC.


### PR DESCRIPTION
When we migrated to enforce correct usage of modifiers and `...attributes`, we didn't add `Element` declarations for the built-in `<Input>`, `<Textarea>` and `<LinkTo>` components. The `{{component}}` intrinsic also didn't pass through its target's `Element` information.

This PR takes care of both of those issues. Fixes #85 