### PR TITLE
Introduce `ComponentLike` and associated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ TypeScript-powered tooling for Glimmer templates.
     - [Component Signatures](#component-signatures-1)
     - [Ember Components](#ember-components)
     - [Template Registry](#template-registry)
+    - [Contextual Components](#contextual-components)
 - [Known Limitations](#known-limitations)
   - [Environment Re-exports](#environment-re-exports)
   - [Ember-Specific](#ember-specific)
@@ -240,6 +241,66 @@ declare module '@glint/environment-ember-loose/registry' {
     Greeting: typeof Greeting;
   }
 }
+```
+
+#### Contextual Components
+
+When you yield a contextual component, e.g. `{{yield (component "my-component" foo="bar")}}`, you need some way to declare the type of that value in your component signature. For this you can use the `ComponentLike` type, or the `ComponentWithBoundArgs` shorthand.
+
+```ts
+interface MyComponentSignature {
+  Element: HTMLInputElement;
+  Args: {
+    value: string;
+    count: number;
+  };
+}
+
+class MyComponent extends Component<MyComponentSignature> {
+  // ...
+}
+```
+
+Given a component like the one declared above, if you wrote this in some other component's template:
+
+```hbs
+{{yield (hash
+  foo=(component "my-component")
+)}}
+```
+
+You could type your `Yields` as:
+
+```ts
+Yields: {
+  default: [{ foo: typeof MyComponent }]
+}
+```
+
+However, if you pre-set the value of the `@value` arg, the consumer shouldn't _also_ need to set that arg. You need a way to declare that that argument is now optional:
+
+```ts
+import { ComponentWithBoundArgs } from '@glint/environment-ember-loose';
+
+// ...
+
+Yields: {
+  default: [{ foo: ComponentWithBoundArgs<typeof MyComponent, 'value'> }]
+}
+```
+
+If you had pre-bound multiple args, you could union them together with the `|` type operator, e.g. `'value' | 'count'`.
+
+Note that `ComponentWithBoundArgs` is effectively shorthand for writing out a `ComponentLike<Signature>` type, which is a generic type that any Glimmer component, Ember component or `{{component}}` return value is assignable to, assuming it has a matching signature.
+
+```ts
+import { ComponentLike } from '@glint/environment-ember-loose';
+
+type AcceptsAFooString = ComponentLike<{ Args: { foo: string } }>;
+
+const Ember: AcceptsAFooString = class extends EmberComponent<{ Args: { foo: string } }> {};
+const Glimmer: AcceptsAFooString = class extends GlimmerComponent<{ Args: { foo: string } }> {};
+const Bound: AcceptsAFooString = /* the result of `{{component "ember-component"}}` */
 ```
 
 ## Known Limitations

--- a/packages/environment-ember-loose/-private/index.ts
+++ b/packages/environment-ember-loose/-private/index.ts
@@ -1,0 +1,1 @@
+export { ComponentSignature, ComponentLike, ComponentWithBoundArgs } from './utilities';

--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -1,0 +1,91 @@
+import {
+  AcceptsBlocks,
+  ElementInvokable,
+  EmptyObject,
+  HasElement,
+  Invokable,
+} from '@glint/template/-private/integration';
+
+type Constructor<T> = new (...params: any) => T;
+type Get<T, K, Otherwise = EmptyObject> = K extends keyof T ? Exclude<T[K], undefined> : Otherwise;
+
+export type ElementOf<C extends ComponentLike> = C extends Constructor<HasElement<infer Element>>
+  ? Element
+  : null;
+
+export type ArgsOf<C extends ComponentLike> = C extends Constructor<
+  Invokable<(args: infer Args) => any>
+>
+  ? Args
+  : never;
+
+export type YieldsOf<C extends ComponentLike> = C extends Constructor<
+  Invokable<(args: any) => AcceptsBlocks<infer Yields>>
+>
+  ? Yields
+  : never;
+
+/**
+ * The basic shape of a valid component signature. See the
+ * README for further details.
+ */
+export type ComponentSignature = {
+  Args?: Partial<Record<string, unknown>>;
+  Yields?: Partial<Record<string, Array<unknown>>>;
+  Element?: Element | null;
+};
+
+/**
+ * A value that is invokable like a component in a template. Notably,
+ * subclasses of `EmberComponent` and `GlimmerComponent` are `ComponentLike`,
+ * as are the values returned from the `{{component}}` helper.
+ */
+export type ComponentLike<T extends ComponentSignature = any> = Constructor<
+  ElementInvokable<
+    Get<T, 'Element', null>,
+    (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>>
+  >
+>;
+
+/**
+ * A shorthand type for declaring the result of a `{{component}}`
+ * call. For instance, if you had a component like this:
+ *
+ * ```ts
+ * class MyComponent extends Component<{ Args: { foo: string; bar: number } }> {}
+ * ```
+ *
+ * And yielded it to a block like this:
+ *
+ * ```handlebars
+ * {{yield (component 'my-component' foo="hello")}}
+ * ```
+ *
+ * You could type that yield parameter as:
+ *
+ * ```ts
+ * ComponentWithBoundArgs<typeof MyComponent, 'foo'>;
+ * ```
+ *
+ * And the resulting `ComponentLike` would have the `foo` key as
+ * optional in its `Args`.
+ *
+ * Note that this shorthand won't work if the type of other args
+ * or of yielded parameters depends on the type of one or more
+ * bound arguments. In such cases you may need to construct a
+ * `ComponentLike` type manually instead.
+ *
+ * Note also that TypeScript will not perfectly enforce that the
+ * bound component you pass actually _meets_ the given type. You
+ * can write `{{component 'my-component'}}` and pass that value in
+ * a place where you said to expect the `foo` arg to already be
+ * bound, and TypeScript unfortunately won't catch that.
+ */
+export type ComponentWithBoundArgs<
+  T extends ComponentLike,
+  BoundArgs extends keyof ArgsOf<T>
+> = ComponentLike<{
+  Element: ElementOf<T>;
+  Yields: YieldsOf<T>;
+  Args: Omit<ArgsOf<T>, BoundArgs> & Partial<Pick<ArgsOf<T>, BoundArgs>>;
+}>;

--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -75,11 +75,13 @@ export type ComponentLike<T extends ComponentSignature = any> = Constructor<
  * bound arguments. In such cases you may need to construct a
  * `ComponentLike` type manually instead.
  *
- * Note also that TypeScript will not perfectly enforce that the
- * bound component you pass actually _meets_ the given type. You
- * can write `{{component 'my-component'}}` and pass that value in
- * a place where you said to expect the `foo` arg to already be
- * bound, and TypeScript unfortunately won't catch that.
+ * Note also that you must have `strictFunctionTypes` enabled for
+ * TypeScript to fully enforce that the bound component you pass
+ * actually _meets_ the given type. Given the definition above,
+ * You can write `{{component 'my-component'}}` and pass that value
+ * in a place where you said to expect the `foo` arg to already be
+ * bound, that won't be flagged as an error if `strictFunctionTypes`
+ * is disabled.
  */
 export type ComponentWithBoundArgs<
   T extends ComponentLike,

--- a/packages/environment-ember-loose/__tests__/intrinsics/component.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/component.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@glint/environment-ember-loose/-private/dsl';
 import Component from '@glint/environment-ember-loose/ember-component';
 import { ComponentKeyword } from '@glint/environment-ember-loose/-private/intrinsics/component';
+import { ComponentWithBoundArgs, ComponentLike } from '@glint/environment-ember-loose';
 
 const componentKeyword = resolve({} as ComponentKeyword<LocalRegistry>);
 
@@ -23,6 +24,20 @@ class StringComponent extends Component<{
 
 const NoopCurriedStringComponent = componentKeyword({}, 'string');
 const ValueCurriedStringComponent = componentKeyword({ value: 'hello' }, 'string');
+
+// Once value is curried, it should be optional in args
+expectTypeOf(ValueCurriedStringComponent).toEqualTypeOf<
+  ComponentLike<{
+    Element: HTMLFormElement;
+    Args: { value?: string };
+    Yields: { default?: [string] };
+  }>
+>();
+
+// This is also equivalent to this `ComponentWithBoundArgs` shorthand:
+expectTypeOf(ValueCurriedStringComponent).toEqualTypeOf<
+  ComponentWithBoundArgs<typeof ValueCurriedStringComponent, 'value'>
+>();
 
 // Invoking the noop-curried component
 invokeBlock(resolve(NoopCurriedStringComponent)({ value: 'hello' }), {});

--- a/packages/environment-ember-loose/ember-component/index.ts
+++ b/packages/environment-ember-loose/ember-component/index.ts
@@ -7,6 +7,9 @@ import type {
   EmptyObject,
 } from '@glint/template/-private/integration';
 
+import type { ComponentSignature } from '../-private';
+export type { ComponentSignature };
+
 declare const Ember: { Component: EmberComponentConstructor };
 
 const EmberComponent = Ember.Component;
@@ -18,12 +21,6 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   : Otherwise;
 
 export type ArgsFor<T extends ComponentSignature> = 'Args' extends keyof T ? T['Args'] : {};
-
-export interface ComponentSignature {
-  Args?: Partial<Record<string, unknown>>;
-  Yields?: Partial<Record<string, Array<unknown>>>;
-  Element?: Element;
-}
 
 const Component = (EmberComponent as unknown) as new <T extends ComponentSignature = {}>(
   ...args: ConstructorParameters<EmberComponentConstructor>

--- a/packages/environment-ember-loose/glimmer-component/index.ts
+++ b/packages/environment-ember-loose/glimmer-component/index.ts
@@ -7,6 +7,9 @@ import type {
   EmptyObject,
 } from '@glint/template/-private/integration';
 
+import type { ComponentSignature } from '../-private';
+export type { ComponentSignature };
+
 const GlimmerComponent = window.require('@glimmer/component').default;
 type GlimmerComponent<T> = import('@glimmer/component').default<T>;
 type GlimmerComponentConstructor = typeof import('@glimmer/component').default;
@@ -14,12 +17,6 @@ type GlimmerComponentConstructor = typeof import('@glimmer/component').default;
 type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
-
-export interface ComponentSignature {
-  Args?: Partial<Record<string, unknown>>;
-  Yields?: Partial<Record<string, Array<unknown>>>;
-  Element?: Element;
-}
 
 const Component = GlimmerComponent as new <T extends ComponentSignature = {}>(
   ...args: ConstructorParameters<GlimmerComponentConstructor>

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -6,6 +6,8 @@
   "license": "MIT",
   "author": "Dan Freeman (https://github.com/dfreeman)",
   "glint-environment": "-private/environment/index.js",
+  "main": "-private/index.js",
+  "types": "-private/index.d.ts",
   "keywords": [
     "glint-environment"
   ],


### PR DESCRIPTION
Currently we don't have a way to express the kind of value `{{component}}` returns in userland. This PR introduces a `ComponentLike<T extends ComponentSignature>` type to `@glint/environment-ember-loose`.

`ComponentLike` is a unifying type for anything that can be invoked as a component. This includes subclasses of `EmberComponent` and `GlimmerComponent` (note: the classes themselves, _not_ their instances) as well as `{{component}}`'s return value. In this way it's now possible for users to write an appropriate type when they expect to receive or yield a component, using the same `ComponentSignature` basis as they already use for defining components themselves.

This PR also introduces a `ComponentWithBoundArgs<T extends ComponentLike, ArgNames>` type as a useful shorthand for constructing a `ComponentLike` where certain args have been made optional e.g. because they were already set by invoking `{{component}}`. In other words, given a type like this:

```ts
class MyComponent extends Component<{
  Element: HTMLFormElement;
  Yields: { default?: [] };
  Args: {
    foo: string;
    bar: number;
  };
}> {}
```

Then `ComponentWithBoundArgs<typeof MyComponent, 'foo'>` would be:

```ts
ComponentLike<{
  Element: HTMLFormElement;
  Yields: { default?: [] };
  Args: {
    foo?: string; // <-- optional now
    bar: number;
  };
}>
```