### PR TITLE
Bugfix batch for `environment-ember-loose`

### DIFF
--- a/packages/environment-ember-loose/-private/dsl/globals.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/globals.d.ts
@@ -3,6 +3,7 @@ import * as VM from '@glint/template/-private/keywords';
 import { ActionKeyword } from '../intrinsics/action';
 import { ComponentKeyword } from '../intrinsics/component';
 import { ConcatHelper } from '../intrinsics/concat';
+import { EachKeyword } from '../intrinsics/each';
 import { EachInKeyword } from '../intrinsics/each-in';
 import { FnHelper } from '../intrinsics/fn';
 import { GetHelper } from '../intrinsics/get';
@@ -59,7 +60,7 @@ interface Keywords {
 
     [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=each
   */
-  each: VM.EachKeyword;
+  each: EachKeyword;
 
   /**
     The `{{each-in}}` helper loops over properties on an object.

--- a/packages/environment-ember-loose/-private/intrinsics/each.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each.d.ts
@@ -1,0 +1,11 @@
+import { AcceptsBlocks, DirectInvokable } from '@glint/template/-private/integration';
+import EmberArray from '@ember/array';
+
+type ArrayLike<T> = ReadonlyArray<T> | Iterable<T> | EmberArray<T>;
+
+export type EachKeyword = DirectInvokable<{
+  <T>(args: { key?: string }, items: ArrayLike<T>): AcceptsBlocks<{
+    default: [T, number];
+    inverse?: [];
+  }>;
+}>;

--- a/packages/environment-ember-loose/-private/intrinsics/get.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/get.d.ts
@@ -1,6 +1,8 @@
 import { DirectInvokable, EmptyObject } from '@glint/template/-private/integration';
+import ObjectProxy from '@ember/object/proxy';
 
 export type GetHelper = DirectInvokable<{
   <T, K extends keyof T>(args: EmptyObject, obj: T, key: K): T[K];
+  <T extends object, K extends keyof T>(args: EmptyObject, obj: ObjectProxy<T>, key: K): T[K];
   (args: EmptyObject, obj: unknown, key: string): unknown;
 }>;

--- a/packages/environment-ember-loose/__tests__/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/helper.test.ts
@@ -72,3 +72,18 @@ import { EmptyObject } from '@glint/template/-private/integration';
   expectTypeOf(repeat({ value: 'hi' })).toEqualTypeOf<Array<string>>();
   expectTypeOf(repeat({ value: 123, count: 3 })).toEqualTypeOf<Array<number>>();
 }
+
+// Class-based helpers can return undefined
+{
+  class MaybeStringHelper extends Helper<{ Return: string | undefined }> {
+    compute(): string | undefined {
+      if (Math.random() > 0.5) {
+        return 'ok';
+      }
+    }
+  }
+
+  let maybeString = resolve(MaybeStringHelper);
+
+  expectTypeOf(maybeString).toEqualTypeOf<(args: EmptyObject) => string | undefined>();
+}

--- a/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
@@ -1,0 +1,54 @@
+import { expectTypeOf } from 'expect-type';
+import { Globals, resolve, invokeBlock } from '@glint/environment-ember-loose/-private/dsl';
+import ArrayProxy from '@ember/array/proxy';
+
+let each = resolve(Globals['each']);
+
+// Yield out array values and indices
+
+invokeBlock(each({}, ['a', 'b', 'c']), {
+  default(value, index) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  },
+  inverse(...args) {
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  },
+});
+
+// Works for Ember arrays
+
+declare const proxiedArray: ArrayProxy<string>;
+
+invokeBlock(each({}, proxiedArray), {
+  default(value, index) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  },
+});
+
+// Works for other iterables
+
+invokeBlock(each({}, new Map<string, symbol>()), {
+  default([key, value], index) {
+    expectTypeOf(key).toEqualTypeOf<string>();
+    expectTypeOf(value).toEqualTypeOf<symbol>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  },
+});
+
+// Works for `readonly` arrays
+
+invokeBlock(each({}, ['a', 'b', 'c'] as readonly string[]), {
+  default(value, index) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  },
+});
+
+// Accept a `key` string
+invokeBlock(each({ key: 'id' }, [{ id: 1 }]), {
+  default() {
+    // Don't yield
+  },
+});

--- a/packages/environment-ember-loose/__tests__/intrinsics/get.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/get.test.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf } from 'expect-type';
 import { Globals, resolve } from '@glint/environment-ember-loose/-private/dsl';
+import ObjectProxy from '@ember/object/proxy';
 
 let get = resolve(Globals['get']);
 
@@ -17,3 +18,10 @@ get(
   {},
   'hi'
 );
+
+// Getting a value off an ObjectProxy
+declare const proxiedObject: ObjectProxy<{ name: string }>;
+
+expectTypeOf(get({}, proxiedObject, 'content')).toEqualTypeOf<{ name: string }>();
+expectTypeOf(get({}, proxiedObject, 'name')).toEqualTypeOf<string>();
+expectTypeOf(get({}, proxiedObject, 'unknownKey')).toEqualTypeOf<unknown>();

--- a/packages/environment-ember-loose/ember-component/helper.ts
+++ b/packages/environment-ember-loose/ember-component/helper.ts
@@ -8,9 +8,7 @@ type EmberHelperConstructor = typeof import('@ember/component/helper').default;
 const EmberHelper = Ember.Helper;
 const emberHelper = Ember.Helper.helper;
 
-type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
-  ? Exclude<T[Key], undefined>
-  : Otherwise;
+type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T ? T[Key] : Otherwise;
 
 type HelperFactory = <Positional extends unknown[] = [], Named = EmptyObject, Return = unknown>(
   fn: (params: Positional, hash: Named) => Return
@@ -39,7 +37,7 @@ interface Helper<T extends HelperSignature> extends Omit<EmberHelper, 'compute'>
 
   [Invoke]: (
     named: Get<T, 'NamedArgs'>,
-    ...positional: Get<T, 'PositionalArgs', []>
+    ...positional: Exclude<Get<T, 'PositionalArgs', []>, undefined>
   ) => Get<T, 'Return'>;
 }
 


### PR DESCRIPTION
This PR contains fixes for a handful of issues reported with `environment-ember-loose`:

 - class-based helpers no longer have `undefined` stripped from their return type (fixes #87)
 - `{{each}}` handles Ember arrays and native `Iterable` values (fixes #118)
 - `{{get}}` handles `ObjectProxy` instances, which allows for template-native access of fields from things like ember-data's `AsyncBelongsTo`, even if it's not quite as ergonomic as just writing `{{proxy.field}}` (fixes #104)