### PR TITLE
Don't crash for operations on an unaffiliated template

### DIFF
--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -14,6 +14,18 @@ describe('Language Server: Completions', () => {
     await project.destroy();
   });
 
+  test('querying an unaffiliated template', () => {
+    project.write('index.hbs', '{{foo}}');
+
+    let server = project.startLanguageServer();
+    let completions = server.getCompletions(project.fileURI('index.hbs'), {
+      line: 0,
+      character: 2,
+    });
+
+    expect(completions).toBeUndefined();
+  });
+
   test('passing component args', () => {
     let code = stripIndent`
       import Component, { hbs } from '@glint/environment-glimmerx/component';

--- a/packages/core/__tests__/language-server/definitions.test.ts
+++ b/packages/core/__tests__/language-server/definitions.test.ts
@@ -13,6 +13,18 @@ describe('Language Server: Definitions', () => {
     await project.destroy();
   });
 
+  test('querying an unaffiliated template', () => {
+    project.write('index.hbs', '{{foo}}');
+
+    let server = project.startLanguageServer();
+    let definitions = server.getDefinition(project.fileURI('index.hbs'), {
+      line: 0,
+      character: 2,
+    });
+
+    expect(definitions).toEqual([]);
+  });
+
   test('component invocation', () => {
     project.write({
       'greeting.ts': stripIndent`

--- a/packages/core/__tests__/language-server/hover.test.ts
+++ b/packages/core/__tests__/language-server/hover.test.ts
@@ -13,6 +13,18 @@ describe('Language Server: Hover', () => {
     await project.destroy();
   });
 
+  test('querying an unaffiliated template', () => {
+    project.write('index.hbs', '{{foo}}');
+
+    let server = project.startLanguageServer();
+    let info = server.getHover(project.fileURI('index.hbs'), {
+      line: 0,
+      character: 2,
+    });
+
+    expect(info).toBeUndefined();
+  });
+
   test('using private properties', () => {
     project.write({
       'index.ts': stripIndent`

--- a/packages/core/__tests__/language-server/references.test.ts
+++ b/packages/core/__tests__/language-server/references.test.ts
@@ -13,6 +13,18 @@ describe('Language Server: References', () => {
     await project.destroy();
   });
 
+  test('querying an unaffiliated template', () => {
+    project.write('index.hbs', '{{foo}}');
+
+    let server = project.startLanguageServer();
+    let references = server.getReferences(project.fileURI('index.hbs'), {
+      line: 0,
+      character: 2,
+    });
+
+    expect(references).toEqual([]);
+  });
+
   test('component references', () => {
     project.write({
       'greeting.ts': stripIndent`

--- a/packages/core/__tests__/language-server/rename.test.ts
+++ b/packages/core/__tests__/language-server/rename.test.ts
@@ -13,6 +13,18 @@ describe('Language Server: Renaming Symbols', () => {
     await project.destroy();
   });
 
+  test('querying an unaffiliated template', () => {
+    project.write('index.hbs', '{{foo}}');
+
+    let server = project.startLanguageServer();
+    let renameInfo = server.prepareRename(project.fileURI('index.hbs'), {
+      line: 0,
+      character: 2,
+    });
+
+    expect(renameInfo).toBeUndefined();
+  });
+
   test('preparing rename-able and unrename-able elements', () => {
     project.write({
       'index.ts': stripIndent`

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -125,6 +125,8 @@ export default class GlintLanguageServer {
 
   public getCompletions(uri: string, position: Position): CompletionItem[] | undefined {
     let { transformedFileName, transformedOffset } = this.getTransformedOffset(uri, position);
+    if (isTemplate(transformedFileName)) return;
+
     let completions = this.service.getCompletionsAtPosition(
       transformedFileName,
       transformedOffset,
@@ -172,6 +174,8 @@ export default class GlintLanguageServer {
 
   public prepareRename(uri: string, position: Position): Range | undefined {
     let { transformedFileName, transformedOffset } = this.getTransformedOffset(uri, position);
+    if (isTemplate(transformedFileName)) return;
+
     let rename = this.service.getRenameInfo(transformedFileName, transformedOffset);
     if (rename.canRename) {
       let { originalStart, originalEnd } = this.transformManager.getOriginalRange(
@@ -191,6 +195,8 @@ export default class GlintLanguageServer {
 
   public getEditsForRename(uri: string, position: Position, newText: string): WorkspaceEdit {
     let { transformedFileName, transformedOffset } = this.getTransformedOffset(uri, position);
+    if (isTemplate(transformedFileName)) return {};
+
     let renameLocations = this.service.findRenameLocations(
       transformedFileName,
       transformedOffset,
@@ -235,6 +241,8 @@ export default class GlintLanguageServer {
 
   public getHover(uri: string, position: Position): Hover | undefined {
     let { transformedFileName, transformedOffset } = this.getTransformedOffset(uri, position);
+    if (isTemplate(transformedFileName)) return;
+
     let info = this.service.getQuickInfoAtPosition(transformedFileName, transformedOffset);
     if (!info) return;
 
@@ -259,6 +267,8 @@ export default class GlintLanguageServer {
 
   public getDefinition(uri: string, position: Position): Location[] {
     let { transformedFileName, transformedOffset } = this.getTransformedOffset(uri, position);
+    if (isTemplate(transformedFileName)) return [];
+
     let definitions =
       this.service.getDefinitionAtPosition(transformedFileName, transformedOffset) ?? [];
 
@@ -267,6 +277,8 @@ export default class GlintLanguageServer {
 
   public getReferences(uri: string, position: Position): Location[] {
     let { transformedFileName, transformedOffset } = this.getTransformedOffset(uri, position);
+    if (isTemplate(transformedFileName)) return [];
+
     let references =
       this.service.getReferencesAtPosition(transformedFileName, transformedOffset) ?? [];
 

--- a/packages/core/src/language-server/util/index.ts
+++ b/packages/core/src/language-server/util/index.ts
@@ -4,6 +4,10 @@ export { scriptElementKindToCompletionItemKind } from './protocol';
 import { URI } from 'vscode-uri';
 import type TS from 'typescript';
 
+export function isTemplate(uriOrFilePath: string): boolean {
+  return uriOrFilePath.endsWith('.hbs');
+}
+
 export function uriToFilePath(uri: string): string {
   return URI.parse(uri).fsPath.replace(/\\/g, '/');
 }


### PR DESCRIPTION
If we ever try to look up the translated TS code for a particular location and find ourselves still looking at a template, it means we didn't know what to do with that `.hbs` file and asking TypeScript about it will lead to a bad time. This change guards against that scenario.

This should fix #124.