### PR TITLE
Allow emitting `Element` values

### DIFF
--- a/packages/template/-private/dsl/invoke.d.ts
+++ b/packages/template/-private/dsl/invoke.d.ts
@@ -12,7 +12,7 @@ import { SafeString } from '@glimmer/runtime';
  *     <div data-x="hello {{value foo=bar}}">
  */
 export declare function invokeEmit<
-  T extends AcceptsBlocks<{}> | SafeString | string | number | boolean | null | void
+  T extends AcceptsBlocks<{}> | SafeString | Element | string | number | boolean | null | void
 >(value: T): void;
 
 /*

--- a/packages/template/__tests__/custom-invokable.test.ts
+++ b/packages/template/__tests__/custom-invokable.test.ts
@@ -2,8 +2,6 @@ import { expectTypeOf } from 'expect-type';
 import SumType from 'sums-up';
 import { AcceptsBlocks, DirectInvokable, EmptyObject } from '../-private/integration';
 import { invokeBlock, invokeEmit, resolve, resolveOrReturn } from '../-private/dsl';
-import { SafeString } from '@glimmer/runtime';
-import { htmlSafe } from '@ember/template';
 
 ///////////////////////////////////////////////////////////////////////////////
 // This module exercises what's possible when declaring a signature for a
@@ -69,18 +67,6 @@ invokeBlock(resolve(caseOf)({}, maybeValue), {
     });
   },
 });
-
-// Glimmer's SafeString interface
-let safeString: SafeString = {
-  toHTML(): string {
-    return '<span>Foo</span>';
-  },
-};
-
-invokeEmit(safeString);
-
-// @ember/template's SafeString
-invokeEmit(htmlSafe('<span>Foo</span>'));
 
 // Below is an alternative formulation using named block syntax.
 // This is a bit weird as it's really a control structure and looks here

--- a/packages/template/__tests__/invoke-emit.test.ts
+++ b/packages/template/__tests__/invoke-emit.test.ts
@@ -1,0 +1,19 @@
+import { SafeString } from '@glimmer/runtime';
+import { htmlSafe } from '@ember/template';
+import { invokeEmit } from '../-private/dsl';
+
+// Glimmer's SafeString interface
+let safeString: SafeString = {
+  toHTML(): string {
+    return '<span>Foo</span>';
+  },
+};
+
+invokeEmit(safeString);
+
+// @ember/template's SafeString
+invokeEmit(htmlSafe('<span>Foo</span>'));
+
+// Emitting an HTML element inserts that element into the DOM
+invokeEmit(document.createElement('div'));
+invokeEmit(document.createElementNS('http://www.w3.org/2000/svg', 'svg'));


### PR DESCRIPTION
Putting an `Element` value in a mustache, or returning one from a helper, adds that node to the DOM in that location. Fixes #100 