### PR TITLE
Allow invoking nullable component values

### DIFF
--- a/packages/template/-private/dsl/resolve.d.ts
+++ b/packages/template/-private/dsl/resolve.d.ts
@@ -32,7 +32,7 @@ import { DirectInvokable, EmptyObject, Invokable, Invoke, InvokeDirect } from '.
 
 export declare function resolve<T extends DirectInvokable>(item: T): T[typeof InvokeDirect];
 export declare function resolve<Args extends unknown[], Instance extends Invokable>(
-  item: new (...args: Args) => Instance
+  item: (new (...args: Args) => Instance) | null | undefined
 ): (...args: Parameters<Instance[typeof Invoke]>) => ReturnType<Instance[typeof Invoke]>;
 
 /*
@@ -47,6 +47,6 @@ export declare function resolve<Args extends unknown[], Instance extends Invokab
 
 export declare function resolveOrReturn<T extends DirectInvokable>(item: T): T[typeof InvokeDirect];
 export declare function resolveOrReturn<Args extends unknown[], Instance extends Invokable>(
-  item: new (...args: Args) => Instance
+  item: (new (...args: Args) => Instance) | null | undefined
 ): (...args: Parameters<Instance[typeof Invoke]>) => ReturnType<Instance[typeof Invoke]>;
 export declare function resolveOrReturn<T>(item: T): (args: EmptyObject) => T;

--- a/packages/template/__tests__/emit-component.test.ts
+++ b/packages/template/__tests__/emit-component.test.ts
@@ -130,6 +130,19 @@ emitComponent(resolve(MyComponent)({ value: 123 }), (component) => {
 emitValue(resolve(MyComponent)({ value: 123 }));
 
 /**
+ * Ensure we can invoke a maybe-undefined component.
+ */
+declare const MaybeMyComponent: typeof MyComponent | undefined;
+
+emitComponent(resolve(MaybeMyComponent)({ value: 'hi' }), (component) => {
+  bindBlocks(component.blockParams, {});
+});
+
+emitComponent(resolveOrReturn(MaybeMyComponent)({ value: 'hi' }), (component) => {
+  bindBlocks(component.blockParams, {});
+});
+
+/**
  * Constrained type parameters can be tricky, and `expect-type` doesn't
  * work well with type assertions directly against them, but we can assert
  * against a property that the constraint dictates must exist to ensure

--- a/test-packages/ts-ember-app/app/components/foo.hbs
+++ b/test-packages/ts-ember-app/app/components/foo.hbs
@@ -30,6 +30,12 @@
 
 <WrapperComponent @value="req" as |WC|>
   <WC.InnerComponent @optional={{1}} class="custom" />
+
+  {{! should work, even though MaybeComponent might not be present }}
+  <WC.MaybeComponent @key="hi" />
+
+  {{! should fail, since a string is not invokable }}
+  <WC.stringValue />
 </WrapperComponent>
 
 {{repeat "foo" 3}}

--- a/test-packages/ts-ember-app/app/components/wrapper-component.ts
+++ b/test-packages/ts-ember-app/app/components/wrapper-component.ts
@@ -1,4 +1,4 @@
-import { ComponentWithBoundArgs } from '@glint/environment-ember-loose';
+import { ComponentLike, ComponentWithBoundArgs } from '@glint/environment-ember-loose';
 import Component from '@glint/environment-ember-loose/glimmer-component';
 import EmberComponent from './ember-component';
 
@@ -8,7 +8,13 @@ interface WrapperComponentSignature {
     value: string;
   };
   Yields: {
-    default: [{ InnerComponent: ComponentWithBoundArgs<typeof EmberComponent, 'required'> }];
+    default: [
+      {
+        InnerComponent: ComponentWithBoundArgs<typeof EmberComponent, 'required'>;
+        MaybeComponent?: ComponentLike<{ Args: { key: string } }>;
+        stringValue?: string;
+      }
+    ];
   };
 }
 


### PR DESCRIPTION
It's legal to invoke a potentially-undefined component; if there's nothing there, the engine will just skip it entirely. Fixes #135.