### PR TITLE
Ensure the invocation-context 𝛄 doesn't trigger an unused symbol warning

### DIFF
--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -25,7 +25,7 @@ describe('Language Server: Diagnostics', () => {
         private startupTime = new Date().toISOString();
 
         public static template = hbs\`
-          Welcome to app v{{@version}}.
+          Welcome to app <code>v{{@version}}</code>.
           The current time is {{this.startupTimee}}.
         \`;
       }

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -632,6 +632,7 @@ describe('rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "χ.emitElement(\\"div\\", 𝛄 => {
+          𝛄;
           χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));
         });"
       `);
@@ -692,6 +693,7 @@ describe('rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}), 𝛄 => {
+          𝛄;
           χ.bindBlocks(𝛄.blockParams, {
             default(bar) {
               χ.emitValue(χ.resolveOrReturn(bar)({}));
@@ -760,12 +762,14 @@ describe('rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}), 𝛄 => {
+          𝛄;
           χ.bindBlocks(𝛄.blockParams, {
             head(h) {
               χ.emitValue(χ.resolveOrReturn(h)({}));
             },
             body(b) {
               χ.emitComponent(χ.resolve(b?.contents)({}), 𝛄 => {
+                𝛄;
                 χ.bindBlocks(𝛄.blockParams, {
                   default() {
                   },
@@ -799,6 +803,7 @@ describe('rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}), 𝛄 => {
+          𝛄;
           χ.bindBlocks(𝛄.blockParams, {
             default(NS) {
               χ.emitComponent(χ.resolve(NS?.Nested?.Custom)({}), 𝛄 => {

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -373,9 +373,7 @@ export function templateToTypescript(
         emit.indent();
         emit.newline();
 
-        emitSplattributes(node);
-        emitPlainAttributes(node);
-        emitModifiers(node);
+        emitAttributesAndModifiers(node);
 
         emit.text('χ.bindBlocks(𝛄.blockParams, {');
 
@@ -497,9 +495,7 @@ export function templateToTypescript(
         emit.newline();
         emit.indent();
 
-        emitSplattributes(node);
-        emitPlainAttributes(node);
-        emitModifiers(node);
+        emitAttributesAndModifiers(node);
 
         for (let child of node.children) {
           emitTopLevelStatement(child);
@@ -509,6 +505,18 @@ export function templateToTypescript(
         emit.text('});');
         emit.newline();
       });
+    }
+
+    function emitAttributesAndModifiers(node: AST.ElementNode): void {
+      if (!node.attributes.length && !node.modifiers.length) {
+        // Avoid unused-symbol diagnostics
+        emit.text('𝛄;');
+        emit.newline();
+      } else {
+        emitSplattributes(node);
+        emitPlainAttributes(node);
+        emitModifiers(node);
+      }
     }
 
     function emitPlainAttributes(node: AST.ElementNode): void {


### PR DESCRIPTION
In light of #143 there's likely to be some further changes in this area, but in the short term this will fix #142.