### PR TITLE
Avoid a direct `@glimmer/runtime` reference

### DIFF
--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -1,8 +1,5 @@
 import { AcceptsBlocks, AnyBlocks, AnyContext, BoundModifier } from '../integration';
-import { SafeString } from '@glimmer/runtime';
-import { ElementForTagName } from './types';
-
-export type EmittableValue = SafeString | Element | string | number | boolean | null | void;
+import { ElementForTagName, EmittableValue } from './types';
 
 /*
  * Emits the given value to the DOM. This corresponds to a mustache
@@ -13,9 +10,7 @@ export type EmittableValue = SafeString | Element | string | number | boolean | 
  *     <div data-x={{value foo=bar}}>
  *     <div data-x="hello {{value foo=bar}}">
  */
-export declare function emitValue<T extends AcceptsBlocks<{}, any> | EmittableValue>(
-  value: T
-): void;
+export declare function emitValue(value: AcceptsBlocks<{}, any> | EmittableValue): void;
 
 /*
  * Emits an element of the given name, providing a value to the

--- a/packages/template/-private/dsl/types.d.ts
+++ b/packages/template/-private/dsl/types.d.ts
@@ -19,3 +19,12 @@ export type ElementForTagName<Name extends string> = Name extends keyof HTMLElem
  * `TemplateContext` type for its template.
  */
 export type ResolveContext<T> = T extends HasContext<infer Context> ? Context : unknown;
+
+// This encompasses both @glimmer/runtime and @ember/template's notion of `SafeString`s,
+// and this coverage is tested in `emit-value.test.ts`.
+type SafeString = { toHTML(): string };
+
+/**
+ * Represents values that can safely be emitted into the DOM i.e. as `<span>{{value}}</span>`.
+ */
+export type EmittableValue = SafeString | Element | string | number | boolean | null | void;


### PR DESCRIPTION
The assorted `@glimmer` packages often end up causing transitive type errors for people if their versions don't quite line up or sometimes just if they're doing something TypeScript has more recently deemed an error condition.

As an example that recently came up [in Discord](https://discord.com/channels/480462759797063690/484421406659182603/829792501966700576):
```
node_modules/@glimmer/reference/dist/types/lib/validators.d.ts:79:52 - error TS2422: A class can only implement an object type or intersection of object types with statically known members.

79 export declare class MonomorphicTagImpl implements MonomorphicTag {
                                                      ~~~~~~~~~~~~~~

node_modules/@glimmer/runtime/dist/types/lib/component/curried-component.d.ts:6:87 - error TS2677: A type predicate's type must be assignable to its parameter's type.
  Type 'CurriedComponentDefinition' is not assignable to type 'Maybe<Dict<unknown>>'.
    Type 'CurriedComponentDefinition' is not assignable to type 'Dict<unknown>'.
      Index signature is missing in type 'CurriedComponentDefinition'.

6 export declare function isComponentDefinition(definition: Maybe<Dict>): definition is CurriedComponentDefinition;
                                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@glimmer/util/dist/types/lib/destroy.d.ts:3:69 - error TS2677: A type predicate's type must be assignable to its parameter's type.
  Type 'SymbolDestroyable' is not assignable to type 'Maybe<Dict<unknown>>'.
    Type 'SymbolDestroyable' is not assignable to type 'Dict<unknown>'.
      Index signature is missing in type 'SymbolDestroyable'.

3 export declare function isDestroyable(value: Maybe<Dict>): value is SymbolDestroyable;
```

While this isn't directly due to Glint, we can avoid being the package responsible for bringing those problematic declarations into the build.