### PR TITLE
Ensure type narrowing propagates downward

### DIFF
--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -40,6 +40,65 @@ describe('CLI: single-pass typechecking', () => {
     expect(checkResult.stderr).toEqual('');
   });
 
+  test('handles conditionals with yielding', async () => {
+    project.write('.glintrc', 'environment: ember-loose\n');
+
+    let script = stripIndent`
+      import Component from '@glint/environment-ember-loose/ember-component';
+
+      export type MyComponentArgs = {
+        foo?: () => {};
+        bar?: string;
+        baz?: { value: string };
+      };
+
+      export default class MyComponent extends Component<{ Args: MyComponentArgs }> { }
+    `;
+
+    let template = stripIndent`
+      {{#if @foo}}
+        <button {{on "click" @foo}} type="button"></button>
+      {{/if}}
+      {{#if @bar}}
+        <LinkTo @route="my-route">
+          <OtherComponent @value={{@bar}} />
+        </LinkTo>
+      {{/if}}
+      {{#if @baz}}
+        <LinkTo @route="my-route">
+          <OtherComponent @value={{@baz.value}} />
+        </LinkTo>
+      {{/if}}
+    `;
+
+    let otherScript = stripIndent`
+      import Component from '@glint/environment-ember-loose/ember-component';
+
+      export type OtherComponentArgs = {
+        value: string;
+      };
+
+      export default class OtherComponent extends Component<{ Args: OtherComponentArgs }> { }
+
+
+      declare module '@glint/environment-ember-loose/registry' {
+        export default interface Registry {
+          OtherComponent: typeof OtherComponent;
+        }
+      }
+    `;
+
+    project.write('my-component.ts', script);
+    project.write('my-component.hbs', template);
+    project.write('other-component.ts', otherScript);
+
+    let checkResult = await project.check();
+
+    expect(checkResult.exitCode).toBe(0);
+    expect(checkResult.stdout).toEqual('');
+    expect(checkResult.stderr).toEqual('');
+  });
+
   test('reports diagnostics for a template syntax error', async () => {
     let code = stripIndent`
       import Component, { hbs } from '@glint/environment-glimmerx/component';

--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -49,7 +49,7 @@ describe('CLI: single-pass typechecking', () => {
       export type MyComponentArgs = {
         foo?: () => {};
         bar?: string;
-        baz?: { value: string };
+        baz?: { value?: string };
       };
 
       export default class MyComponent extends Component<{ Args: MyComponentArgs }> { }
@@ -64,7 +64,7 @@ describe('CLI: single-pass typechecking', () => {
           <OtherComponent @value={{@bar}} />
         </LinkTo>
       {{/if}}
-      {{#if @baz}}
+      {{#if @baz.value}}
         <LinkTo @route="my-route">
           <OtherComponent @value={{@baz.value}} />
         </LinkTo>

--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -152,7 +152,7 @@ describe('Language Server: Completions', () => {
 
     let details = server.getCompletionDetails(letterCompletion!);
 
-    expect(details.detail).toEqual('(parameter) letter: string');
+    expect(details.detail).toEqual('const letter: string');
   });
 
   test('globals', () => {
@@ -242,6 +242,6 @@ describe('Language Server: Completions', () => {
 
     let details = server.getCompletionDetails(letterCompletion!);
 
-    expect(details.detail).toEqual('(parameter) letter: string');
+    expect(details.detail).toEqual('const letter: string');
   });
 });

--- a/packages/core/__tests__/language-server/hover.test.ts
+++ b/packages/core/__tests__/language-server/hover.test.ts
@@ -117,7 +117,7 @@ describe('Language Server: Hover', () => {
 
     // {{index}} in the template matches back to the block param
     expect(indexInfo).toEqual({
-      contents: [{ language: 'ts', value: '(parameter) index: number' }],
+      contents: [{ language: 'ts', value: 'const index: number' }],
       range: {
         start: { line: 5, character: 14 },
         end: { line: 5, character: 19 },
@@ -131,7 +131,7 @@ describe('Language Server: Hover', () => {
 
     // {{item}} in the template matches back to the block param
     expect(itemInfo).toEqual({
-      contents: [{ language: 'ts', value: '(parameter) item: string' }],
+      contents: [{ language: 'ts', value: 'const item: string' }],
       range: {
         start: { line: 5, character: 25 },
         end: { line: 5, character: 29 },

--- a/packages/environment-ember-loose/__tests__/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/helper.test.ts
@@ -8,7 +8,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
   let definition = helper(<T, U>([a, b]: [T, U]) => a || b);
   let or = resolve(definition);
 
-  expectTypeOf(or).toEqualTypeOf<<T, U>(args: EmptyObject, t: T, u: U) => T | U>();
+  expectTypeOf(or).toEqualTypeOf<{ <T, U>(args: EmptyObject, t: T, u: U): T | U }>();
 
   // @ts-expect-error: extra named arg
   or({ hello: true }, 'a', 'b');
@@ -32,7 +32,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
 
   let repeat = resolve(definition);
 
-  expectTypeOf(repeat).toEqualTypeOf<<T>(args: { value: T; count?: number }) => Array<T>>();
+  expectTypeOf(repeat).toEqualTypeOf<{ <T>(args: { value: T; count?: number }): Array<T> }>();
 
   // @ts-expect-error: extra positional arg
   repeat({ word: 'hi' }, 123);
@@ -58,7 +58,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
 
   let repeat = resolve(RepeatHelper);
 
-  expectTypeOf(repeat).toEqualTypeOf<<T>(args: { value: T; count?: number }) => Array<T>>();
+  expectTypeOf(repeat).toEqualTypeOf<{ <T>(args: { value: T; count?: number }): Array<T> }>();
 
   // @ts-expect-error: extra positional arg
   repeat({ word: 'hi' }, 123);

--- a/packages/environment-ember-loose/__tests__/intrinsics/action.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/action.test.ts
@@ -5,7 +5,7 @@ let action = resolve(Globals['action']);
 
 // Basic plumbing
 expectTypeOf(action({}, () => 'hi')).toEqualTypeOf<() => string>();
-expectTypeOf(action({}, <T>(value: T) => value)).toEqualTypeOf<<T>(value: T) => T>();
+expectTypeOf(action({}, <T>(value: T) => value)).toEqualTypeOf<{ <T>(value: T): T }>();
 
 // Binding parameters
 expectTypeOf(action({}, (x: string, y: number) => x.padStart(y), 'hello')).toEqualTypeOf<

--- a/packages/environment-ember-loose/__tests__/intrinsics/component.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/component.test.ts
@@ -3,7 +3,6 @@ import {
   resolve,
   applySplattributes,
   emitComponent,
-  bindBlocks,
 } from '@glint/environment-ember-loose/-private/dsl';
 import Component from '@glint/environment-ember-loose/ember-component';
 import { ComponentKeyword } from '@glint/environment-ember-loose/-private/intrinsics/component';
@@ -40,13 +39,12 @@ expectTypeOf(ValueCurriedStringComponent).toEqualTypeOf<
 >();
 
 // Invoking the noop-curried component
-emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }), (component) => {
-  // Passing no blocks
-  bindBlocks(component.blockParams, {});
+{
+  const component = emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }));
 
   // Applying attributes/modifiers
   applySplattributes(new HTMLFormElement(), component.element);
-});
+}
 
 resolve(NoopCurriedStringComponent)(
   // @ts-expect-error: Invoking the curried component but forgetting `value`
@@ -57,44 +55,37 @@ resolve(NoopCurriedStringComponent)(
 resolve(NoopCurriedStringComponent)({ value: 123 });
 
 // Invoking the noop-curried component with a valid block
-emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }), (component) =>
-  bindBlocks(component.blockParams, {
-    default(...args) {
-      expectTypeOf(args).toEqualTypeOf<[string]>();
-    },
-  })
-);
+{
+  const component = emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }));
+
+  {
+    const [...args] = component.blockParams.default;
+    expectTypeOf(args).toEqualTypeOf<[string]>();
+  }
+}
 
 // Invoking the noop-curried component with an invalid block
-emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {
-      /* nothing */
-    },
-    // @ts-expect-error: invalid block name
-    asdf() {
-      /* nothing */
-    },
-  })
-);
+{
+  const component = emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }));
+
+  // @ts-expect-error: invalid block name
+  component.blockParams.asdf;
+}
 
 // Invoking the curried-with-value component with no value
-emitComponent(resolve(ValueCurriedStringComponent)({}), (component) =>
-  bindBlocks(component.blockParams, {})
-);
+emitComponent(resolve(ValueCurriedStringComponent)({}));
 
 // Invoking the curried-with-value component with a valid value
-emitComponent(resolve(ValueCurriedStringComponent)({ value: 'hi' }), (component) => {
-  bindBlocks(component.blockParams, {});
+{
+  const component = emitComponent(resolve(ValueCurriedStringComponent)({ value: 'hi' }));
   applySplattributes(new HTMLFormElement(), component.element);
-});
+}
 
 emitComponent(
   resolve(ValueCurriedStringComponent)({
     // @ts-expect-error: Invoking the curred-with-value component with an invalid value
     value: 123,
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 // @ts-expect-error: Attempting to curry a nonexistent arg
@@ -126,39 +117,39 @@ const OptionalValueCurriedParametricComponent = componentKeyword(
 );
 
 // Invoking the noop-curried component with number values
-emitComponent(resolve(NoopCurriedParametricComponent)({ values: [1, 2, 3] }), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(resolve(NoopCurriedParametricComponent)({ values: [1, 2, 3] }));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+}
 
 // Invoking the noop-curried component with string values
-emitComponent(resolve(NoopCurriedParametricComponent)({ values: ['hello'] }), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  });
+{
+  const component = emitComponent(resolve(NoopCurriedParametricComponent)({ values: ['hello'] }));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
 
   applySplattributes(new HTMLFormElement(), component.element);
-});
+}
 
 emitComponent(
   resolve(NoopCurriedParametricComponent)(
     // @ts-expect-error: missing required arg `values`
     {}
-  ),
-  (component) => bindBlocks(component.blockParams, {})
+  )
 );
 
 emitComponent(
   resolve(NoopCurriedParametricComponent)({
     // @ts-expect-error: wrong type for `values`
     values: 'hello',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 emitComponent(
@@ -166,61 +157,62 @@ emitComponent(
     values: [1, 2, 3],
     // @ts-expect-error: extra arg
     extra: 'uh oh',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 // Invoking the curred component with no additional args
-emitComponent(resolve(RequiredValueCurriedParametricComponent)({}), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  })
-);
+{
+  const component = emitComponent(resolve(RequiredValueCurriedParametricComponent)({}));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 // Invoking the curred component and overriding the given arg
-emitComponent(resolve(RequiredValueCurriedParametricComponent)({ values: ['ok'] }), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  })
-);
+{
+  const component = emitComponent(
+    resolve(RequiredValueCurriedParametricComponent)({ values: ['ok'] })
+  );
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 emitComponent(
   resolve(RequiredValueCurriedParametricComponent)({
     // @ts-expect-error: wrong type for arg override
     values: [1, 2, 3],
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 emitComponent(
   resolve(RequiredValueCurriedParametricComponent)({
     // @ts-expect-error: extra arg
     extra: 'bad',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 // Invoking the curried component, supplying missing required args
-emitComponent(
-  resolve(OptionalValueCurriedParametricComponent)({ values: [1, 2, 3] }),
-  (component) =>
-    bindBlocks(component.blockParams, {
-      default(value) {
-        expectTypeOf(value).toEqualTypeOf<number>();
-      },
-    })
-);
+{
+  const component = emitComponent(
+    resolve(OptionalValueCurriedParametricComponent)({ values: [1, 2, 3] })
+  );
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+}
 
 emitComponent(
   resolve(OptionalValueCurriedParametricComponent)(
     // @ts-expect-error: missing required arg `values`
     {}
-  ),
-  (component) => bindBlocks(component.blockParams, {})
+  )
 );
 
 // {{component (component BoundParametricComponent values=(array "hello")) optional="hi"}}
@@ -230,31 +222,28 @@ const DoubleCurriedComponent = componentKeyword(
 );
 
 // Invoking the component with no args
-emitComponent(resolve(DoubleCurriedComponent)({}), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  })
-);
+{
+  const component = emitComponent(resolve(DoubleCurriedComponent)({}));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 // Invoking the component overriding an arg correctly
-emitComponent(resolve(DoubleCurriedComponent)({ values: ['a', 'b'] }), (component) =>
-  bindBlocks(component.blockParams, {})
-);
+emitComponent(resolve(DoubleCurriedComponent)({ values: ['a', 'b'] }));
 
 emitComponent(
   resolve(DoubleCurriedComponent)({
     // @ts-expect-error: invalid arg override
     values: [1, 2, 3],
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 emitComponent(
   resolve(DoubleCurriedComponent)({
     // @ts-expect-error: unexpected args
     foo: 'bar',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );

--- a/packages/environment-ember-loose/__tests__/intrinsics/each-in.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/each-in.test.ts
@@ -1,75 +1,83 @@
 import { expectTypeOf } from 'expect-type';
-import {
-  emitComponent,
-  Globals,
-  bindBlocks,
-  resolve,
-} from '@glint/environment-ember-loose/-private/dsl';
+import { emitComponent, Globals, resolve } from '@glint/environment-ember-loose/-private/dsl';
 
 let eachIn = resolve(Globals['each-in']);
 
-emitComponent(eachIn({}, { a: 5, b: 3 }), (component) =>
-  bindBlocks(component.blockParams, {
-    default(key, value) {
-      expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
-      expectTypeOf(value).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(eachIn({}, { a: 5, b: 3 }));
+
+  {
+    const [key, value] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+}
 
 // Can render maybe undefined
 
 declare const maybeVal: { a: number; b: number } | undefined;
 
-emitComponent(eachIn({}, maybeVal), (component) =>
-  bindBlocks(component.blockParams, {
-    default(key, value) {
-      expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
-      expectTypeOf(value).toEqualTypeOf<number>();
-    },
-    inverse(...args) {
-      expectTypeOf(args).toEqualTypeOf<[]>();
-    },
-  })
-);
+{
+  const component = emitComponent(eachIn({}, maybeVal));
+
+  {
+    const [key, value] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+
+  {
+    const [...args] = component.blockParams.inverse;
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}
 
 // Can render inverse when undefined, null, or empty.
 
-emitComponent(eachIn({}, undefined), (component) =>
-  bindBlocks(component.blockParams, {
-    default(key, value) {
-      // This won't get called when no value, but gets default for keyof
-      expectTypeOf(key).toEqualTypeOf<string | number | symbol>();
-      expectTypeOf(value).toEqualTypeOf<never>();
-    },
-    inverse(...args) {
-      expectTypeOf(args).toEqualTypeOf<[]>();
-    },
-  })
-);
+{
+  const component = emitComponent(eachIn({}, undefined));
 
-emitComponent(eachIn({}, null), (component) =>
-  bindBlocks(component.blockParams, {
-    default(key, value) {
-      // This won't get called when no value, but gets default for keyof
-      expectTypeOf(key).toEqualTypeOf<string | number | symbol>();
-      expectTypeOf(value).toEqualTypeOf<never>();
-    },
-    inverse(...args) {
-      expectTypeOf(args).toEqualTypeOf<[]>();
-    },
-  })
-);
+  {
+    const [key, value] = component.blockParams.default;
+    // This won't get called when no value, but gets default for keyof
+    expectTypeOf(key).toEqualTypeOf<string | number | symbol>();
+    expectTypeOf(value).toEqualTypeOf<never>();
+  }
 
-emitComponent(eachIn({}, {}), (component) =>
-  bindBlocks(component.blockParams, {
-    default(key, value) {
-      // This won't get called when no value
-      expectTypeOf(key).toEqualTypeOf<never>();
-      expectTypeOf(value).toEqualTypeOf<never>();
-    },
-    inverse(...args) {
-      expectTypeOf(args).toEqualTypeOf<[]>();
-    },
-  })
-);
+  {
+    const [...args] = component.blockParams.inverse;
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}
+
+{
+  const component = emitComponent(eachIn({}, null));
+
+  {
+    const [key, value] = component.blockParams.default;
+    // This won't get called when no value, but gets default for keyof
+    expectTypeOf(key).toEqualTypeOf<string | number | symbol>();
+    expectTypeOf(value).toEqualTypeOf<never>();
+  }
+
+  {
+    const [...args] = component.blockParams.inverse;
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}
+
+{
+  const component = emitComponent(eachIn({}, {}));
+
+  {
+    const [key, value] = component.blockParams.default;
+    // This won't get called when no value
+    expectTypeOf(key).toEqualTypeOf<never>();
+    expectTypeOf(value).toEqualTypeOf<never>();
+  }
+
+  {
+    const [...args] = component.blockParams.inverse;
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}

--- a/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
@@ -1,94 +1,98 @@
 import { expectTypeOf } from 'expect-type';
-import {
-  Globals,
-  resolve,
-  emitComponent,
-  bindBlocks,
-} from '@glint/environment-ember-loose/-private/dsl';
+import { Globals, resolve, emitComponent } from '@glint/environment-ember-loose/-private/dsl';
 import ArrayProxy from '@ember/array/proxy';
 
 let each = resolve(Globals['each']);
 
 // Yield out array values and indices
 
-emitComponent(each({}, ['a', 'b', 'c']), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-    inverse(...args) {
-      expectTypeOf(args).toEqualTypeOf<[]>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({}, ['a', 'b', 'c']));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+
+  {
+    const [...args] = component.blockParams.inverse;
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}
 
 // Works for Ember arrays
 
 declare const proxiedArray: ArrayProxy<string>;
 
-emitComponent(each({}, proxiedArray), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({}, proxiedArray));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 // Works for other iterables
 
-emitComponent(each({}, new Map<string, symbol>()), (component) =>
-  bindBlocks(component.blockParams, {
-    default([key, value], index) {
-      expectTypeOf(key).toEqualTypeOf<string>();
-      expectTypeOf(value).toEqualTypeOf<symbol>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({}, new Map<string, symbol>()));
+
+  {
+    const [[key, value], index] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<string>();
+    expectTypeOf(value).toEqualTypeOf<symbol>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 // Works for `readonly` arrays
 
-emitComponent(each({}, ['a', 'b', 'c'] as readonly string[]), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({}, ['a', 'b', 'c'] as readonly string[]));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 // Accept a `key` string
-emitComponent(each({ key: 'id' }, [{ id: 1 }]), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<{ id: number }>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({ key: 'id' }, [{ id: 1 }]));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<{ id: number }>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 declare const arrayOrUndefined: string[] | undefined;
 
 // Works for undefined
-emitComponent(each({}, arrayOrUndefined), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({}, arrayOrUndefined));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 declare const arrayOrNull: string[] | null;
 
 // Works for null
-emitComponent(each({}, arrayOrNull), (component) =>
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  })
-);
+{
+  const component = emitComponent(each({}, arrayOrNull));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}

--- a/packages/environment-ember-loose/__tests__/intrinsics/fn.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/fn.test.ts
@@ -19,4 +19,4 @@ let identity = <T>(x: T): T => x;
 expectTypeOf(fn({}, identity, 'hi')).toEqualTypeOf<() => string>();
 
 // Unbound type parameters survive to the output
-expectTypeOf(fn({}, identity)).toEqualTypeOf<<T>(x: T) => T>();
+expectTypeOf(fn({}, identity)).toEqualTypeOf<{ <T>(x: T): T }>();

--- a/packages/environment-ember-loose/__tests__/intrinsics/input.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/input.test.ts
@@ -24,9 +24,10 @@ Input({ type: '', value: 'hello' });
 Input({ type: 'string', value: 'hello' });
 
 // Ensure we can apply <input>-specific attributes
-emitComponent(Input({}), (𝛄) => {
+{
+  const 𝛄 = emitComponent(Input({}));
   applySplattributes(new HTMLInputElement(), 𝛄.element);
-});
+}
 
 // @ts-expect-error: `checked` only works with `@type=checkbox`
 Input({ checked: true });

--- a/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
@@ -3,72 +3,62 @@ import {
   resolve,
   applySplattributes,
   emitComponent,
-  bindBlocks,
 } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 
 let linkTo = resolve(Globals['link-to']);
 let LinkTo = resolve(Globals['LinkTo']);
 
-emitComponent(linkTo({}, 'index', 123), (component) => bindBlocks(component.blockParams, {}));
+emitComponent(linkTo({}, 'index', 123));
 
 // @ts-expect-error: bad type for route name
 linkTo({}, 123);
 
-emitComponent(LinkTo({ route: 'index', model: 123 }), (component) => {
+{
+  const component = emitComponent(LinkTo({ route: 'index', model: 123 }));
   expectTypeOf(component.element).toEqualTypeOf<HTMLAnchorElement>();
   applySplattributes(new HTMLAnchorElement(), component.element);
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
-  bindBlocks(component.blockParams, {
-    default() {},
-  });
-});
+{
+  const component = emitComponent(LinkTo({ route: 'index' }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
-emitComponent(LinkTo({ route: 'index' }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {},
-  })
-);
+{
+  const component = emitComponent(LinkTo({ route: 'index', query: { a: 123 } }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
-emitComponent(LinkTo({ route: 'index', query: { a: 123 } }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {},
-  })
-);
-
-emitComponent(LinkTo({ route: 'index', models: [123, 'abc'] }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {},
-  })
-);
+{
+  const component = emitComponent(LinkTo({ route: 'index', models: [123, 'abc'] }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
 // Requires at least one of `@route`, `@model`, `@models` or `@query`
 
-emitComponent(
-  LinkTo(
-    // @ts-expect-error: missing one of required props
-    {}
-  ),
-  (component) =>
-    bindBlocks(component.blockParams, {
-      default() {},
-    })
-);
+{
+  const component = emitComponent(
+    LinkTo(
+      // @ts-expect-error: missing one of required props
+      {}
+    )
+  );
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
-emitComponent(LinkTo({ model: 123 }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {},
-  })
-);
+{
+  const component = emitComponent(LinkTo({ model: 123 }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
-emitComponent(LinkTo({ models: [123] }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {},
-  })
-);
+{
+  const component = emitComponent(LinkTo({ models: [123] }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
 
-emitComponent(LinkTo({ query: { a: 123 } }), (component) =>
-  bindBlocks(component.blockParams, {
-    default() {},
-  })
-);
+{
+  const component = emitComponent(LinkTo({ query: { a: 123 } }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}

--- a/packages/environment-ember-loose/__tests__/intrinsics/textarea.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/textarea.test.ts
@@ -18,9 +18,10 @@ Textarea({ value: undefined });
 Textarea({ value: null });
 
 // Ensure we can apply <textarea>-specific attributes
-emitComponent(Textarea({}), (𝛄) => {
+{
+  const 𝛄 = emitComponent(Textarea({}));
   applySplattributes(new HTMLTextAreaElement(), 𝛄.element);
-});
+}
 
 // Event handlers
 Textarea({

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -4,7 +4,6 @@ import {
   resolve,
   ResolveContext,
   yieldToBlock,
-  bindBlocks,
   emitComponent,
 } from '@glint/environment-glimmerx/-private/dsl';
 import { expectTypeOf } from 'expect-type';
@@ -28,14 +27,16 @@ import { EmptyObject } from '@glint/template/-private/integration';
     'oops'
   );
 
-  emitComponent(resolve(NoArgsComponent)({}), (component) =>
-    bindBlocks(component.blockParams, {
-      // @ts-expect-error: never yields, so shouldn't accept blocks
-      default() {},
-    })
-  );
+  {
+    const component = emitComponent(resolve(NoArgsComponent)({}));
 
-  emitComponent(resolve(NoArgsComponent)({}), (component) => bindBlocks(component.blockParams, {}));
+    {
+      // @ts-expect-error: never yields, so shouldn't accept blocks
+      component.blockParams.default;
+    }
+  }
+
+  emitComponent(resolve(NoArgsComponent)({}));
 }
 
 {
@@ -49,9 +50,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
     });
   }
 
-  emitComponent(resolve(StatefulComponent)({}), (component) =>
-    bindBlocks(component.blockParams, {})
-  );
+  emitComponent(resolve(StatefulComponent)({}));
 }
 
 {
@@ -94,30 +93,35 @@ import { EmptyObject } from '@glint/template/-private/integration';
     oops: true,
   });
 
-  emitComponent(resolve(YieldingComponent)({ values: [] }), (component) =>
-    bindBlocks(component.blockParams, {
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [] }));
+
+    {
       // @ts-expect-error: invalid block name
-      foo() {},
-    })
-  );
+      component.blockParams.foo;
+    }
+  }
 
-  emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }), (component) =>
-    bindBlocks(component.blockParams, {
-      default(value) {
-        expectTypeOf(value).toEqualTypeOf<number>();
-      },
-    })
-  );
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
 
-  emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }), (component) =>
-    bindBlocks(component.blockParams, {
-      default(...args) {
-        expectTypeOf(args).toEqualTypeOf<[number]>();
-      },
+    {
+      const [value] = component.blockParams.default;
+      expectTypeOf(value).toEqualTypeOf<number>();
+    }
+  }
 
-      inverse(...args) {
-        expectTypeOf(args).toEqualTypeOf<[]>();
-      },
-    })
-  );
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [...args] = component.blockParams.default;
+      expectTypeOf(args).toEqualTypeOf<[number]>();
+    }
+
+    {
+      const [...args] = component.blockParams.inverse;
+      expectTypeOf(args).toEqualTypeOf<[]>();
+    }
+  }
 }

--- a/packages/environment-glimmerx/__tests__/helper.test.ts
+++ b/packages/environment-glimmerx/__tests__/helper.test.ts
@@ -23,7 +23,7 @@ import { expectTypeOf } from 'expect-type';
   expectTypeOf(fn({}, identity, 'hi')).toEqualTypeOf<() => string>();
 
   // Unbound type parameters survive to the output
-  expectTypeOf(fn({}, identity)).toEqualTypeOf<<T>(x: T) => T>();
+  expectTypeOf(fn({}, identity)).toEqualTypeOf<{ <T>(x: T): T }>();
 }
 
 // Custom helper: positional params
@@ -31,7 +31,7 @@ import { expectTypeOf } from 'expect-type';
   let definition = helper(<T, U>([a, b]: [T, U]) => a || b);
   let or = resolve(definition);
 
-  expectTypeOf(or).toEqualTypeOf<<T, U>(args: EmptyObject, t: T, u: U) => T | U>();
+  expectTypeOf(or).toEqualTypeOf<{ <T, U>(args: EmptyObject, t: T, u: U): T | U }>();
 
   // @ts-expect-error: extra named arg
   or({ hello: true }, 'a', 'b');
@@ -78,7 +78,9 @@ import { expectTypeOf } from 'expect-type';
 
   let repeat = resolve(definition);
 
-  expectTypeOf(repeat).toEqualTypeOf<<T>(args: EmptyObject, item: T, count?: number) => Array<T>>();
+  expectTypeOf(repeat).toEqualTypeOf<{
+    <T>(args: EmptyObject, item: T, count?: number): Array<T>;
+  }>();
 
   // @ts-expect-error: unexpected named arg
   repeat({ word: 'hi' }, 123, 12);

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -1,4 +1,4 @@
-import { AcceptsBlocks, AnyBlocks, AnyContext, BoundModifier } from '../integration';
+import { AcceptsBlocks, AnyContext, BoundModifier } from '../integration';
 import { ElementForTagName, EmittableValue } from './types';
 
 /*
@@ -28,9 +28,8 @@ export declare function emitValue(value: AcceptsBlocks<{}, any> | EmittableValue
  *     });
  */
 export declare function emitElement<Name extends string>(
-  name: Name,
-  handler: (elementContext: { element: ElementForTagName<Name> }) => void
-): void;
+  name: Name
+): { element: ElementForTagName<Name> };
 
 /*
  * Emits the given value as an entity that expects to receive blocks
@@ -45,17 +44,15 @@ export declare function emitElement<Name extends string>(
  * blocks bound to it. The final line above would produce code like:
  *
  *     emitComponent(resolve(Value)({ foo: bar })), (𝛄) => {
- *       bindBlocks(𝛄.blockParams, {});
  *       applyModifier(𝛄.element, resolve(baz)({}));
  *     });
  */
 export declare function emitComponent<T extends AcceptsBlocks<any, any>>(
-  component: T,
-  handler: (componentContext: {
-    element: T extends AcceptsBlocks<any, infer El> ? El : null;
-    blockParams: T extends AcceptsBlocks<infer Yields, any> ? Yields : never;
-  }) => void
-): void;
+  component: T
+): {
+  element: T extends AcceptsBlocks<any, infer El> ? El : null;
+  blockParams: T extends AcceptsBlocks<infer Yields, any> ? Required<Yields> : never;
+};
 
 /**
  * Acts as a top-level wrapper for translated template bodies.
@@ -106,17 +103,4 @@ export declare function applyAttributes(element: Element, attrs: Record<string, 
 export declare function applyModifier<TargetElement extends Element>(
   element: TargetElement,
   modifier: BoundModifier<TargetElement>
-): void;
-
-/*
- * Given a mapping of block names to the parameters they provide
- * `{ [name: string]: [...params] }`, binds the given block
- * implementations that will make use of those parameters, ensuring
- * they typecheck appropriately.
- */
-export declare function bindBlocks<T extends AnyBlocks>(
-  params: T,
-  blocks: {
-    [K in keyof T]: (...params: NonNullable<T[K]>) => void;
-  }
 ): void;

--- a/packages/template/__tests__/attributes.test.ts
+++ b/packages/template/__tests__/attributes.test.ts
@@ -8,7 +8,6 @@ import {
   applyAttributes,
   emitElement,
   emitComponent,
-  bindBlocks,
 } from '../-private/dsl';
 import { BoundModifier, DirectInvokable, EmptyObject } from '../-private/integration';
 import TestComponent from './test-component';
@@ -36,127 +35,149 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
   public static template = template(function (𝚪: ResolveContext<MyComponent>) {
     expectTypeOf(𝚪.element).toEqualTypeOf<HTMLImageElement>();
 
-    emitElement('img', (ctx) => {
+    {
+      const ctx = emitElement('img');
       expectTypeOf(ctx.element).toEqualTypeOf<HTMLImageElement>();
 
       applyModifier(ctx.element, resolve(imageModifier)({}));
       applySplattributes(𝚪.element, ctx.element);
-    });
+    }
   });
 }
 
 // `emitElement` type resolution
-emitElement('img', (el) => expectTypeOf(el).toEqualTypeOf<{ element: HTMLImageElement }>());
-emitElement('unknown', (el) => expectTypeOf(el).toEqualTypeOf<{ element: Element }>());
+{
+  const el = emitElement('img');
+  expectTypeOf(el).toEqualTypeOf<{ element: HTMLImageElement }>();
+}
+
+{
+  const el = emitElement('unknown');
+  expectTypeOf(el).toEqualTypeOf<{ element: Element }>();
+}
 
 /**
  * ```handlebars
  * <MyComponent ...attributes foo="bar" />
  * ```
  */
-emitComponent(resolve(MyComponent)({}), (component) => {
-  bindBlocks(component.blockParams, {});
+{
+  const component = emitComponent(resolve(MyComponent)({}));
   applySplattributes(new HTMLImageElement(), component.element);
   applyAttributes(component.element, { foo: 'bar' });
-});
+}
 
 /**
  * ```handlebars
  * <SVGElementComponent ...attributes />
  * ```
  */
-emitComponent(resolve(SVGElementComponent)({}), (component) => {
-  bindBlocks(component.blockParams, {});
+{
+  const component = emitComponent(resolve(SVGElementComponent)({}));
   applySplattributes(new SVGSVGElement(), component.element);
-});
+}
 
 /**
  * ```handlebars
  * <svg ...attributes></svg>
  * ```
  */
-emitElement('svg', (ctx) => applySplattributes(new SVGSVGElement(), ctx.element));
+{
+  const ctx = emitElement('svg');
+  applySplattributes(new SVGSVGElement(), ctx.element);
+}
 
 /**
  * ```handlebars
  * <a {{anchorModifier}}></a>
  * ```
  */
-emitElement('a', (ctx) => {
+{
+  const ctx = emitElement('a');
   expectTypeOf(ctx).toEqualTypeOf<{ element: HTMLAnchorElement & SVGAElement }>();
   applyModifier(ctx.element, resolve(anchorModifier)({}));
-});
+}
 
 // Error conditions:
 
-emitElement('unknown', (element) => {
+{
+  const element = emitElement('unknown');
   applySplattributes(
     new HTMLFormElement(),
     // @ts-expect-error: Trying to pass splattributes specialized for another element
     element
   );
-});
+}
 
-emitComponent(resolve(MyComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(MyComponent)({}));
   applySplattributes(
     new HTMLFormElement(),
     // @ts-expect-error: Trying to pass splattributes specialized for another element
     component.element
   );
-});
+}
 
-emitComponent(resolve(TestComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(TestComponent)({}));
   applySplattributes(
     new HTMLUnknownElement(),
     // @ts-expect-error: Trying to apply splattributes to a component with no root element
     component.element
   );
-});
+}
 
-emitComponent(resolve(SVGAElementComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(SVGAElementComponent)({}));
   applySplattributes(
     new HTMLAnchorElement(),
     // @ts-expect-error: Trying to apply splattributes for an HTML <a> to an SVG <a>
     component.element
   );
-});
+}
 
-emitElement('div', (div) =>
+{
+  const div = emitElement('div');
+
   applyModifier(
     // @ts-expect-error: `imageModifier` expects an `HTMLImageElement`
     div,
     resolve(imageModifier)({})
-  )
-);
+  );
+}
 
-emitComponent(resolve(GenericElementComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(GenericElementComponent)({}));
   applyModifier(
     // @ts-expect-error: `imageModifier` expects an `HTMLImageElement`
     component.element,
     resolve(imageModifier)({})
   );
-});
+}
 
-emitComponent(resolve(TestComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(TestComponent)({}));
   applyModifier(
     // @ts-expect-error: Trying to apply a modifier to a component with no root element
     component.element,
     resolve(imageModifier)({})
   );
-});
+}
 
-emitComponent(resolve(SVGAElementComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(SVGAElementComponent)({}));
   applyModifier(
     // @ts-expect-error: Can't apply modifier for HTML <a> to SVG <a>
     component.element,
     resolve(anchorModifier)({})
   );
-});
+}
 
-emitComponent(resolve(TestComponent)({}), (component) => {
+{
+  const component = emitComponent(resolve(TestComponent)({}));
   applyAttributes(
     // @ts-expect-error: Trying to apply attributes to a component with no root element
     component.element,
     { foo: 'bar' }
   );
-});
+}

--- a/packages/template/__tests__/custom-invokable.test.ts
+++ b/packages/template/__tests__/custom-invokable.test.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 import SumType from 'sums-up';
 import { AcceptsBlocks, DirectInvokable, EmptyObject } from '../-private/integration';
-import { emitComponent, emitValue, bindBlocks, resolve, resolveOrReturn } from '../-private/dsl';
+import { emitComponent, emitValue, resolve, resolveOrReturn } from '../-private/dsl';
 
 ///////////////////////////////////////////////////////////////////////////////
 // This module exercises what's possible when declaring a signature for a
@@ -50,29 +50,27 @@ declare const caseOf: DirectInvokable<
  * {{/case-of}}
  * ```
  */
-emitComponent(resolve(caseOf)({}, maybeValue), (component) => {
-  bindBlocks(component.blockParams, {
-    default(when) {
-      emitComponent(resolve(when)({}, 'Just'), (component) => {
-        bindBlocks(component.blockParams, {
-          default(n) {
-            expectTypeOf(n).toEqualTypeOf<number>();
-            emitValue(resolveOrReturn(n)({}));
-          },
-          inverse() {
-            emitComponent(resolve(when)({}, 'Nothing'), (component) => {
-              bindBlocks(component.blockParams, {
-                default() {
-                  /* nothin */
-                },
-              });
-            });
-          },
-        });
-      });
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(caseOf)({}, maybeValue));
+  {
+    const [when] = component.blockParams.default;
+    {
+      const component = emitComponent(resolve(when)({}, 'Just'));
+      {
+        const [n] = component.blockParams.default;
+        expectTypeOf(n).toEqualTypeOf<number>();
+        emitValue(resolveOrReturn(n)({}));
+      }
+      {
+        component.blockParams.inverse;
+        {
+          const component = emitComponent(resolve(when)({}, 'Nothing'));
+          expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+        }
+      }
+    }
+  }
+}
 
 // Below is an alternative formulation using named block syntax.
 // This is a bit weird as it's really a control structure and looks here
@@ -96,14 +94,16 @@ declare const CaseOf: DirectInvokable<
  * </CaseOf>
  * ```
  */
-emitComponent(resolve(CaseOf)({ value: maybeValue }), (component) => {
-  bindBlocks(component.blockParams, {
-    Just(value) {
-      expectTypeOf(value).toEqualTypeOf<number>();
-      emitValue(resolveOrReturn(value)({}));
-    },
-    Nothing() {
-      /* nothin */
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(CaseOf)({ value: maybeValue }));
+
+  {
+    const [value] = component.blockParams.Just;
+    expectTypeOf(value).toEqualTypeOf<number>();
+    emitValue(resolveOrReturn(value)({}));
+  }
+
+  {
+    component.blockParams.Nothing;
+  }
+}

--- a/packages/template/__tests__/emit-component.test.ts
+++ b/packages/template/__tests__/emit-component.test.ts
@@ -4,7 +4,6 @@ import {
   emitComponent,
   emitElement,
   emitValue,
-  bindBlocks,
   resolve,
   ResolveContext,
   resolveOrReturn,
@@ -41,37 +40,35 @@ class MyComponent<T> extends TestComponent<MyComponentSignature<T>> {
    * ```
    */
   public static template = template(function <T>(𝚪: ResolveContext<MyComponent<T>>) {
-    emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready), (component) => {
-      bindBlocks(component.blockParams, {
-        default(isReady) {
-          emitElement('div', (𝛄) => {
-            expectTypeOf(𝛄).toEqualTypeOf<{ element: HTMLDivElement }>();
-            applyModifier(𝛄.element, resolve(globals.on)({}, 'click', 𝚪.this.wrapperClicked));
-          });
+    const component = emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready));
+    const [isReady] = component.blockParams.default;
 
-          yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
+    {
+      const 𝛄 = emitElement('div');
+      expectTypeOf(𝛄).toEqualTypeOf<{ element: HTMLDivElement }>();
+      applyModifier(𝛄.element, resolve(globals.on)({}, 'click', 𝚪.this.wrapperClicked));
+    }
 
-          yieldToBlock(
-            𝚪,
-            // @ts-expect-error: bad block
-            'bad',
-            isReady,
-            𝚪.args.value
-          );
+    yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
 
-          // @ts-expect-error: missing params
-          yieldToBlock(𝚪, 'body');
+    yieldToBlock(
+      𝚪,
+      // @ts-expect-error: bad block
+      'bad',
+      isReady,
+      𝚪.args.value
+    );
 
-          yieldToBlock(
-            𝚪,
-            'body',
-            isReady,
-            // @ts-expect-error: wrong param type
-            Symbol()
-          );
-        },
-      });
-    });
+    // @ts-expect-error: missing params
+    yieldToBlock(𝚪, 'body');
+
+    yieldToBlock(
+      𝚪,
+      'body',
+      isReady,
+      // @ts-expect-error: wrong param type
+      Symbol()
+    );
   });
 }
 
@@ -85,17 +82,18 @@ class MyComponent<T> extends TestComponent<MyComponentSignature<T>> {
  *   </:body>
  * </MyComponent>
  */
-emitComponent(resolve(MyComponent)({ value: 'hi' }), (component) => {
-  bindBlocks(component.blockParams, {
-    body(isReady, value) {
-      expectTypeOf(isReady).toEqualTypeOf<boolean>();
-      expectTypeOf(value).toEqualTypeOf<string>();
+{
+  const component = emitComponent(resolve(MyComponent)({ value: 'hi' }));
 
-      emitValue(resolveOrReturn(value)({}));
-      emitValue(resolveOrReturn(isReady)({}));
-    },
-  });
-});
+  {
+    const [isReady, value] = component.blockParams.body;
+    expectTypeOf(isReady).toEqualTypeOf<boolean>();
+    expectTypeOf(value).toEqualTypeOf<string>();
+
+    emitValue(resolveOrReturn(value)({}));
+    emitValue(resolveOrReturn(isReady)({}));
+  }
+}
 
 /**
  * Instantiate `T` to `number` and verify it's threaded through:
@@ -107,17 +105,18 @@ emitComponent(resolve(MyComponent)({ value: 'hi' }), (component) => {
  *   </:body>
  * </MyComponent>
  */
-emitComponent(resolve(MyComponent)({ value: 123 }), (component) => {
-  bindBlocks(component.blockParams, {
-    body(isReady, value) {
-      expectTypeOf(isReady).toEqualTypeOf<boolean>();
-      expectTypeOf(value).toEqualTypeOf<number>();
+{
+  const component = emitComponent(resolve(MyComponent)({ value: 123 }));
 
-      emitValue(resolveOrReturn(value)({}));
-      emitValue(resolveOrReturn(isReady)({}));
-    },
-  });
-});
+  {
+    const [isReady, value] = component.blockParams.body;
+    expectTypeOf(isReady).toEqualTypeOf<boolean>();
+    expectTypeOf(value).toEqualTypeOf<number>();
+
+    emitValue(resolveOrReturn(value)({}));
+    emitValue(resolveOrReturn(isReady)({}));
+  }
+}
 
 /**
  * Invoke the component inline, which is valid since it has no
@@ -134,13 +133,9 @@ emitValue(resolve(MyComponent)({ value: 123 }));
  */
 declare const MaybeMyComponent: typeof MyComponent | undefined;
 
-emitComponent(resolve(MaybeMyComponent)({ value: 'hi' }), (component) => {
-  bindBlocks(component.blockParams, {});
-});
+emitComponent(resolve(MaybeMyComponent)({ value: 'hi' }));
 
-emitComponent(resolveOrReturn(MaybeMyComponent)({ value: 'hi' }), (component) => {
-  bindBlocks(component.blockParams, {});
-});
+emitComponent(resolveOrReturn(MaybeMyComponent)({ value: 'hi' }));
 
 /**
  * Constrained type parameters can be tricky, and `expect-type` doesn't

--- a/packages/template/__tests__/keywords/component.test.ts
+++ b/packages/template/__tests__/keywords/component.test.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from 'expect-type';
-import { emitComponent, bindBlocks, resolve } from '../../-private/dsl';
+import { emitComponent, resolve } from '../../-private/dsl';
 import { ComponentKeyword } from '../../-private/keywords';
 import TestComponent from '../test-component';
 
@@ -14,9 +14,7 @@ const NoopCurriedStringComponent = componentKeyword({}, StringComponent);
 const ValueCurriedStringComponent = componentKeyword({ value: 'hello' }, StringComponent);
 
 // Invoking the noop-curried component
-emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }), (component) => {
-  bindBlocks(component.blockParams, {});
-});
+emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }));
 
 // @ts-expect-error: Invoking the curried component but forgetting `value`
 resolve(NoopCurriedStringComponent)({});
@@ -25,45 +23,36 @@ resolve(NoopCurriedStringComponent)({});
 resolve(NoopCurriedStringComponent)({ value: 123 });
 
 // Invoking the noop-curried component with a valid block
-emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }), (component) => {
-  bindBlocks(component.blockParams, {
-    default(...args) {
-      expectTypeOf(args).toEqualTypeOf<[string]>();
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }));
+
+  {
+    const [...args] = component.blockParams.default;
+    expectTypeOf(args).toEqualTypeOf<[string]>();
+  }
+}
 
 // Invoking the noop-curried component with an invalid block
-emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }), (component) => {
-  bindBlocks(component.blockParams, {
-    default() {
-      /* nothing */
-    },
+{
+  const component = emitComponent(resolve(NoopCurriedStringComponent)({ value: 'hello' }));
+
+  {
     // @ts-expect-error: invalid block name
-    asdf() {
-      /* nothing */
-    },
-  });
-});
+    component.blockParams.asdf;
+  }
+}
 
 // Invoking the curried-with-value component with no value
-emitComponent(resolve(ValueCurriedStringComponent)({}), (component) => {
-  bindBlocks(component.blockParams, {});
-});
+emitComponent(resolve(ValueCurriedStringComponent)({}));
 
 // Invoking the curried-with-value component with a valid value
-emitComponent(resolve(ValueCurriedStringComponent)({ value: 'hi' }), (component) => {
-  bindBlocks(component.blockParams, {});
-});
+emitComponent(resolve(ValueCurriedStringComponent)({ value: 'hi' }));
 
 emitComponent(
   resolve(ValueCurriedStringComponent)({
     // @ts-expect-error: Invoking the curred-with-value component with an invalid value
     value: 123,
-  }),
-  (component) => {
-    bindBlocks(component.blockParams, {});
-  }
+  })
 );
 
 componentKeyword(
@@ -104,37 +93,37 @@ const OptionalValueCurriedParametricComponent = componentKeyword(
 );
 
 // Invoking the noop-curried component with number values
-emitComponent(resolve(NoopCurriedParametricComponent)({ values: [1, 2, 3] }), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<number>();
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(NoopCurriedParametricComponent)({ values: [1, 2, 3] }));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+}
 
 // Invoking the noop-curried component with string values
-emitComponent(resolve(NoopCurriedParametricComponent)({ values: ['hello'] }), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(NoopCurriedParametricComponent)({ values: ['hello'] }));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 emitComponent(
   resolve(NoopCurriedParametricComponent)(
     // @ts-expect-error: missing required arg `values`
     {}
-  ),
-  (component) => bindBlocks(component.blockParams, {})
+  )
 );
 
 emitComponent(
   resolve(NoopCurriedParametricComponent)(
     // @ts-expect-error: wrong type for `values`
     { values: 'hello' }
-  ),
-  (component) => bindBlocks(component.blockParams, {})
+  )
 );
 
 emitComponent(
@@ -142,62 +131,62 @@ emitComponent(
     values: [1, 2, 3],
     // @ts-expect-error: extra arg
     extra: 'uh oh',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 // Invoking the curred component with no additional args
-emitComponent(resolve(RequiredValueCurriedParametricComponent)({}), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(RequiredValueCurriedParametricComponent)({}));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 // Invoking the curred component and overriding the given arg
-emitComponent(resolve(RequiredValueCurriedParametricComponent)({ values: ['ok'] }), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  });
-});
+{
+  const component = emitComponent(
+    resolve(RequiredValueCurriedParametricComponent)({ values: ['ok'] })
+  );
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 emitComponent(
   resolve(RequiredValueCurriedParametricComponent)({
     // @ts-expect-error: wrong type for arg override
     values: [1, 2, 3],
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 emitComponent(
   resolve(RequiredValueCurriedParametricComponent)({
     // @ts-expect-error: extra arg
     extra: 'bad',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 // Invoking the curried component, supplying missing required args
-emitComponent(
-  resolve(OptionalValueCurriedParametricComponent)({ values: [1, 2, 3] }),
-  (component) => {
-    bindBlocks(component.blockParams, {
-      default(value) {
-        expectTypeOf(value).toEqualTypeOf<number>();
-      },
-    });
+{
+  const component = emitComponent(
+    resolve(OptionalValueCurriedParametricComponent)({ values: [1, 2, 3] })
+  );
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<number>();
   }
-);
+}
 
 emitComponent(
   resolve(OptionalValueCurriedParametricComponent)(
     // @ts-expect-error: missing required arg `values`
     {}
-  ),
-  (component) => bindBlocks(component.blockParams, {})
+  )
 );
 
 // {{component (component BoundParametricComponent values=(array "hello")) optional="hi"}}
@@ -207,31 +196,28 @@ const DoubleCurriedComponent = componentKeyword(
 );
 
 // Invoking the component with no args
-emitComponent(resolve(DoubleCurriedComponent)({}), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-    },
-  });
-});
+{
+  const component = emitComponent(resolve(DoubleCurriedComponent)({}));
+
+  {
+    const [value] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+}
 
 // Invoking the component overriding an arg correctly
-emitComponent(resolve(DoubleCurriedComponent)({ values: ['a', 'b'] }), (component) => {
-  bindBlocks(component.blockParams, {});
-});
+emitComponent(resolve(DoubleCurriedComponent)({ values: ['a', 'b'] }));
 
 emitComponent(
   resolve(DoubleCurriedComponent)({
     // @ts-expect-error: invalid arg override
     values: [1, 2, 3],
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );
 
 emitComponent(
   resolve(DoubleCurriedComponent)({
     // @ts-expect-error: unexpected args
     foo: 'bar',
-  }),
-  (component) => bindBlocks(component.blockParams, {})
+  })
 );

--- a/packages/template/__tests__/keywords/each.test.ts
+++ b/packages/template/__tests__/keywords/each.test.ts
@@ -1,36 +1,32 @@
 import { expectTypeOf } from 'expect-type';
-import { emitComponent, bindBlocks, resolve } from '../../-private/dsl';
+import { emitComponent, resolve } from '../../-private/dsl';
 import { EachKeyword } from '../../-private/keywords';
 
 const eachKeyword = resolve({} as EachKeyword);
 
 // Yield out array values and indices
 
-emitComponent(eachKeyword({}, ['a', 'b', 'c']), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  });
-});
+{
+  const component = emitComponent(eachKeyword({}, ['a', 'b', 'c']));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 // Works for `readonly` arrays
 
-emitComponent(eachKeyword({}, ['a', 'b', 'c'] as readonly string[]), (component) => {
-  bindBlocks(component.blockParams, {
-    default(value, index) {
-      expectTypeOf(value).toEqualTypeOf<string>();
-      expectTypeOf(index).toEqualTypeOf<number>();
-    },
-  });
-});
+{
+  const component = emitComponent(eachKeyword({}, ['a', 'b', 'c'] as readonly string[]));
+
+  {
+    const [value, index] = component.blockParams.default;
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(index).toEqualTypeOf<number>();
+  }
+}
 
 // Accept a `key` string
-emitComponent(eachKeyword({ key: 'id' }, [{ id: 1 }]), (component) => {
-  bindBlocks(component.blockParams, {
-    default() {
-      // Don't yield
-    },
-  });
-});
+emitComponent(eachKeyword({ key: 'id' }, [{ id: 1 }]));

--- a/packages/template/__tests__/keywords/let.test.ts
+++ b/packages/template/__tests__/keywords/let.test.ts
@@ -1,15 +1,16 @@
 import { expectTypeOf } from 'expect-type';
-import { emitComponent, bindBlocks, resolve } from '../../-private/dsl';
+import { emitComponent, resolve } from '../../-private/dsl';
 import { LetKeyword } from '../../-private/keywords';
 
 const letKeyword = resolve({} as LetKeyword);
 
 // Yields out the given values
-emitComponent(letKeyword({}, 'hello', 123), (component) => {
-  bindBlocks(component.blockParams, {
-    default(str, num) {
-      expectTypeOf(str).toEqualTypeOf<string>();
-      expectTypeOf(num).toEqualTypeOf<number>();
-    },
-  });
-});
+{
+  const component = emitComponent(letKeyword({}, 'hello', 123));
+
+  {
+    const [str, num] = component.blockParams.default;
+    expectTypeOf(str).toEqualTypeOf<string>();
+    expectTypeOf(num).toEqualTypeOf<number>();
+  }
+}

--- a/packages/template/__tests__/keywords/with.test.ts
+++ b/packages/template/__tests__/keywords/with.test.ts
@@ -1,20 +1,26 @@
 import { expectTypeOf } from 'expect-type';
-import { emitComponent, bindBlocks, resolve } from '../../-private/dsl';
+import { emitComponent, resolve } from '../../-private/dsl';
 import { WithKeyword } from '../../-private/keywords';
 
 const withKeyword = resolve({} as WithKeyword);
 
 // Yields out the given value
-emitComponent(withKeyword({}, 'hello'), (component) => {
-  bindBlocks(component.blockParams, {
-    default(str) {
-      expectTypeOf(str).toEqualTypeOf<string>();
-    },
-    inverse() {
-      // Nothing
-    },
-  });
-});
+{
+  const component = emitComponent(withKeyword({}, 'hello'));
 
-// @ts-expect-error: Rejects multiple values
-withKeyword({}, 'hello', 'goodbye');
+  {
+    const [str] = component.blockParams.default;
+    expectTypeOf(str).toEqualTypeOf<string>();
+  }
+
+  {
+    component.blockParams.inverse;
+  }
+}
+
+withKeyword(
+  {},
+  'hello',
+  // @ts-expect-error: Rejects multiple values
+  'goodbye'
+);

--- a/packages/template/__tests__/resolution.test.ts
+++ b/packages/template/__tests__/resolution.test.ts
@@ -2,7 +2,6 @@ import { expectTypeOf } from 'expect-type';
 import { AcceptsBlocks, DirectInvokable, TemplateContext } from '../-private/integration';
 import {
   emitComponent,
-  bindBlocks,
   resolve,
   ResolveContext,
   resolveOrReturn,
@@ -34,13 +33,14 @@ declare function value<T>(): T;
      * ```
      */
     public static template = template(function <T>(𝚪: ResolveContext<MyComponent<T>>) {
-      emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready), (component) => {
-        bindBlocks(component.blockParams, {
-          default(isReady) {
-            yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
-          },
-        });
-      });
+      {
+        const component = emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready));
+
+        {
+          const [isReady] = component.blockParams.default;
+          yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
+        }
+      }
     });
   }
 

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -34,7 +34,7 @@ describe('Debug utilities', () => {
 
       | Mapping: Template
       |  hbs(0:50):    hbs\`\\\\n    <HelperComponent @foo={{this.bar}} />\\\\n  \`
-      |  ts(0:344):    (() => {\\\\n  hbs;\\\\n  let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");\\\\n  return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>) {\\\\n    χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }), 𝛄 => {\\\\n      χ.bindBlocks(𝛄.blockParams, {});\\\\n    });\\\\n    𝚪;\\\\n  });\\\\n})()
+      |  ts(0:324):    (() => {\\\\n  hbs;\\\\n  let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");\\\\n  return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>) {\\\\n    {\\\\n      const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n      𝛄;\\\\n    }\\\\n    𝚪;\\\\n  });\\\\n})()
       |
       | | Mapping: Identifier
       | |  hbs(0:0):
@@ -42,35 +42,35 @@ describe('Debug utilities', () => {
       | |
       | | Mapping: ElementNode
       | |  hbs(9:46):    <HelperComponent @foo={{this.bar}} />
-      | |  ts(200:326):  χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }), 𝛄 => {\\\\n      χ.bindBlocks(𝛄.blockParams, {});\\\\n    });
+      | |  ts(200:306):  {\\\\n      const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n      𝛄;\\\\n    }
       | |
       | | | Mapping: Identifier
       | | |  hbs(10:25):   HelperComponent
-      | | |  ts(230:245):  HelperComponent
+      | | |  ts(249:264):  HelperComponent
       | | |
       | | | Mapping: AttrNode
       | | |  hbs(26:43):   @foo={{this.bar}}
-      | | |  ts(249:265):  foo: 𝚪.this.bar
+      | | |  ts(268:284):  foo: 𝚪.this.bar
       | | |
       | | | | Mapping: Identifier
       | | | |  hbs(27:30):   foo
-      | | | |  ts(249:252):  foo
+      | | | |  ts(268:271):  foo
       | | | |
       | | | | Mapping: MustacheStatement
       | | | |  hbs(31:43):   {{this.bar}}
-      | | | |  ts(254:265):  𝚪.this.bar
+      | | | |  ts(273:284):  𝚪.this.bar
       | | | |
       | | | | | Mapping: PathExpression
       | | | | |  hbs(33:41):   this.bar
-      | | | | |  ts(254:265):  𝚪.this.bar
+      | | | | |  ts(273:284):  𝚪.this.bar
       | | | | |
       | | | | | | Mapping: Identifier
       | | | | | |  hbs(33:37):   this
-      | | | | | |  ts(257:261):  this
+      | | | | | |  ts(276:280):  this
       | | | | | |
       | | | | | | Mapping: Identifier
       | | | | | |  hbs(38:41):   bar
-      | | | | | |  ts(262:265):  bar
+      | | | | | |  ts(281:284):  bar
       | | | | | |
       | | | | |
       | | | |
@@ -80,7 +80,7 @@ describe('Debug utilities', () => {
 
       | Mapping: Template
       |  hbs(0:62):    hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n    </p>\\\\n  \`
-      |  ts(0:368):    (() => {\\\\n  hbs;\\\\n  let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");\\\\n  return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>) {\\\\n    χ.emitElement(\\"p\\", 𝛄 => {\\\\n      χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    });\\\\n    𝚪;\\\\n  });\\\\n})()
+      |  ts(0:378):    (() => {\\\\n  hbs;\\\\n  let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");\\\\n  return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>) {\\\\n    {\\\\n      const 𝛄 = χ.emitElement(\\"p\\");\\\\n      χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    }\\\\n    𝚪;\\\\n  });\\\\n})()
       |
       | | Mapping: Identifier
       | |  hbs(0:0):
@@ -88,23 +88,23 @@ describe('Debug utilities', () => {
       | |
       | | Mapping: ElementNode
       | |  hbs(9:58):    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n    </p>
-      | |  ts(204:350):  χ.emitElement(\\"p\\", 𝛄 => {\\\\n      χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    });
+      | |  ts(204:360):  {\\\\n      const 𝛄 = χ.emitElement(\\"p\\");\\\\n      χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    }
       | |
       | | | Mapping: AttrNode
       | | |  hbs(12:25):   ...attributes
-      | | |  ts(235:286):  χ.applySplattributes(𝚪.element, 𝛄.element);
+      | | |  ts(247:298):  χ.applySplattributes(𝚪.element, 𝛄.element);
       | | |
       | | | Mapping: MustacheStatement
       | | |  hbs(40:48):   {{@foo}}
-      | | |  ts(287:340):  χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}))
+      | | |  ts(299:352):  χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}))
       | | |
       | | | | Mapping: PathExpression
       | | | |  hbs(42:46):   @foo
-      | | | |  ts(323:334):  𝚪.args.foo
+      | | | |  ts(335:346):  𝚪.args.foo
       | | | |
       | | | | | Mapping: Identifier
       | | | | |  hbs(43:46):   foo
-      | | | | |  ts(331:334):  foo
+      | | | | |  ts(343:346):  foo
       | | | | |
       | | | |
       | | |

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -484,7 +484,7 @@ describe('Diagnostic offset mapping', () => {
           code,
           file: transformedContentsFile,
           messageText: relatedMessageText,
-          start: transformedModule.transformedContents.indexOf('(bar)') + 1,
+          start: transformedModule.transformedContents.indexOf('[bar]') + 1,
           length: 3,
         },
       ],

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -179,17 +179,18 @@ describe('rewriteTemplate', () => {
           "if (𝚪.args.foo) {
             χ.emitValue(χ.resolveOrReturn(𝚪.args.ok)({}));
           } else {
-            χ.emitComponent(χ.resolve(χ.Globals[\\"doAThing\\"])({}), 𝛄 => {
-              χ.bindBlocks(𝛄.blockParams, {
-                default(ok) {
-                  χ.emitValue(χ.resolveOrReturn(ok)({}));
-                },
-                inverse() {
-                  χ.emitValue(χ.resolveOrReturn(𝚪.args.nevermind)({}));
-                },
-              });
-            });
-            χ.Globals[\\"doAThing\\"];
+            {
+              const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"doAThing\\"])({}));
+              {
+                const [ok] = 𝛄.blockParams.default;
+                χ.emitValue(χ.resolveOrReturn(ok)({}));
+              }
+              {
+                const [] = 𝛄.blockParams.inverse;
+                χ.emitValue(χ.resolveOrReturn(𝚪.args.nevermind)({}));
+              }
+              χ.Globals[\\"doAThing\\"];
+            }
           }"
         `);
       });
@@ -383,12 +384,12 @@ describe('rewriteTemplate', () => {
           let template = '<Foo data-bar={{helper param=true}} />';
 
           expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-            "χ.emitComponent(χ.resolve(Foo)({}), 𝛄 => {
+            "{
+              const 𝛄 = χ.emitComponent(χ.resolve(Foo)({}));
               χ.applyAttributes(𝛄.element, {
                 \\"data-bar\\": χ.emitValue(χ.resolve(helper)({ param: true })),
               });
-              χ.bindBlocks(𝛄.blockParams, {});
-            });"
+            }"
           `);
         });
 
@@ -397,9 +398,10 @@ describe('rewriteTemplate', () => {
           let template = '<Foo @bar={{helper param=true}} />';
 
           expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-            "χ.emitComponent(χ.resolve(Foo)({ bar: χ.resolve(helper)({ param: true }) }), 𝛄 => {
-              χ.bindBlocks(𝛄.blockParams, {});
-            });"
+            "{
+              const 𝛄 = χ.emitComponent(χ.resolve(Foo)({ bar: χ.resolve(helper)({ param: true }) }));
+              𝛄;
+            }"
           `);
         });
       });
@@ -417,11 +419,12 @@ describe('rewriteTemplate', () => {
           let template = '<div data-attr={{@input}}></div>';
 
           expect(templateBody(template)).toMatchInlineSnapshot(`
-            "χ.emitElement(\\"div\\", 𝛄 => {
+            "{
+              const 𝛄 = χ.emitElement(\\"div\\");
               χ.applyAttributes(𝛄.element, {
                 \\"data-attr\\": χ.emitValue(χ.resolveOrReturn(𝚪.args.input)({})),
               });
-            });"
+            }"
           `);
         });
 
@@ -429,11 +432,12 @@ describe('rewriteTemplate', () => {
           let template = '<div data-attr="hello, {{@input}}"></div>';
 
           expect(templateBody(template)).toMatchInlineSnapshot(`
-            "χ.emitElement(\\"div\\", 𝛄 => {
+            "{
+              const 𝛄 = χ.emitElement(\\"div\\");
               χ.applyAttributes(𝛄.element, {
                 \\"data-attr\\": \`\${χ.emitValue(χ.resolveOrReturn(𝚪.args.input)({}))}\`,
               });
-            });"
+            }"
           `);
         });
 
@@ -442,9 +446,10 @@ describe('rewriteTemplate', () => {
           let template = '<Greet @message={{@arg}} />';
 
           expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-            "χ.emitComponent(χ.resolve(Greet)({ message: 𝚪.args.arg }), 𝛄 => {
-              χ.bindBlocks(𝛄.blockParams, {});
-            });"
+            "{
+              const 𝛄 = χ.emitComponent(χ.resolve(Greet)({ message: 𝚪.args.arg }));
+              𝛄;
+            }"
           `);
         });
 
@@ -520,9 +525,10 @@ describe('rewriteTemplate', () => {
       let template = `<div {{modifier foo="bar"}}></div>`;
 
       expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-        "χ.emitElement(\\"div\\", 𝛄 => {
+        "{
+          const 𝛄 = χ.emitElement(\\"div\\");
           χ.applyModifier(𝛄.element, χ.resolve(modifier)({ foo: \\"bar\\" }));
-        });"
+        }"
       `);
     });
 
@@ -531,10 +537,10 @@ describe('rewriteTemplate', () => {
       let template = `<MyComponent {{modifier foo="bar"}}/>`;
 
       expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(MyComponent)({}), 𝛄 => {
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(MyComponent)({}));
           χ.applyModifier(𝛄.element, χ.resolve(modifier)({ foo: \\"bar\\" }));
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        }"
       `);
     });
   });
@@ -545,11 +551,12 @@ describe('rewriteTemplate', () => {
       let template = `<div data-attr={{concat (foo 1) (foo true)}}></div>`;
 
       expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-        "χ.emitElement(\\"div\\", 𝛄 => {
+        "{
+          const 𝛄 = χ.emitElement(\\"div\\");
           χ.applyAttributes(𝛄.element, {
             \\"data-attr\\": χ.emitValue(χ.resolve(concat)({}, χ.resolve(foo)({}, 1), χ.resolve(foo)({}, true))),
           });
-        });"
+        }"
       `);
     });
   });
@@ -563,15 +570,15 @@ describe('rewriteTemplate', () => {
       `;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {
-            default(bar, baz) {
-              χ.emitValue(χ.resolveOrReturn(bar)({}));
-              χ.emitValue(χ.resolveOrReturn(baz)({}));
-            },
-          });
-        });
-        χ.Globals[\\"foo\\"];"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}));
+          {
+            const [bar, baz] = 𝛄.blockParams.default;
+            χ.emitValue(χ.resolveOrReturn(bar)({}));
+            χ.emitValue(χ.resolveOrReturn(baz)({}));
+          }
+          χ.Globals[\\"foo\\"];
+        }"
       `);
     });
 
@@ -585,18 +592,19 @@ describe('rewriteTemplate', () => {
       `;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {
-            default(bar, baz) {
-              χ.emitValue(χ.resolveOrReturn(bar)({}));
-              χ.emitValue(χ.resolveOrReturn(baz)({}));
-            },
-            inverse() {
-              χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
-            },
-          });
-        });
-        χ.Globals[\\"foo\\"];"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}));
+          {
+            const [bar, baz] = 𝛄.blockParams.default;
+            χ.emitValue(χ.resolveOrReturn(bar)({}));
+            χ.emitValue(χ.resolveOrReturn(baz)({}));
+          }
+          {
+            const [] = 𝛄.blockParams.inverse;
+            χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
+          }
+          χ.Globals[\\"foo\\"];
+        }"
       `);
     });
 
@@ -610,18 +618,19 @@ describe('rewriteTemplate', () => {
       `;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {
-            default(bar, baz) {
-              χ.emitValue(χ.resolveOrReturn(bar)({}));
-              χ.emitValue(χ.resolveOrReturn(baz)({}));
-            },
-            inverse() {
-              χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
-            },
-          });
-        });
-        χ.Globals[\\"foo\\"];"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}));
+          {
+            const [bar, baz] = 𝛄.blockParams.default;
+            χ.emitValue(χ.resolveOrReturn(bar)({}));
+            χ.emitValue(χ.resolveOrReturn(baz)({}));
+          }
+          {
+            const [] = 𝛄.blockParams.inverse;
+            χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
+          }
+          χ.Globals[\\"foo\\"];
+        }"
       `);
     });
   });
@@ -631,10 +640,11 @@ describe('rewriteTemplate', () => {
       let template = '<div>{{@foo}}</div>';
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitElement(\\"div\\", 𝛄 => {
+        "{
+          const 𝛄 = χ.emitElement(\\"div\\");
           𝛄;
           χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));
-        });"
+        }"
       `);
     });
 
@@ -642,11 +652,12 @@ describe('rewriteTemplate', () => {
       let template = '<div data-foo={{@foo}}></div>';
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitElement(\\"div\\", 𝛄 => {
+        "{
+          const 𝛄 = χ.emitElement(\\"div\\");
           χ.applyAttributes(𝛄.element, {
             \\"data-foo\\": χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({})),
           });
-        });"
+        }"
       `);
     });
 
@@ -654,11 +665,12 @@ describe('rewriteTemplate', () => {
       let template = '<div data-foo="value-{{@foo}}-{{@bar}}"></div>';
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitElement(\\"div\\", 𝛄 => {
+        "{
+          const 𝛄 = χ.emitElement(\\"div\\");
           χ.applyAttributes(𝛄.element, {
             \\"data-foo\\": \`\${χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}))}\${χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}))}\`,
           });
-        });"
+        }"
       `);
     });
 
@@ -666,9 +678,10 @@ describe('rewriteTemplate', () => {
       let template = '<div ...attributes></div>';
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitElement(\\"div\\", 𝛄 => {
+        "{
+          const 𝛄 = χ.emitElement(\\"div\\");
           χ.applySplattributes(𝚪.element, 𝛄.element);
-        });"
+        }"
       `);
     });
   });
@@ -678,9 +691,10 @@ describe('rewriteTemplate', () => {
       let template = `<Foo @bar="hello" />`;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({ bar: \\"hello\\" }), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({ bar: \\"hello\\" }));
+          𝛄;
+        }"
       `);
     });
 
@@ -692,15 +706,15 @@ describe('rewriteTemplate', () => {
       `;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}), 𝛄 => {
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
           𝛄;
-          χ.bindBlocks(𝛄.blockParams, {
-            default(bar) {
-              χ.emitValue(χ.resolveOrReturn(bar)({}));
-            },
-          });
+          {
+            const [bar] = 𝛄.blockParams.default;
+            χ.emitValue(χ.resolveOrReturn(bar)({}));
+          }
           χ.Globals[\\"Foo\\"];
-        });"
+        }"
       `);
     });
 
@@ -709,10 +723,10 @@ describe('rewriteTemplate', () => {
       let template = '<Foo ...attributes />';
 
       expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(Foo)({}), 𝛄 => {
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(Foo)({}));
           χ.applySplattributes(𝚪.element, 𝛄.element);
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        }"
       `);
     });
 
@@ -721,9 +735,10 @@ describe('rewriteTemplate', () => {
       let template = '<foo.bar @arg="hello" />';
 
       expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(foo?.bar)({ arg: \\"hello\\" }), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(foo?.bar)({ arg: \\"hello\\" }));
+          𝛄;
+        }"
       `);
     });
 
@@ -731,9 +746,10 @@ describe('rewriteTemplate', () => {
       let template = '<@foo @arg="hello" />';
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(𝚪.args.foo)({ arg: \\"hello\\" }), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(𝚪.args.foo)({ arg: \\"hello\\" }));
+          𝛄;
+        }"
       `);
     });
 
@@ -741,9 +757,10 @@ describe('rewriteTemplate', () => {
       let template = '<this.foo @arg="hello" />';
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(𝚪.this.foo)({ arg: \\"hello\\" }), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(𝚪.this.foo)({ arg: \\"hello\\" }));
+          𝛄;
+        }"
       `);
     });
 
@@ -761,25 +778,26 @@ describe('rewriteTemplate', () => {
       `;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}), 𝛄 => {
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
           𝛄;
-          χ.bindBlocks(𝛄.blockParams, {
-            head(h) {
-              χ.emitValue(χ.resolveOrReturn(h)({}));
-            },
-            body(b) {
-              χ.emitComponent(χ.resolve(b?.contents)({}), 𝛄 => {
-                𝛄;
-                χ.bindBlocks(𝛄.blockParams, {
-                  default() {
-                  },
-                });
-                b?.contents;
-              });
-            },
-          });
+          {
+            const [h] = 𝛄.blockParams.head;
+            χ.emitValue(χ.resolveOrReturn(h)({}));
+          }
+          {
+            const [b] = 𝛄.blockParams.body;
+            {
+              const 𝛄 = χ.emitComponent(χ.resolve(b?.contents)({}));
+              𝛄;
+              {
+                const [] = 𝛄.blockParams.default;
+              }
+              b?.contents;
+            }
+          }
           χ.Globals[\\"Foo\\"];
-        });"
+        }"
       `);
     });
 
@@ -788,9 +806,10 @@ describe('rewriteTemplate', () => {
       let template = `<Foo @arg="bar-{{baz}}" />`;
 
       expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(Foo)({ arg: \`\${χ.emitValue(χ.resolveOrReturn(baz)({}))}\` }), 𝛄 => {
-          χ.bindBlocks(𝛄.blockParams, {});
-        });"
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(Foo)({ arg: \`\${χ.emitValue(χ.resolveOrReturn(baz)({}))}\` }));
+          𝛄;
+        }"
       `);
     });
 
@@ -802,20 +821,20 @@ describe('rewriteTemplate', () => {
       `;
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}), 𝛄 => {
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
           𝛄;
-          χ.bindBlocks(𝛄.blockParams, {
-            default(NS) {
-              χ.emitComponent(χ.resolve(NS?.Nested?.Custom)({}), 𝛄 => {
-                χ.applyAttributes(𝛄.element, {
-                  class: \\"foo\\",
-                });
-                χ.bindBlocks(𝛄.blockParams, {});
+          {
+            const [NS] = 𝛄.blockParams.default;
+            {
+              const 𝛄 = χ.emitComponent(χ.resolve(NS?.Nested?.Custom)({}));
+              χ.applyAttributes(𝛄.element, {
+                class: \\"foo\\",
               });
-            },
-          });
+            }
+          }
           χ.Globals[\\"Foo\\"];
-        });"
+        }"
       `);
     });
   });


### PR DESCRIPTION
## Background

In #138, we reworked the way components and vanilla HTML elements were emitted. This had several nice effects, but it also exacerbated a problem that was already lurking.

As a general rule, TypeScript discards any narrowing information about a mutable variable or field inside a closure that captures it, because there's no way for it to guarantee that the narrowing still applies. Concretely:

```ts
function myFunction(input: { foo: string | number }) {
  if (typeof input.foo === 'string') {
    // `input.foo` is a string here

    [1, 2, 3].forEach(() => {
      // `input.foo` is back to `string | number` here
    });
  }
}
```

In the example above, even though we as humans can say it's unlikely that `input.foo` will change before that `forEach` callback is invoked, TypeScript has no way of knowing that. For all it (and, technically, us) knows, `forEach` might stash that function away and call it again an hour from now, and `input.foo` could have been changed to a number in that time.

Prior to #138, we used functions to represent blocks passed to a component, so if you narrowed the type of a value outside a block and then tried to use it inside, the result of the narrowing would be lost. With #138, that problem also began to apply to attributes and modifiers passed to elements and components, which made the issue much more obvious, as seen in #143.

## The Fix

Since the code Glint generates is never actually executed, using callbacks the way we do isn't actually accomplishing much other than introducing a nested block scope, and that's something we can do ourselves instead.

The general change here goes from the form:

```ts
emitComponent(..., 𝛄 => {
  applyAttributes(𝛄.element, ...);
});
```

To:

```ts
{
  const 𝛄 = emitComponent(...);
  applyAttributes(𝛄.element, ...);
}
```

Here `𝛄` enters and leaves scope in the same places as before, and can continue to be shadowed by deeper blocks as appropriate. However, since there's nary a callback in sight, any type information produced by narrowing will continue to be available in further nested blocks.

Blocks passed to components work similarly, going from:

```ts
bindBlocks(𝛄.blockParams, {
  header() {
    // header stuff
  },
  body(item, index) {
    // body stuff
  }
});
```

To:

```ts
{
  const [] = 𝛄.blockParams.header;
  // header stuff
}
{
  const [item, index] = 𝛄.blockParams.body;
  // body stuff
}
```

## Notes

### (No More) Mandatory Blocks

With this change we drop the notion of a 'mandatory' block. Previously if you wrote `Yields: { default: [] }`, a consumer would be _required_ to invoke your component with a default block. This always struck me as being of questionable value (the error message was awful), but it was a natural side effect of how we were passing blocks before so I left it.

Now we treat all declared blocks as available but not required, and it's up to the consumer to decide whether to make use of them, which maps neatly to the reality at runtime (`yield`-ing to a block you weren't passed is a no-op). Anecdotally this also feels better to me, as I've frequently found myself having to go back and stick a `?` on a block declaration because I'd inadvertently made it required.

That said, if others feel differently we can revisit and probably construct a synthetic way to enforce that mandatory blocks are actually used.

### Narrowing Safety

Because components can't store blocks and invoke them at some later point in time, this change is safe—any narrower type information we infer at one level _will_ still be true further down.

However, there's always the potential for that to change in the future. The original named blocks proposal did allow them to be reified into JS-accessible objects, but there were similar lifetime concerns for blocks that led to the trimmed down "yieldable-only" version that shipped.

If that changes in the future we may need to either revisit this specifically for blocks, or see if it's reasonable to advocate for a syntactic differentiator between yieldable blocks and reified ones.

Fixes #143, closes #146 (thanks for the failing tests, @wagenet! they're in the base commit here)