### PR TITLE
Ensure we reexport static members from upstream classes

### DIFF
--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -3,6 +3,8 @@ import { AcceptsBlocks, EmptyObject, Invokable } from '@glint/template/-private/
 type Constructor<T> = new (...params: any) => T;
 type Get<T, K, Otherwise = EmptyObject> = K extends keyof T ? Exclude<T[K], undefined> : Otherwise;
 
+export type AsObjectType<T> = { [K in keyof T]: T[K] };
+
 export type ElementOf<C extends ComponentLike> = C extends Constructor<
   Invokable<(...args: any) => AcceptsBlocks<any, infer Element>>
 >

--- a/packages/environment-ember-loose/__tests__/component.test.ts
+++ b/packages/environment-ember-loose/__tests__/component.test.ts
@@ -1,3 +1,4 @@
+import UpstreamEmberComponent from '@ember/component';
 import Component, { ComponentSignature } from '@glint/environment-ember-loose/ember-component';
 import {
   template,
@@ -9,6 +10,9 @@ import {
 } from '@glint/environment-ember-loose/-private/dsl';
 import { EmptyObject } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
+
+// Our `Component` reexport should inherit static members
+expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
 
 {
   class NoArgsComponent extends Component {

--- a/packages/environment-ember-loose/__tests__/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/helper.test.ts
@@ -1,7 +1,11 @@
+import UpstreamEmberHelper from '@ember/component/helper';
 import Helper, { helper } from '@glint/environment-ember-loose/ember-component/helper';
 import { resolve } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { EmptyObject } from '@glint/template/-private/integration';
+
+// Our `Helper` reexport should inherit static members
+expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
 
 // Functional helper: positional params
 {

--- a/packages/environment-ember-loose/ember-component/helper.ts
+++ b/packages/environment-ember-loose/ember-component/helper.ts
@@ -1,4 +1,5 @@
 import type { Invoke, Invokable, EmptyObject } from '@glint/template/-private/integration';
+import type { AsObjectType } from '../-private/utilities';
 
 declare const Ember: { Helper: EmberHelperConstructor };
 
@@ -25,9 +26,10 @@ export interface HelperSignature {
 // Overriding `compute` directly is impossible because the base class has such
 // wide parameter types, so we explicitly exclude that from the interface we're
 // extending here so our override can "take" without an error.
-const Helper = (EmberHelper as unknown) as new <T extends HelperSignature>(
-  ...args: ConstructorParameters<EmberHelperConstructor>
-) => Helper<T>;
+const Helper = EmberHelper as AsObjectType<typeof EmberHelper> &
+  (new <T extends HelperSignature>(
+    ...args: ConstructorParameters<EmberHelperConstructor>
+  ) => Helper<T>);
 
 interface Helper<T extends HelperSignature> extends Omit<EmberHelper, 'compute'> {
   compute(

--- a/packages/environment-ember-loose/ember-component/index.ts
+++ b/packages/environment-ember-loose/ember-component/index.ts
@@ -6,7 +6,9 @@ import type {
   EmptyObject,
 } from '@glint/template/-private/integration';
 
+import type { AsObjectType } from '../-private/utilities';
 import type { ComponentSignature } from '../-private';
+
 export type { ComponentSignature };
 
 declare const Ember: { Component: EmberComponentConstructor };
@@ -21,9 +23,10 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
 
 export type ArgsFor<T extends ComponentSignature> = 'Args' extends keyof T ? T['Args'] : {};
 
-const Component = (EmberComponent as unknown) as new <T extends ComponentSignature = {}>(
-  ...args: ConstructorParameters<EmberComponentConstructor>
-) => Component<T>;
+const Component = EmberComponent as AsObjectType<typeof EmberComponent> &
+  (new <T extends ComponentSignature = {}>(
+    ...args: ConstructorParameters<EmberComponentConstructor>
+  ) => Component<T>);
 
 interface Component<T extends ComponentSignature = {}> extends EmberComponent {
   [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;

--- a/packages/environment-ember-loose/ember-modifier/index.ts
+++ b/packages/environment-ember-loose/ember-modifier/index.ts
@@ -4,6 +4,7 @@ import type {
   BoundModifier,
   EmptyObject,
 } from '@glint/template/-private/integration';
+import type { AsObjectType } from '../-private/utilities';
 
 const EmberModifier = window.require('ember-modifier').default;
 type EmberModifier<T> = import('ember-modifier').default<T>;
@@ -27,9 +28,10 @@ export interface ModifierSignature {
   Element?: Element;
 }
 
-const Modifier = EmberModifier as new <T extends ModifierSignature>(
-  ...args: ConstructorParameters<EmberModifierConstructor>
-) => Modifier<T>;
+const Modifier = EmberModifier as AsObjectType<typeof EmberModifier> &
+  (new <T extends ModifierSignature>(
+    ...args: ConstructorParameters<EmberModifierConstructor>
+  ) => Modifier<T>);
 
 interface Modifier<T extends ModifierSignature>
   extends EmberModifier<{

--- a/packages/environment-ember-loose/glimmer-component/index.ts
+++ b/packages/environment-ember-loose/glimmer-component/index.ts
@@ -5,6 +5,7 @@ import type {
   AcceptsBlocks,
   EmptyObject,
 } from '@glint/template/-private/integration';
+import { AsObjectType } from '../-private/utilities';
 
 import type { ComponentSignature } from '../-private';
 export type { ComponentSignature };
@@ -17,9 +18,10 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
 
-const Component = GlimmerComponent as new <T extends ComponentSignature = {}>(
-  ...args: ConstructorParameters<GlimmerComponentConstructor>
-) => Component<T>;
+const Component = GlimmerComponent as AsObjectType<typeof GlimmerComponent> &
+  (new <T extends ComponentSignature = {}>(
+    ...args: ConstructorParameters<GlimmerComponentConstructor>
+  ) => Component<T>);
 
 interface Component<T extends ComponentSignature = {}> extends GlimmerComponent<Get<T, 'Args'>> {
   [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;


### PR DESCRIPTION
Prior to this change we were _only_ exporting the constructor signature for upstream classes. This change ensures we also reflect static members like `extend`.

Fixes #147.