### PR TITLE
Introduce `PositionalArgs` for component signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ export default class Greeting extends Component<GreetingSignature> {
 {{yield (concat @message ", " this.greetingTarget "!")}}
 ```
 
+Ember components also support `PositionalArgs` in their signature. Such usage is relatively rare, but components such as [`{{animated-if}}`](https://github.com/ember-animation/ember-animated) do take advantage of it. `PositionalArgs` are specified using a tuple type in the same way that block parameters are. You can also include `PositionalArgs` in the signature passed to `ComponentLike` (see below) when declaring types for third-party components.
+
+Note that both `Element` and `PositionalArgs` are not fully integrated with the string-based APIs on the `@ember/component` base class. This means, for example that there's no enforcement that `tagName = 'table'` and `Element: HTMLTableElement` are actually correlated to one another.
+
 #### Template Registry
 
 Because Ember's template resolution occurs dynamically at runtime today, Glint needs a way of mapping the names used in your templates to the actual backing value they'll be resolved to. This takes the form of a "type registry" similar to the one that powers Ember Data's types.

--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -29,6 +29,7 @@ export type YieldsOf<C extends ComponentLike> = C extends Constructor<
  */
 export type ComponentSignature = {
   Args?: Partial<Record<string, unknown>>;
+  PositionalArgs?: Array<unknown>;
   Yields?: Partial<Record<string, Array<unknown>>>;
   Element?: Element | null;
 };
@@ -39,7 +40,12 @@ export type ComponentSignature = {
  * as are the values returned from the `{{component}}` helper.
  */
 export type ComponentLike<T extends ComponentSignature = any> = Constructor<
-  Invokable<(args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>>
+  Invokable<
+    (
+      args: Get<T, 'Args'>,
+      ...positional: Get<T, 'PositionalArgs', []>
+    ) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>
+  >
 >;
 
 /**

--- a/packages/environment-ember-loose/__tests__/component-like.test.ts
+++ b/packages/environment-ember-loose/__tests__/component-like.test.ts
@@ -1,0 +1,115 @@
+import { ComponentLike } from '@glint/environment-ember-loose';
+import { resolve, emitComponent } from '@glint/environment-ember-loose/-private/dsl';
+import { expectTypeOf } from 'expect-type';
+
+{
+  const NoArgsComponent = {} as ComponentLike<{}>;
+
+  resolve(NoArgsComponent)({
+    // @ts-expect-error: extra named arg
+    foo: 'bar',
+  });
+
+  resolve(NoArgsComponent)(
+    {},
+    // @ts-expect-error: extra positional arg
+    'oops'
+  );
+
+  {
+    const component = emitComponent(resolve(NoArgsComponent)({}));
+
+    {
+      // @ts-expect-error: never yields, so shouldn't accept blocks
+      component.blockParams.default;
+    }
+  }
+
+  emitComponent(resolve(NoArgsComponent)({}));
+}
+
+{
+  interface YieldingComponentSignature {
+    Args: {
+      values: Array<number>;
+    };
+    Yields: {
+      default: [number];
+      inverse?: [];
+    };
+  }
+
+  const YieldingComponent = {} as ComponentLike<YieldingComponentSignature>;
+
+  // @ts-expect-error: missing required arg
+  resolve(YieldingComponent)({});
+
+  resolve(YieldingComponent)(
+    { values: [] },
+    // @ts-expect-error: extra positional arg
+    'hi'
+  );
+
+  resolve(YieldingComponent)({
+    // @ts-expect-error: incorrect type for arg
+    values: 'hello',
+  });
+
+  resolve(YieldingComponent)({
+    values: [1, 2, 3],
+    // @ts-expect-error: extra arg
+    oops: true,
+  });
+
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [value] = component.blockParams.default;
+      expectTypeOf(value).toEqualTypeOf<number>();
+    }
+  }
+
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [...args] = component.blockParams.default;
+      expectTypeOf(args).toEqualTypeOf<[number]>();
+    }
+
+    {
+      const [...args] = component.blockParams.inverse;
+      expectTypeOf(args).toEqualTypeOf<[]>();
+    }
+  }
+}
+
+{
+  interface PositionalArgsComponentSignature {
+    Args: { key?: string };
+    PositionalArgs: [name: string, age?: number];
+  }
+
+  const PositionalArgsComponent = {} as ComponentLike<PositionalArgsComponentSignature>;
+
+  // @ts-expect-error: missing required positional arg
+  resolve(PositionalArgsComponent)({});
+
+  resolve(PositionalArgsComponent)(
+    {},
+    // @ts-expect-error: incorrect type for positional arg
+    123
+  );
+
+  resolve(PositionalArgsComponent)(
+    {},
+    'a',
+    1,
+    // @ts-expect-error: extra positional arg
+    true
+  );
+
+  resolve(PositionalArgsComponent)({}, 'a');
+  resolve(PositionalArgsComponent)({}, 'a', 1);
+}

--- a/packages/environment-ember-loose/__tests__/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/ember-component.test.ts
@@ -1,5 +1,5 @@
 import UpstreamEmberComponent from '@ember/component';
-import Component, { ComponentSignature } from '@glint/environment-ember-loose/ember-component';
+import Component, { ArgsFor } from '@glint/environment-ember-loose/ember-component';
 import {
   template,
   resolve,
@@ -58,8 +58,6 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
 }
 
 {
-  type ArgsOf<T extends ComponentSignature> = 'Args' extends keyof T ? T['Args'] : EmptyObject;
-
   interface YieldingComponentSignature<T> {
     Args: {
       values: Array<T>;
@@ -70,7 +68,7 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
     };
   }
 
-  interface YieldingComponent<T> extends ArgsOf<YieldingComponentSignature<T>> {}
+  interface YieldingComponent<T> extends ArgsFor<YieldingComponentSignature<T>> {}
   class YieldingComponent<T> extends Component<YieldingComponentSignature<T>> {
     static template = template(function* <T>(𝚪: ResolveContext<YieldingComponent<T>>) {
       expectTypeOf(𝚪.this).toEqualTypeOf<YieldingComponent<T>>();

--- a/packages/environment-ember-loose/__tests__/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/ember-component.test.ts
@@ -116,3 +116,33 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
     }
   }
 }
+
+{
+  interface PositionalArgsComponentSignature {
+    Args: { key?: string };
+    PositionalArgs: [name: string, age?: number];
+  }
+
+  interface PositionalArgsComponent extends ArgsFor<PositionalArgsComponentSignature> {}
+  class PositionalArgsComponent extends Component<PositionalArgsComponentSignature> {}
+
+  // @ts-expect-error: missing required positional arg
+  resolve(PositionalArgsComponent)({});
+
+  resolve(PositionalArgsComponent)(
+    {},
+    // @ts-expect-error: incorrect type for positional arg
+    123
+  );
+
+  resolve(PositionalArgsComponent)(
+    {},
+    'a',
+    1,
+    // @ts-expect-error: extra positional arg
+    true
+  );
+
+  resolve(PositionalArgsComponent)({}, 'a');
+  resolve(PositionalArgsComponent)({}, 'a', 1);
+}

--- a/packages/environment-ember-loose/__tests__/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/glimmer-component.test.ts
@@ -1,0 +1,109 @@
+import Component from '@glint/environment-ember-loose/glimmer-component';
+import {
+  template,
+  resolve,
+  ResolveContext,
+  yieldToBlock,
+  emitComponent,
+} from '@glint/environment-ember-loose/-private/dsl';
+import { EmptyObject } from '@glint/template/-private/integration';
+import { expectTypeOf } from 'expect-type';
+
+{
+  class NoArgsComponent extends Component {}
+
+  resolve(NoArgsComponent)({
+    // @ts-expect-error: extra named arg
+    foo: 'bar',
+  });
+
+  resolve(NoArgsComponent)(
+    {},
+    // @ts-expect-error: extra positional arg
+    'oops'
+  );
+
+  {
+    const component = emitComponent(resolve(NoArgsComponent)({}));
+
+    {
+      // @ts-expect-error: never yields, so shouldn't accept blocks
+      component.blockParams.default;
+    }
+  }
+
+  emitComponent(resolve(NoArgsComponent)({}));
+}
+
+{
+  class StatefulComponent extends Component {
+    private foo = 'hello';
+
+    static template = template(function* (𝚪: ResolveContext<StatefulComponent>) {
+      expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
+      expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
+      expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
+      expectTypeOf(𝚪.this.args).toEqualTypeOf<EmptyObject>();
+    });
+  }
+
+  emitComponent(resolve(StatefulComponent)({}));
+}
+
+{
+  interface YieldingComponentSignature<T> {
+    Args: {
+      values: Array<T>;
+    };
+    Yields: {
+      default: [T];
+      inverse?: [];
+    };
+  }
+
+  class YieldingComponent<T> extends Component<YieldingComponentSignature<T>> {
+    static template = template(function* <T>(𝚪: ResolveContext<YieldingComponent<T>>) {
+      expectTypeOf(𝚪.this).toEqualTypeOf<YieldingComponent<T>>();
+      expectTypeOf(𝚪.args).toEqualTypeOf<{ values: T[] }>();
+      expectTypeOf(𝚪.this.args).toEqualTypeOf<{ values: T[] }>();
+
+      if (𝚪.args.values.length) {
+        yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
+      } else {
+        yieldToBlock(𝚪, 'inverse');
+      }
+    });
+  }
+
+  // @ts-expect-error: missing required arg
+  resolve(YieldingComponent)({});
+
+  // @ts-expect-error: incorrect type for arg
+  resolve(YieldingComponent)({ values: 'hello' });
+
+  // @ts-expect-error: extra arg
+  resolve(YieldingComponent)({ values: [1, 2, 3], oops: true });
+
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [value] = component.blockParams.default;
+      expectTypeOf(value).toEqualTypeOf<number>();
+    }
+  }
+
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [...args] = component.blockParams.default;
+      expectTypeOf(args).toEqualTypeOf<[number]>();
+    }
+
+    {
+      const [...args] = component.blockParams.inverse;
+      expectTypeOf(args).toEqualTypeOf<[]>();
+    }
+  }
+}

--- a/packages/environment-ember-loose/ember-component/index.ts
+++ b/packages/environment-ember-loose/ember-component/index.ts
@@ -29,8 +29,11 @@ const Component = EmberComponent as AsObjectType<typeof EmberComponent> &
   ) => Component<T>);
 
 interface Component<T extends ComponentSignature = {}> extends EmberComponent {
-  [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
   [Context]: TemplateContext<this, Get<T, 'Args'>, Get<T, 'Yields'>, Get<T, 'Element', null>>;
+  [Invoke]: (
+    args: Get<T, 'Args'>,
+    ...positional: Get<T, 'PositionalArgs', []>
+  ) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
 }
 
 export default Component;


### PR DESCRIPTION
While not super common, classic Ember components (as well as those that use custom component managers) can accept positional args when invoked with curlies. This PR adds `PositionalArgs` as a valid signature member for `EmberComponent` and `ComponentLike` in order to capture those cases.

Note: while the static property that's used to configure this at runtime on an Ember component is called `positionalParams`, I went with `PositionalArgs` for consistency with helper and modifier signatures (as well as `Args` itself on the component signature).

I also noticed in working on this that we had types tests for `EmberComponent`'s Glint integration, but not for `GlimmerComponent` or `ComponentLike`, so I added coverage for those as well.

Fixes #105 