### PR TITLE
Remove `Record`-based constraints on signature members

### DIFF
--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -28,9 +28,9 @@ export type YieldsOf<C extends ComponentLike> = C extends Constructor<
  * README for further details.
  */
 export type ComponentSignature = {
-  Args?: Partial<Record<string, unknown>>;
+  Args?: object;
   PositionalArgs?: Array<unknown>;
-  Yields?: Partial<Record<string, Array<unknown>>>;
+  Yields?: object;
   Element?: Element | null;
 };
 

--- a/packages/environment-ember-loose/ember-component/helper.ts
+++ b/packages/environment-ember-loose/ember-component/helper.ts
@@ -18,7 +18,7 @@ type HelperFactory = <Positional extends unknown[] = [], Named = EmptyObject, Re
 export const helper = (emberHelper as unknown) as HelperFactory;
 
 export interface HelperSignature {
-  NamedArgs?: Record<string, unknown>;
+  NamedArgs?: object;
   PositionalArgs?: Array<unknown>;
   Return?: unknown;
 }

--- a/packages/environment-ember-loose/ember-modifier/index.ts
+++ b/packages/environment-ember-loose/ember-modifier/index.ts
@@ -23,7 +23,7 @@ type ModifierFactory = <El extends Element, Positional extends unknown[] = [], N
 export const modifier = emberModifier as ModifierFactory;
 
 export interface ModifierSignature {
-  NamedArgs?: Record<string, unknown>;
+  NamedArgs?: object;
   PositionalArgs?: Array<unknown>;
   Element?: Element;
 }

--- a/packages/environment-glimmerx/component/index.ts
+++ b/packages/environment-glimmerx/component/index.ts
@@ -15,8 +15,8 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   : Otherwise;
 
 export interface ComponentSignature {
-  Args?: Partial<Record<string, unknown>>;
-  Yields?: Partial<Record<string, Array<unknown>>>;
+  Args?: object;
+  Yields?: object;
   Element?: Element;
 }
 

--- a/packages/template/__tests__/resolution.test.ts
+++ b/packages/template/__tests__/resolution.test.ts
@@ -14,13 +14,13 @@ declare function value<T>(): T;
 
 // Component with a template
 {
-  type MyArgs<T> = {
+  interface MyArgs<T> {
     value: T;
-  };
+  }
 
-  type MyYields<T> = {
-    body: [boolean, T];
-  };
+  interface MyYields<T> {
+    body: [someFlag: boolean, someValue: T];
+  }
 
   class MyComponent<T> extends TestComponent<{ Args: MyArgs<T>; Yields: MyYields<T> }> {
     private state = { ready: false };

--- a/packages/template/__tests__/test-component.ts
+++ b/packages/template/__tests__/test-component.ts
@@ -28,8 +28,8 @@ export declare const globals: {
 type Get<T, K, Otherwise = EmptyObject> = K extends keyof T ? Exclude<T[K], undefined> : Otherwise;
 
 export interface ComponentSignature {
-  Args?: Record<string, unknown>;
-  Yields?: Record<string, unknown[] | undefined>;
+  Args?: object;
+  Yields?: object;
   Element?: Element;
 }
 


### PR DESCRIPTION
Currently, people who have `class MyComponent extends Component<MyArgs>` and are adopting Glint are naturally inclined to change that to `Component<{ Args: MyArgs }>`. Unfortunately, if the `MyArgs` type is declared as an `interface`, that change will fail with a confusing error:

```
Type '{ Args: MyArgs; }' does not satisfy the constraint 'ComponentSignature'.
  Types of property 'Args' are incompatible.
    Type 'MyArgs' is not assignable to type 'Record<string, unknown>'.
      Index signature is missing in type 'MyArgs'.(2344)
```

The underlying reason for this is that TS will infer an index signature for type aliases, but is unwilling to do so for interfaces because [that's more unsafe due to the potential for declaration merging](https://github.com/microsoft/TypeScript/issues/15300#issuecomment-332366024). Needing to migrate `interface`s to `type` declarations is an annoying adoption papercut, particularly given that it's not apparent from the error message that that's a viable fix.

In practice this constraint doesn't provide a _whole_ lot of value over using `object` instead, particularly relative to the number of folks who've already run into this index signature issue. We may consider some type-aware linting in the future, but for now this should remove some real pain for people working to adopt Glint.