### PR TITLE
Don't block Windows on Linux in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
 
   test-windows:
     name: Test Windows
-    needs: [test]
     runs-on: windows-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
When this repo was private, it made sense to wait for Linux to pass before even trying to test Windows. Now that Actions minutes aren't so tight, though, we're probably better off running the Windows job ASAP, as it takes about as long as Linux + TS Nightly _combined_.