### PR TITLE
Allow LinkTo current-when to be boolean

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
@@ -24,7 +24,7 @@ type LinkToArgs = RequireAtLeastOne<
     query?: Record<string, unknown>;
     disabled?: boolean;
     activeClass?: string;
-    'current-when'?: string;
+    'current-when'?: string | boolean;
     preventDefault?: boolean;
     tagName?: string;
   },

--- a/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
@@ -36,6 +36,16 @@ linkTo({}, 123);
   expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
 }
 
+{
+  const component = emitComponent(LinkTo({ route: 'index', 'current-when': 'index' }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
+
+{
+  const component = emitComponent(LinkTo({ route: 'index', 'current-when': true }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
+
 // Requires at least one of `@route`, `@model`, `@models` or `@query`
 
 {


### PR DESCRIPTION
> A link will be active if current-when is true or the current route is the route this link would transition to.

https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo