### PR TITLE
Capture given signatures so TS can infer them from the concrete type

### DIFF
--- a/packages/environment-ember-loose/__tests__/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/ember-component.test.ts
@@ -93,6 +93,11 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
   // @ts-expect-error: extra arg
   resolve(YieldingComponent)({ values: [1, 2, 3], oops: true });
 
+  type InferSignature<T> = T extends Component<infer Signature> ? Signature : never;
+  expectTypeOf<InferSignature<YieldingComponent<number>>>().toEqualTypeOf<
+    YieldingComponentSignature<number>
+  >();
+
   {
     const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
 

--- a/packages/environment-ember-loose/__tests__/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/glimmer-component.test.ts
@@ -84,6 +84,11 @@ import { expectTypeOf } from 'expect-type';
   // @ts-expect-error: extra arg
   resolve(YieldingComponent)({ values: [1, 2, 3], oops: true });
 
+  type InferSignature<T> = T extends Component<infer Signature> ? Signature : never;
+  expectTypeOf<InferSignature<YieldingComponent<number>>>().toEqualTypeOf<
+    YieldingComponentSignature<number>
+  >();
+
   {
     const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
 

--- a/packages/environment-ember-loose/__tests__/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/helper.test.ts
@@ -81,6 +81,12 @@ expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
 
   expectTypeOf(repeat({ value: 'hi' })).toEqualTypeOf<Array<string>>();
   expectTypeOf(repeat({ value: 123, count: 3 })).toEqualTypeOf<Array<number>>();
+
+  type InferSignature<T> = T extends Helper<infer Signature> ? Signature : never;
+  expectTypeOf<InferSignature<RepeatHelper<number>>>().toEqualTypeOf<{
+    NamedArgs: RepeatArgs<number>;
+    Return: Array<number>;
+  }>();
 }
 
 // Class-based helper: positional args

--- a/packages/environment-ember-loose/__tests__/modifier.test.ts
+++ b/packages/environment-ember-loose/__tests__/modifier.test.ts
@@ -5,11 +5,13 @@ import { BoundModifier } from '@glint/template/-private/integration';
 
 // Class-based modifier
 {
-  class NeatModifier extends Modifier<{
+  interface NeatModifierSignature {
     NamedArgs: { multiplier?: number };
     PositionalArgs: [input: string];
     Element: HTMLImageElement;
-  }> {
+  }
+
+  class NeatModifier extends Modifier<NeatModifierSignature> {
     private interval?: number;
 
     get lengthOfInput(): number {
@@ -41,6 +43,9 @@ import { BoundModifier } from '@glint/template/-private/integration';
 
   expectTypeOf(neat({}, 'hello')).toEqualTypeOf<BoundModifier<HTMLImageElement>>();
   expectTypeOf(neat({ multiplier: 3 }, 'hello')).toEqualTypeOf<BoundModifier<HTMLImageElement>>();
+
+  type InferSignature<T> = T extends Modifier<infer Signature> ? Signature : never;
+  expectTypeOf<InferSignature<NeatModifier>>().toEqualTypeOf<NeatModifierSignature>();
 
   // @ts-expect-error: missing required positional arg
   neat({});

--- a/packages/environment-ember-loose/ember-component/helper.ts
+++ b/packages/environment-ember-loose/ember-component/helper.ts
@@ -2,6 +2,7 @@ import type { Invoke, Invokable, EmptyObject } from '@glint/template/-private/in
 import type { AsObjectType } from '../-private/utilities';
 
 declare const Ember: { Helper: EmberHelperConstructor };
+declare const GivenSignature: unique symbol;
 
 type EmberHelper = import('@ember/component/helper').default;
 type EmberHelperConstructor = typeof import('@ember/component/helper').default;
@@ -36,6 +37,9 @@ interface Helper<T extends HelperSignature> extends Omit<EmberHelper, 'compute'>
     params: Get<T, 'PositionalArgs', []>,
     hash: Get<T, 'NamedArgs'>
   ): Get<T, 'Return', undefined>;
+
+  // Allows `extends Helper<infer Signature>` clauses to work as expected
+  [GivenSignature]: T;
 
   [Invoke]: (
     named: Get<T, 'NamedArgs'>,

--- a/packages/environment-ember-loose/ember-component/index.ts
+++ b/packages/environment-ember-loose/ember-component/index.ts
@@ -12,6 +12,7 @@ import type { ComponentSignature } from '../-private';
 export type { ComponentSignature };
 
 declare const Ember: { Component: EmberComponentConstructor };
+declare const GivenSignature: unique symbol;
 
 const EmberComponent = Ember.Component;
 type EmberComponent = import('@ember/component').default;
@@ -29,6 +30,9 @@ const Component = EmberComponent as AsObjectType<typeof EmberComponent> &
   ) => Component<T>);
 
 interface Component<T extends ComponentSignature = {}> extends EmberComponent {
+  // Allows `extends Component<infer Signature>` clauses to work as expected
+  [GivenSignature]: T;
+
   [Context]: TemplateContext<this, Get<T, 'Args'>, Get<T, 'Yields'>, Get<T, 'Element', null>>;
   [Invoke]: (
     args: Get<T, 'Args'>,

--- a/packages/environment-ember-loose/ember-modifier/index.ts
+++ b/packages/environment-ember-loose/ember-modifier/index.ts
@@ -10,6 +10,8 @@ const EmberModifier = window.require('ember-modifier').default;
 type EmberModifier<T> = import('ember-modifier').default<T>;
 type EmberModifierConstructor = typeof import('ember-modifier').default;
 
+declare const GivenSignature: unique symbol;
+
 const emberModifier = window.require('ember-modifier').modifier;
 
 type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
@@ -28,7 +30,7 @@ export interface ModifierSignature {
   Element?: Element;
 }
 
-const Modifier = EmberModifier as AsObjectType<typeof EmberModifier> &
+const Modifier = EmberModifier as AsObjectType<EmberModifierConstructor> &
   (new <T extends ModifierSignature>(
     ...args: ConstructorParameters<EmberModifierConstructor>
   ) => Modifier<T>);
@@ -39,6 +41,10 @@ interface Modifier<T extends ModifierSignature>
     positional: Extract<Get<T, 'PositionalArgs', []>, any[]>;
   }> {
   readonly element: Get<T, 'Element', Element>;
+
+  // Allows `extends Modifier<infer Signature>` clauses to work as expected
+  [GivenSignature]: T;
+
   [Invoke]: (
     args: Get<T, 'NamedArgs'>,
     ...positional: Get<T, 'PositionalArgs', []>

--- a/packages/environment-ember-loose/glimmer-component/index.ts
+++ b/packages/environment-ember-loose/glimmer-component/index.ts
@@ -14,16 +14,21 @@ const GlimmerComponent = window.require('@glimmer/component').default;
 type GlimmerComponent<T> = import('@glimmer/component').default<T>;
 type GlimmerComponentConstructor = typeof import('@glimmer/component').default;
 
+declare const GivenSignature: unique symbol;
+
 type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
 
-const Component = GlimmerComponent as AsObjectType<typeof GlimmerComponent> &
+const Component = GlimmerComponent as AsObjectType<GlimmerComponentConstructor> &
   (new <T extends ComponentSignature = {}>(
     ...args: ConstructorParameters<GlimmerComponentConstructor>
   ) => Component<T>);
 
 interface Component<T extends ComponentSignature = {}> extends GlimmerComponent<Get<T, 'Args'>> {
+  // Allows `extends Component<infer Signature>` clauses to work as expected
+  [GivenSignature]: T;
+
   [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
   [Context]: TemplateContext<this, Get<T, 'Args'>, Get<T, 'Yields'>, Get<T, 'Element', null>>;
 }

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -93,6 +93,11 @@ import { EmptyObject } from '@glint/template/-private/integration';
     oops: true,
   });
 
+  type InferSignature<T> = T extends Component<infer Signature> ? Signature : never;
+  expectTypeOf<InferSignature<YieldingComponent<number>>>().toEqualTypeOf<
+    YieldingComponentSignature<number>
+  >();
+
   {
     const component = emitComponent(resolve(YieldingComponent)({ values: [] }));
 

--- a/packages/environment-glimmerx/component/index.ts
+++ b/packages/environment-glimmerx/component/index.ts
@@ -14,6 +14,8 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
 
+declare const GivenSignature: unique symbol;
+
 export interface ComponentSignature {
   Args?: object;
   Yields?: object;
@@ -25,6 +27,9 @@ const Component = glimmerxComponent.default as new <
 >() => Component<T>;
 interface Component<T extends ComponentSignature = {}>
   extends glimmerxComponent.default<Get<T, 'Args'> & {}> {
+  // Allows `extends Component<infer Signature>` clauses to work as expected
+  [GivenSignature]: T;
+
   [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
   [Context]: TemplateContext<this, Get<T, 'Args'>, Get<T, 'Yields'>, Get<T, 'Element', null>>;
 }


### PR DESCRIPTION
For situations like writing types tests, since there's no (public) way to verify how an entity will behave when invoked in a template, it's reasonable to want to be able extract a class's signature type from the instance type. However, because of the `Get<T, 'PositionalArgs' []>`-style lookups we do to handle the presence or absence of keys in a signature, TypeScript can't `infer` backwards through those conditional types to reconstruct the original signature.

This PR captures the signature type directly on the instance type for all the signature-having classes we export. Notably, this type has _no_ bearing on how these entities behave in templates, and is only to enable recovery of the original signature.

An alternative to this approach would be to encourage the use of `Invokable`, `AcceptsBlocks` and other currently-private API to more directly validate an entity's template behavior. While that's somewhat appealing in terms of being able to test something closer to the "actual" type, my leaning at this point is to say we're not yet ready to commit to making the details of `[Invoke]` stable and public.