### PR TITLE
Ensure `{{each}}` yields `any` given `any` or a non-iterable value

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/each.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each.d.ts
@@ -4,8 +4,8 @@ import EmberArray from '@ember/array';
 type ArrayLike<T> = ReadonlyArray<T> | Iterable<T> | EmberArray<T>;
 
 export type EachKeyword = DirectInvokable<{
-  <T>(args: { key?: string }, items: ArrayLike<T> | null | undefined): AcceptsBlocks<{
+  <T = any>(args: { key?: string }, items: ArrayLike<T> | null | undefined): AcceptsBlocks<{
     default: [T, number];
-    inverse?: [];
+    inverse: [];
   }>;
 }>;

--- a/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
@@ -96,3 +96,22 @@ declare const arrayOrNull: string[] | null;
     expectTypeOf(index).toEqualTypeOf<number>();
   }
 }
+
+// Gives `any` given `any`
+{
+  const component = emitComponent(each({}, {} as any));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[any, number]>();
+}
+
+// Gives `any` given an invalid iterable (avoiding a cascade of type errors)
+{
+  const component = emitComponent(
+    each(
+      {},
+      // @ts-expect-error: number is not a valid iterable
+      123
+    )
+  );
+
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[any, number]>();
+}


### PR DESCRIPTION
If `{{each}}` is given an `any` value (or a non-iterable value), the type of the value it yields comes out as `unknown`. This can cause a cascade of type errors that aren't actually helpful because the root issue is the value you tried to iterate over.

In TS itself:

```ts
for (let value of ([] as any)) {
  value; // any
}

for (let value of 123) { // type error on `123`
  value; // any
}
```

This change causes `{{each}}` to behave the same way.