### PR TITLE
Prefer `else` over `inverse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ While GlimmerX components accept `Args` as a type parameter, the Glint version a
 The `Element` field declares what type of element(s), if any, the component applies its passed `...attributes` to. This is often the component's root element. Tracking this type ensures any modifiers used on your component will be compatible with the DOM element(s) they're ultimately attached to. If no `Element` is specified, it will be a type error to set any HTML attributes when invoking your component.
 
 The `Yields` field specifies the names of any blocks the component yields to, as well as the type of any parameter(s) they'll receive. See the [Yieldable Named Blocks RFC] for further details.
+(Note that the `inverse` block is an alias for `else`. These should be defined in `Yields` as `else`, though `{{yield to="inverse"}}` will continue to work.)
 
 ```ts
 import Component from '@glint/environment-glimmerx/component';

--- a/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
@@ -3,6 +3,6 @@ import { AcceptsBlocks, DirectInvokable, EmptyObject } from '@glint/template/-pr
 export type EachInKeyword = DirectInvokable<{
   <T>(args: EmptyObject, object: T): AcceptsBlocks<{
     default: [key: keyof NonNullable<T>, value: NonNullable<T>[keyof NonNullable<T>]];
-    inverse?: [];
+    else?: [];
   }>;
 }>;

--- a/packages/environment-ember-loose/-private/intrinsics/each.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each.d.ts
@@ -6,6 +6,6 @@ type ArrayLike<T> = ReadonlyArray<T> | Iterable<T> | EmberArray<T>;
 export type EachKeyword = DirectInvokable<{
   <T = any>(args: { key?: string }, items: ArrayLike<T> | null | undefined): AcceptsBlocks<{
     default: [T, number];
-    inverse: [];
+    else: [];
   }>;
 }>;

--- a/packages/environment-ember-loose/__tests__/component-like.test.ts
+++ b/packages/environment-ember-loose/__tests__/component-like.test.ts
@@ -35,7 +35,7 @@ import { expectTypeOf } from 'expect-type';
     };
     Yields: {
       default: [number];
-      inverse?: [];
+      else?: [];
     };
   }
 
@@ -79,7 +79,7 @@ import { expectTypeOf } from 'expect-type';
     }
 
     {
-      const [...args] = component.blockParams.inverse;
+      const [...args] = component.blockParams.else;
       expectTypeOf(args).toEqualTypeOf<[]>();
     }
   }

--- a/packages/environment-ember-loose/__tests__/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/ember-component.test.ts
@@ -64,7 +64,7 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
     };
     Yields: {
       default: [T];
-      inverse?: [];
+      else?: [];
     };
   }
 
@@ -79,7 +79,7 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
       if (𝚪.args.values.length) {
         yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
       } else {
-        yieldToBlock(𝚪, 'inverse');
+        yieldToBlock(𝚪, 'else');
       }
     });
   }
@@ -116,7 +116,7 @@ expectTypeOf(Component.extend).toEqualTypeOf(UpstreamEmberComponent.extend);
     }
 
     {
-      const [...args] = component.blockParams.inverse;
+      const [...args] = component.blockParams.else;
       expectTypeOf(args).toEqualTypeOf<[]>();
     }
   }

--- a/packages/environment-ember-loose/__tests__/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/glimmer-component.test.ts
@@ -57,7 +57,7 @@ import { expectTypeOf } from 'expect-type';
     };
     Yields: {
       default: [T];
-      inverse?: [];
+      else?: [];
     };
   }
 
@@ -70,7 +70,7 @@ import { expectTypeOf } from 'expect-type';
       if (𝚪.args.values.length) {
         yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
       } else {
-        yieldToBlock(𝚪, 'inverse');
+        yieldToBlock(𝚪, 'else');
       }
     });
   }
@@ -107,7 +107,7 @@ import { expectTypeOf } from 'expect-type';
     }
 
     {
-      const [...args] = component.blockParams.inverse;
+      const [...args] = component.blockParams.else;
       expectTypeOf(args).toEqualTypeOf<[]>();
     }
   }

--- a/packages/environment-ember-loose/__tests__/intrinsics/each-in.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/each-in.test.ts
@@ -27,12 +27,12 @@ declare const maybeVal: { a: number; b: number } | undefined;
   }
 
   {
-    const [...args] = component.blockParams.inverse;
+    const [...args] = component.blockParams.else;
     expectTypeOf(args).toEqualTypeOf<[]>();
   }
 }
 
-// Can render inverse when undefined, null, or empty.
+// Can render else when undefined, null, or empty.
 
 {
   const component = emitComponent(eachIn({}, undefined));
@@ -45,7 +45,7 @@ declare const maybeVal: { a: number; b: number } | undefined;
   }
 
   {
-    const [...args] = component.blockParams.inverse;
+    const [...args] = component.blockParams.else;
     expectTypeOf(args).toEqualTypeOf<[]>();
   }
 }
@@ -61,7 +61,7 @@ declare const maybeVal: { a: number; b: number } | undefined;
   }
 
   {
-    const [...args] = component.blockParams.inverse;
+    const [...args] = component.blockParams.else;
     expectTypeOf(args).toEqualTypeOf<[]>();
   }
 }
@@ -77,7 +77,7 @@ declare const maybeVal: { a: number; b: number } | undefined;
   }
 
   {
-    const [...args] = component.blockParams.inverse;
+    const [...args] = component.blockParams.else;
     expectTypeOf(args).toEqualTypeOf<[]>();
   }
 }

--- a/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/each.test.ts
@@ -16,7 +16,7 @@ let each = resolve(Globals['each']);
   }
 
   {
-    const [...args] = component.blockParams.inverse;
+    const [...args] = component.blockParams.else;
     expectTypeOf(args).toEqualTypeOf<[]>();
   }
 }

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -60,7 +60,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
     };
     Yields: {
       default: [T];
-      inverse?: [];
+      else?: [];
     };
   }
 
@@ -72,7 +72,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
       if (𝚪.args.values.length) {
         yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
       } else {
-        yieldToBlock(𝚪, 'inverse');
+        yieldToBlock(𝚪, 'else');
       }
     });
   }
@@ -125,7 +125,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
     }
 
     {
-      const [...args] = component.blockParams.inverse;
+      const [...args] = component.blockParams.else;
       expectTypeOf(args).toEqualTypeOf<[]>();
     }
   }

--- a/packages/template/-private/keywords/each.d.ts
+++ b/packages/template/-private/keywords/each.d.ts
@@ -3,6 +3,6 @@ import { AcceptsBlocks, DirectInvokable } from '../integration';
 export type EachKeyword = DirectInvokable<{
   <T>(args: { key?: string }, items: readonly T[]): AcceptsBlocks<{
     default: [T, number];
-    inverse?: [];
+    else?: [];
   }>;
 }>;

--- a/packages/template/-private/keywords/with.d.ts
+++ b/packages/template/-private/keywords/with.d.ts
@@ -3,6 +3,6 @@ import { AcceptsBlocks, DirectInvokable, EmptyObject } from '../integration';
 export type WithKeyword = DirectInvokable<{
   <T>(args: EmptyObject, value: T): AcceptsBlocks<{
     default: [T];
-    inverse?: [];
+    else?: [];
   }>;
 }>;

--- a/packages/template/__tests__/custom-invokable.test.ts
+++ b/packages/template/__tests__/custom-invokable.test.ts
@@ -32,7 +32,7 @@ declare const caseOf: DirectInvokable<
           key: K
         ) => AcceptsBlocks<{
           default: SumVariants<T>[K];
-          inverse?: [];
+          else?: [];
         }>
       >
     ];
@@ -62,7 +62,7 @@ declare const caseOf: DirectInvokable<
         emitValue(resolveOrReturn(n)({}));
       }
       {
-        component.blockParams.inverse;
+        component.blockParams.else;
         {
           const component = emitComponent(resolve(when)({}, 'Nothing'));
           expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();

--- a/packages/template/__tests__/keywords/with.test.ts
+++ b/packages/template/__tests__/keywords/with.test.ts
@@ -14,7 +14,7 @@ const withKeyword = resolve({} as WithKeyword);
   }
 
   {
-    component.blockParams.inverse;
+    component.blockParams.else;
   }
 }
 

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -291,7 +291,7 @@ describe('rewriteTemplate', () => {
                 χ.emitValue(χ.resolveOrReturn(ok)({}));
               }
               {
-                const [] = 𝛄.blockParams.inverse;
+                const [] = 𝛄.blockParams.else;
                 χ.emitValue(χ.resolveOrReturn(𝚪.args.nevermind)({}));
               }
               χ.Globals[\\"doAThing\\"];
@@ -353,6 +353,26 @@ describe('rewriteTemplate', () => {
 
         expect(templateBody(template)).toMatchInlineSnapshot(
           `"χ.yieldToBlock(𝚪, \\"body\\", 123);"`
+        );
+      });
+
+      test('{{yield}} to else', () => {
+        let template = stripIndent`
+          {{yield 123 to="else"}}
+        `;
+
+        expect(templateBody(template)).toMatchInlineSnapshot(
+          `"χ.yieldToBlock(𝚪, \\"else\\", 123);"`
+        );
+      });
+
+      test('{{yield}} to inverse', () => {
+        let template = stripIndent`
+          {{yield 123 to="inverse"}}
+        `;
+
+        expect(templateBody(template)).toMatchInlineSnapshot(
+          `"χ.yieldToBlock(𝚪, \\"else\\", 123);"`
         );
       });
     });
@@ -687,7 +707,7 @@ describe('rewriteTemplate', () => {
       `);
     });
 
-    test('invocation with an inverse block', () => {
+    test('invocation with an else block', () => {
       let template = stripIndent`
         {{#foo as |bar baz|}}
           {{bar}}: {{baz}}
@@ -705,7 +725,7 @@ describe('rewriteTemplate', () => {
             χ.emitValue(χ.resolveOrReturn(baz)({}));
           }
           {
-            const [] = 𝛄.blockParams.inverse;
+            const [] = 𝛄.blockParams.else;
             χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
           }
           χ.Globals[\\"foo\\"];
@@ -713,7 +733,7 @@ describe('rewriteTemplate', () => {
       `);
     });
 
-    test('chained inverse', () => {
+    test('chained else', () => {
       let template = stripIndent`
         {{#foo as |bar baz|}}
           {{bar}}: {{baz}}
@@ -731,7 +751,7 @@ describe('rewriteTemplate', () => {
             χ.emitValue(χ.resolveOrReturn(baz)({}));
           }
           {
-            const [] = 𝛄.blockParams.inverse;
+            const [] = 𝛄.blockParams.else;
             χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
           }
           χ.Globals[\\"foo\\"];

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -671,7 +671,12 @@ export function templateToTypescript(
           to = toPair.value.value;
         }
 
+        if (to === 'inverse') {
+          to = 'else';
+        }
+
         emit.text('χ.yieldToBlock(𝚪, ');
+
         emit.text(JSON.stringify(to));
 
         for (let param of node.params) {
@@ -780,7 +785,7 @@ export function templateToTypescript(
         emitBlock('default', node.program);
 
         if (node.inverse) {
-          emitBlock('inverse', node.inverse);
+          emitBlock('else', node.inverse);
         }
 
         // TODO: emit something corresponding to `{{/foo}}` like we do


### PR DESCRIPTION
Requires `Yields` to use `else`, but still allows for `{{yields to="inverse"}}`