### PR TITLE
Skip `actions/cache` for Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Locate Yarn Cache
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
The decompression step for `actions/cache` on Windows is [known to be slow](https://github.com/actions/cache/issues/442), and in our case it's significantly slower than just installing dependencies from scratch.

In representative sample runs, we spent:

|Step|Linux | Windows | Windows without `actions/cache` |
|-|-|-|-|
| Restore Cache | 0:07 | 3:03 | 0:00 |
| Install Dependencies | 0:22 | 0:40 | 2:18 |
| Save Cache | 0:06 | 0:11 | 0:00 |
| **Total** | **0:37** | **3:36** | **2:18** |