### PR TITLE
Avoid cascading errors on invalid component invocations

### DIFF
--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -50,8 +50,8 @@ export declare function emitElement<Name extends string>(
 export declare function emitComponent<T extends AcceptsBlocks<any, any>>(
   component: T
 ): {
-  element: T extends AcceptsBlocks<any, infer El> ? El : null;
-  blockParams: T extends AcceptsBlocks<infer Yields, any> ? Required<Yields> : never;
+  element: T extends AcceptsBlocks<any, infer El> ? El : any;
+  blockParams: T extends AcceptsBlocks<infer Yields, any> ? Required<Yields> : any;
 };
 
 /**

--- a/packages/template/-private/integration.d.ts
+++ b/packages/template/-private/integration.d.ts
@@ -37,7 +37,7 @@ export type BoundModifier<El extends Element> = { [Modifier]: (el: El) => void }
  * Denotes that the associated entity may be invoked with the given
  * blocks, yielding params of the appropriate type.
  */
-export type AcceptsBlocks<BlockImpls extends AnyBlocks, El extends Element | null = null> = {
+export type AcceptsBlocks<BlockImpls, El extends Element | null = null> = {
   [Element]: El;
   (blocks: BlockImpls): { [Blocks]: true };
 };

--- a/packages/template/__tests__/emit-component.test.ts
+++ b/packages/template/__tests__/emit-component.test.ts
@@ -138,6 +138,25 @@ emitComponent(resolve(MaybeMyComponent)({ value: 'hi' }));
 emitComponent(resolveOrReturn(MaybeMyComponent)({ value: 'hi' }));
 
 /**
+ * Invoking an `any` or `unknown` component should error at the invocation site
+ * if appropriate, but not produce cascading errors.
+ */
+{
+  let anyComponent = emitComponent({} as any);
+  let [anyComponentParam] = anyComponent.blockParams.default;
+
+  expectTypeOf(anyComponent.element).toBeAny();
+  expectTypeOf(anyComponentParam).toBeAny();
+
+  // @ts-expect-error: unknown is an invalid component
+  let unknownComponent = emitComponent({} as unknown);
+  let [unknownComponentParam] = unknownComponent.blockParams.default;
+
+  expectTypeOf(unknownComponent.element).toBeAny();
+  expectTypeOf(unknownComponentParam).toBeAny();
+}
+
+/**
  * Constrained type parameters can be tricky, and `expect-type` doesn't
  * work well with type assertions directly against them, but we can assert
  * against a property that the constraint dictates must exist to ensure


### PR DESCRIPTION
Similar in spirit to #173, this PR ensures that trying to invoke an invalid component doesn't produce a cascade of errors that mask the true problem.

As an example of this, prior to this PR if I were to typo the name of a component in my template, in addition to the "that's not a valid key of `Globals`" error, I'd see a couple of others relating to trying to pass a default block to an unknown component.

![image](https://user-images.githubusercontent.com/108688/115734891-56ae2600-a38a-11eb-8abc-438412b11d84.png)

This change ensures we produce `any` where appropriate in those situations so that we avoid a cascade and don't bury the real error.