### PR TITLE
Link to `glint-template-types` repo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ Glint is a set of tools to aid in developing code that uses the Glimmer VM for r
 
 ⚠️ Note: **Glint is still under active development!** Please bear with us and expect breaking changes and rough edges as we work toward a stable release. Also note that Glint is currently only compatible with TypeScript projects, but our aim is ultimately to support JavaScript as well, as TypeScript's tooling can provide best-in-class support for both TS and JS projects.
 
+As Glint is still quickly evolving, it's likely too soon for addons to begin shipping Glint-enabled type declarations themselves. To ease adoption and avoid repeated labor, the community has begun maintaining a shared [`glint-template-types`] repository with Glint-compatible type declarations for commonly used Ember addons. The README there contains information about how to take advantage of these shared declarations for addons you may use in your Ember projects.
+
 [ember.js]: https://www.emberjs.com
 [glimmerx]: https://github.com/glimmerjs/glimmer-experimental
 [vetur]: https://github.com/vuejs/vetur
+[`glint-template-types`]: https://github.com/Gavant/glint-template-types
 
 ## Getting Started
 
@@ -258,7 +261,9 @@ export default interface Registry {
   'grouping/my-component': typeof MyComponent;
 }
 ```
+
 This would let glint understand the component if it's invoked in any of the following ways:
+
 ```hbs
 <Grouping::MyComponent />
 
@@ -270,7 +275,6 @@ This would let glint understand the component if it's invoked in any of the foll
 ```
 
 With strict mode and template imports, the day is coming when we won't need this anymore, because any components/helpers/modifiers you use will already be statically in scope, but for now this is about the best we can do.
-
 
 #### Contextual Components
 


### PR DESCRIPTION
This points folks toward https://github.com/Gavant/glint-template-types where the community has begun collecting Glint-compatible types for popular addons 😄 