### PR TITLE
Add support for `bubbles` in `link-to`

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
@@ -14,6 +14,7 @@ type LinkToArgs = RequireAtLeastOne<
     disabled?: boolean;
     activeClass?: string;
     'current-when'?: string | boolean;
+    bubbles?: boolean;
     preventDefault?: boolean;
     tagName?: string;
   },

--- a/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
+++ b/packages/environment-ember-loose/__tests__/intrinsics/link-to.test.ts
@@ -90,6 +90,11 @@ linkTo({}, 123);
   expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
 }
 
+{
+  const component = emitComponent(LinkTo({ route: 'index', bubbles: true, preventDefault: true }));
+  expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
+}
+
 // Requires at least one of `@route`, `@model`, `@models` or `@query`
 
 {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/blob/v3.26.1/packages/@ember/-internals/glimmer/lib/components/link-to.ts#L702