### PR TITLE
Support standalone templates as components in GlimmerX

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ TypeScript-powered tooling for Glimmer templates.
   - [With GlimmerX](#with-glimmerx)
     - [Import Paths](#import-paths)
     - [Component Signatures](#component-signatures)
+    - [Template Components](#template-components)
   - [With Ember.js](#with-emberjs)
     - [Import Paths](#import-paths-1)
     - [Component Signatures](#component-signatures-1)
@@ -130,6 +131,30 @@ export class Shout extends Component<ShoutSignature> {
 ```
 
 [yieldable named blocks rfc]: https://github.com/emberjs/rfcs/blob/master/text/0460-yieldable-named-blocks.md
+
+#### Template Components
+
+In GlimmerX, standalone templates can be invoked as components. Like class-based components, you can declare a signature for a template component in order for Glint to understand how it can be used.
+
+The class-based component above could as a template component like so:
+
+```ts
+import { TemplateComponent } from '@glint/environment-glimmerx/component';
+
+interface ShoutSignature {
+  /* same as above */
+}
+
+const shout = (message: string) => `${message.toUpperCase()}!`;
+
+const Shout: TemplateComponent<ShoutSignature> = hbs`
+  <div ...attributes>
+    {{yield (shout @message)}}
+  </div>
+`;
+```
+
+Note that, similar to React's `FunctionComponent` and `FC`, you can also import and use the `TC` type alias as a shorthand for `TemplateComponent`.
 
 ### With Ember.js
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In GlimmerX, standalone templates can be invoked as components. Like class-based
 The class-based component above could as a template component like so:
 
 ```ts
-import { TemplateComponent } from '@glint/environment-glimmerx/component';
+import type { TemplateComponent } from '@glint/environment-glimmerx/component';
 
 interface ShoutSignature {
   /* same as above */
@@ -154,7 +154,11 @@ const Shout: TemplateComponent<ShoutSignature> = hbs`
 `;
 ```
 
-Note that, similar to React's `FunctionComponent` and `FC`, you can also import and use the `TC` type alias as a shorthand for `TemplateComponent`.
+Note that, similar to React's `FunctionComponent` and `FC`, you can also import and use the `TC` type alias as a shorthand for `TemplateComponent`:
+
+```ts
+import type { TC } from '@glint/environment-glimmerx/component';
+```
 
 ### With Ember.js
 

--- a/packages/core/__tests__/cli/declaration.test.ts
+++ b/packages/core/__tests__/cli/declaration.test.ts
@@ -45,7 +45,7 @@ describe('CLI: emitting declarations', () => {
           Args: ApplicationArgs;
       }> {
           private startupTime;
-          static template: void;
+          static template: unknown;
       }
       "
     `);

--- a/packages/environment-glimmerx/component/index.ts
+++ b/packages/environment-glimmerx/component/index.ts
@@ -22,6 +22,12 @@ export interface ComponentSignature {
   Element?: Element;
 }
 
+export type TC<T extends ComponentSignature = {}> = TemplateComponent<T>;
+export type TemplateComponent<T extends ComponentSignature = {}> = new () => {
+  [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
+  [Context]: TemplateContext<null, Get<T, 'Args'>, Get<T, 'Yields'>, Get<T, 'Element', null>>;
+};
+
 const Component = glimmerxComponent.default as new <
   T extends ComponentSignature = {}
 >() => Component<T>;

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -55,9 +55,11 @@ export declare function emitComponent<T extends AcceptsBlocks<any, any>>(
 };
 
 /**
- * Acts as a top-level wrapper for translated template bodies.
+ * Acts as a top-level wrapper for translated template bodies. The given
+ * callback accepts a template context value as well as an instance of the
+ * environment's DSL export.
  */
-export declare function template(f: (𝚪: AnyContext) => void): void;
+export declare function template(f: (𝚪: AnyContext, χ: never) => void): void;
 
 /*
  * Used in template bodies to encode a `{{yield}}` statement.

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -1,4 +1,13 @@
-import { AcceptsBlocks, AnyContext, BoundModifier } from '../integration';
+import {
+  AcceptsBlocks,
+  AnyContext,
+  AnyFunction,
+  BoundModifier,
+  EmptyObject,
+  HasContext,
+  Invokable,
+  TemplateContext,
+} from '../integration';
 import { ElementForTagName, EmittableValue } from './types';
 
 /*
@@ -59,7 +68,10 @@ export declare function emitComponent<T extends AcceptsBlocks<any, any>>(
  * callback accepts a template context value as well as an instance of the
  * environment's DSL export.
  */
-export declare function template(f: (𝚪: AnyContext, χ: never) => void): void;
+export declare function template<
+  Signature extends AnyFunction = (args: EmptyObject) => AcceptsBlocks<EmptyObject>,
+  Context extends AnyContext = TemplateContext<null, EmptyObject, EmptyObject, null>
+>(f: (𝚪: Context, χ: never) => void): new () => Invokable<Signature> & HasContext<Context>;
 
 /*
  * Used in template bodies to encode a `{{yield}}` statement.

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -37,43 +37,43 @@ describe('Debug utilities', () => {
 
       | Mapping: Template
       |  hbs(0:50):    hbs\`\\\\n    <HelperComponent @foo={{this.bar}} />\\\\n  \`
-      |  ts(0:324):    (() => {\\\\n  hbs;\\\\n  let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");\\\\n  return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>) {\\\\n    {\\\\n      const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n      𝛄;\\\\n    }\\\\n    𝚪;\\\\n  });\\\\n})()
+      |  ts(0:348):    ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n})
       |
       | | Mapping: Identifier
       | |  hbs(0:0):
-      | |  ts(184:195):  MyComponent
+      | |  ts(154:165):  MyComponent
       | |
       | | Mapping: ElementNode
       | |  hbs(9:46):    <HelperComponent @foo={{this.bar}} />
-      | |  ts(200:306):  {\\\\n      const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n      𝛄;\\\\n    }
+      | |  ts(239:337):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
       | |
       | | | Mapping: Identifier
       | | |  hbs(10:25):   HelperComponent
-      | | |  ts(249:264):  HelperComponent
+      | | |  ts(284:299):  HelperComponent
       | | |
       | | | Mapping: AttrNode
       | | |  hbs(26:43):   @foo={{this.bar}}
-      | | |  ts(268:284):  foo: 𝚪.this.bar
+      | | |  ts(303:319):  foo: 𝚪.this.bar
       | | |
       | | | | Mapping: Identifier
       | | | |  hbs(27:30):   foo
-      | | | |  ts(268:271):  foo
+      | | | |  ts(303:306):  foo
       | | | |
       | | | | Mapping: MustacheStatement
       | | | |  hbs(31:43):   {{this.bar}}
-      | | | |  ts(273:284):  𝚪.this.bar
+      | | | |  ts(308:319):  𝚪.this.bar
       | | | |
       | | | | | Mapping: PathExpression
       | | | | |  hbs(33:41):   this.bar
-      | | | | |  ts(273:284):  𝚪.this.bar
+      | | | | |  ts(308:319):  𝚪.this.bar
       | | | | |
       | | | | | | Mapping: Identifier
       | | | | | |  hbs(33:37):   this
-      | | | | | |  ts(276:280):  this
+      | | | | | |  ts(311:315):  this
       | | | | | |
       | | | | | | Mapping: Identifier
       | | | | | |  hbs(38:41):   bar
-      | | | | | |  ts(281:284):  bar
+      | | | | | |  ts(316:319):  bar
       | | | | | |
       | | | | |
       | | | |
@@ -83,49 +83,49 @@ describe('Debug utilities', () => {
 
       | Mapping: Template
       |  hbs(0:124):   hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>\\\\n  \`
-      |  ts(0:433):    (() => {\\\\n  hbs;\\\\n  let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");\\\\n  return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>) {\\\\n    {\\\\n      const 𝛄 = χ.emitElement(\\"p\\");\\\\n      χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n    }\\\\n    𝚪;\\\\n  });\\\\n})()
+      |  ts(0:453):    ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n})
       |
       | | Mapping: Identifier
       | |  hbs(0:0):
-      | |  ts(184:199):  HelperComponent
+      | |  ts(154:169):  HelperComponent
       | |
       | | Mapping: ElementNode
       | |  hbs(9:120):   <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
-      | |  ts(204:415):  {\\\\n      const 𝛄 = χ.emitElement(\\"p\\");\\\\n      χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n    }
+      | |  ts(243:442):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
       | |
       | | | Mapping: AttrNode
       | | |  hbs(12:25):   ...attributes
-      | | |  ts(247:298):  χ.applySplattributes(𝚪.element, 𝛄.element);
+      | | |  ts(282:331):  χ.applySplattributes(𝚪.element, 𝛄.element);
       | | |
       | | | Mapping: MustacheStatement
       | | |  hbs(40:48):   {{@foo}}
-      | | |  ts(299:352):  χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}))
+      | | |  ts(332:383):  χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}))
       | | |
       | | | | Mapping: PathExpression
       | | | |  hbs(42:46):   @foo
-      | | | |  ts(335:346):  𝚪.args.foo
+      | | | |  ts(366:377):  𝚪.args.foo
       | | | |
       | | | | | Mapping: Identifier
       | | | | |  hbs(43:46):   foo
-      | | | | |  ts(343:346):  foo
+      | | | | |  ts(374:377):  foo
       | | | | |
       | | | |
       | | |
       | | | Mapping: MustacheCommentStatement
       | | |  hbs(57:96):   {{! @glint-expect-error: no @bar arg }}
-      | | |  ts(354:354):
+      | | |  ts(385:385):
       | | |
       | | | Mapping: MustacheStatement
       | | |  hbs(103:111): {{@bar}}
-      | | |  ts(354:407):  χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}))
+      | | |  ts(385:436):  χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}))
       | | |
       | | | | Mapping: PathExpression
       | | | |  hbs(105:109): @bar
-      | | | |  ts(390:401):  𝚪.args.bar
+      | | | |  ts(419:430):  𝚪.args.bar
       | | | |
       | | | | | Mapping: Identifier
       | | | | |  hbs(106:109): bar
-      | | | | |  ts(398:401):  bar
+      | | | | |  ts(427:430):  bar
       | | | | |
       | | | |
       | | |

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -37,7 +37,7 @@ describe('Debug utilities', () => {
 
       | Mapping: Template
       |  hbs(0:50):    hbs\`\\\\n    <HelperComponent @foo={{this.bar}} />\\\\n  \`
-      |  ts(0:348):    ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n})
+      |  ts(0:359):    ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
       |
       | | Mapping: Identifier
       | |  hbs(0:0):
@@ -83,7 +83,7 @@ describe('Debug utilities', () => {
 
       | Mapping: Template
       |  hbs(0:124):   hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>\\\\n  \`
-      |  ts(0:453):    ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n})
+      |  ts(0:464):    ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitValue(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
       |
       | | Mapping: Identifier
       | |  hbs(0:0):

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -26,7 +26,7 @@ describe('rewriteModule', () => {
           static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
-        });
+        }) as unknown;
         }"
       `);
     });
@@ -51,7 +51,7 @@ describe('rewriteModule', () => {
           static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
-        });
+        }) as unknown;
         }"
       `);
     });
@@ -83,7 +83,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glint/environment-glimmerx/component';
         export default class extends Component {
-          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
         });
@@ -140,7 +140,7 @@ describe('rewriteModule', () => {
         export default class MyComponent extends Component {
         protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        });
+        }) as unknown;
         }"
       `);
     });
@@ -169,7 +169,7 @@ describe('rewriteModule', () => {
         class MyComponent extends Component {
         protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        });
+        }) as unknown;
         }
         export default MyComponent;"
       `);
@@ -198,7 +198,7 @@ describe('rewriteModule', () => {
         export default class MyComponent<K extends string> extends Component<{ value: K }> {
         protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        });
+        }) as unknown;
         }"
       `);
     });
@@ -234,7 +234,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class extends Component {
-        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         });
         }"
@@ -331,7 +331,7 @@ describe('rewriteModule', () => {
         export default class MyComponent extends Component {
         protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        });
+        }) as unknown;
         }
         declare module '@glint/environment-ember-loose/registry' {
           export default interface Registry {

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -23,13 +23,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glint/environment-glimmerx/component';
         export default class MyComponent extends Component {
-          static template = (() => {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
-          let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");
-          return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>) {
-            𝚪;
-          });
-        })();
+          𝚪; χ;
+        });
         }"
       `);
     });
@@ -51,13 +48,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glint/environment-glimmerx/component';
         export default class MyComponent<K extends string> extends Component<{ value: K }> {
-          static template = (() => {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
-          let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");
-          return χ.template(function<K extends string>(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent<K>>) {
-            𝚪;
-          });
-        })();
+          𝚪; χ;
+        });
         }"
       `);
     });
@@ -89,13 +83,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glint/environment-glimmerx/component';
         export default class extends Component {
-          static template = (() => {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
-          let χ!: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\");
-          return χ.template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<unknown>) {
-            𝚪;
-          });
-        })();
+          𝚪; χ;
+        });
         }"
       `);
     });
@@ -147,12 +138,9 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
-        protected static '~template' = (() => {
-          let χ!: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\");
-          return χ.template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>) {
-            𝚪;
-          });
-        })();
+        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+          𝚪; χ;
+        });
         }"
       `);
     });
@@ -179,12 +167,9 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         class MyComponent extends Component {
-        protected static '~template' = (() => {
-          let χ!: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\");
-          return χ.template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>) {
-            𝚪;
-          });
-        })();
+        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+          𝚪; χ;
+        });
         }
         export default MyComponent;"
       `);
@@ -211,12 +196,9 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent<K extends string> extends Component<{ value: K }> {
-        protected static '~template' = (() => {
-          let χ!: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\");
-          return χ.template(function<K extends string>(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent<K>>) {
-            𝚪;
-          });
-        })();
+        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+          𝚪; χ;
+        });
         }"
       `);
     });
@@ -252,12 +234,9 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class extends Component {
-        protected static '~template' = (() => {
-          let χ!: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\");
-          return χ.template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<unknown>) {
-            𝚪;
-          });
-        })();
+        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+          𝚪; χ;
+        });
         }"
       `);
     });
@@ -350,12 +329,9 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
-        protected static '~template' = (() => {
-          let χ!: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\");
-          return χ.template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>) {
-            𝚪;
-          });
-        })();
+        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+          𝚪; χ;
+        });
         }
         declare module '@glint/environment-ember-loose/registry' {
           export default interface Registry {

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -18,21 +18,18 @@ describe('rewriteTemplate', () => {
 
     return (result?.code ?? '')
       .split('\n')
-      .slice(3, -3)
+      .slice(1, -2)
       .join('\n')
-      .replace(/(^|\n) {4}/g, '$1');
+      .replace(/(^|\n) {2}/g, '$1');
   }
 
   describe('template boilerplate', () => {
     test('without any specified type parameters or context type', () => {
       expect(templateToTypescript('', { typesPath: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
-        "(() => {
-          let χ!: typeof import(\\"@glint/template\\");
-          return χ.template(function(𝚪: import(\\"@glint/template\\").ResolveContext<unknown>) {
-            𝚪;
-          });
-        })()"
+        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪: import(\\"@glint/template\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/template\\")) {
+          𝚪; χ;
+        })"
       `);
     });
 
@@ -44,12 +41,9 @@ describe('rewriteTemplate', () => {
         templateToTypescript('', { contextType, typeParams, typesPath: '@glint/template' }).result
           ?.code
       ).toMatchInlineSnapshot(`
-        "(() => {
-          let χ!: typeof import(\\"@glint/template\\");
-          return χ.template(function<T extends string>(𝚪: import(\\"@glint/template\\").ResolveContext<MyComponent<T>>) {
-            𝚪;
-          });
-        })()"
+        "({} as typeof import(\\"@glint/template\\")).template(function<T extends string>(𝚪: import(\\"@glint/template\\").ResolveContext<MyComponent<T>>, χ: typeof import(\\"@glint/template\\")) {
+          𝚪; χ;
+        })"
       `);
     });
 
@@ -58,14 +52,11 @@ describe('rewriteTemplate', () => {
 
       expect(templateToTypescript('', { preamble, typesPath: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
-        "(() => {
+        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪: import(\\"@glint/template\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/template\\")) {
           console.log(\\"hello!\\");
           throw new Error();
-          let χ!: typeof import(\\"@glint/template\\");
-          return χ.template(function(𝚪: import(\\"@glint/template\\").ResolveContext<unknown>) {
-            𝚪;
-          });
-        })()"
+          𝚪; χ;
+        })"
       `);
     });
   });

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -27,7 +27,7 @@ describe('rewriteTemplate', () => {
     test('without any specified type parameters or context type', () => {
       expect(templateToTypescript('', { typesPath: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
-        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪: import(\\"@glint/template\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/template\\")) {
+        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
           𝚪; χ;
         })"
       `);
@@ -43,7 +43,7 @@ describe('rewriteTemplate', () => {
       ).toMatchInlineSnapshot(`
         "({} as typeof import(\\"@glint/template\\")).template(function<T extends string>(𝚪: import(\\"@glint/template\\").ResolveContext<MyComponent<T>>, χ: typeof import(\\"@glint/template\\")) {
           𝚪; χ;
-        })"
+        }) as unknown"
       `);
     });
 
@@ -52,7 +52,7 @@ describe('rewriteTemplate', () => {
 
       expect(templateToTypescript('', { preamble, typesPath: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
-        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪: import(\\"@glint/template\\").ResolveContext<unknown>, χ: typeof import(\\"@glint/template\\")) {
+        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
           console.log(\\"hello!\\");
           throw new Error();
           𝚪; χ;

--- a/packages/transform/src/inlining/index.ts
+++ b/packages/transform/src/inlining/index.ts
@@ -26,8 +26,9 @@ export type CorrelatedSpansResult = {
  */
 export function getContainingTypeInfo(
   path: NodePath<any>
-): { className?: string; contextType?: string; typeParams?: string } {
+): { className?: string; inClass: boolean; contextType?: string; typeParams?: string } {
   let container = findContainingClass(path);
+  let inClass = Boolean(container);
   let className = container?.id?.name;
   let contextType = className;
   let typeParams = undefined;
@@ -38,7 +39,7 @@ export function getContainingTypeInfo(
     contextType += `<${typeParamsNode.params.map((param) => param.name).join(', ')}>`;
   }
 
-  return { className, contextType, typeParams };
+  return { contextType, typeParams, className, inClass };
 }
 
 function findContainingClass(path: NodePath<any>): t.Class | null {

--- a/packages/transform/src/inlining/tagged-strings.ts
+++ b/packages/transform/src/inlining/tagged-strings.ts
@@ -35,7 +35,7 @@ export function calculateTaggedTemplateSpans(
     let preamble = [`${tagName};`];
 
     let identifiersInScope = Object.keys(path.scope.getAllBindings());
-    let { typeParams, contextType } = getContainingTypeInfo(path);
+    let { inClass, className, typeParams, contextType } = getContainingTypeInfo(path);
     let transformedTemplate = templateToTypescript(template, {
       typesPath,
       preamble,
@@ -44,7 +44,7 @@ export function calculateTaggedTemplateSpans(
       contextType,
     });
 
-    if (!contextType) {
+    if (inClass && !className) {
       errors.push({
         source: script,
         message: 'Classes containing templates must have a name',

--- a/test-packages/ts-glimmerx-app/src/App.ts
+++ b/test-packages/ts-glimmerx-app/src/App.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-glimmerx/component';
+import Component, { TC } from '@glint/environment-glimmerx/component';
 import { hbs } from '@glimmerx/component';
 
 import logo from './logo.svg';
@@ -22,8 +22,10 @@ export default class App extends Component {
   `;
 }
 
-class SubHeader extends Component<{ Yields: { default: [] } }> {
-  public static template = hbs`
-    <h3>{{yield}}</h3>
-  `;
+interface SubHeaderSignature {
+  Yields: { default: [] };
 }
+
+const SubHeader: TC<SubHeaderSignature> = hbs`
+  <h3>{{yield}}</h3>
+`;


### PR DESCRIPTION
## Overview

In GlimmerX, a standalone template is a valid component:

```js
const Foo = hbs`
  Hello, {{@target}}!
`;

export default hbs`
  <Foo @target="World" />
  <Foo @target="Everyone" />
`;
```

This PR enables these template components to work in Glint, using a type annotation to associate a signature where needed:

```ts
interface FooSignature {
  Args: { target: string };
}

const Foo: TemplateComponent<FooSignature> = hbs`
  Hello, {{@target}}!
`;

export default hbs`
  <Foo @target="World" />
  <Foo @target="Everyone" />
`;
```

Just as with class-based components, template components that don't declare a signature are assumed to accept no args, have no splattributes element, and never yield.

## Change Details

This PR tweaks the emit from `@glint/transform` slightly in order for type inference to work for the template contents.

Where previously we had:

```ts
(() => {
  let χ!: typeof import("dsl-path");
  return χ.template(function(𝚪: import("dsl-path").ResolveContext<MyComponent>) {
    // template contents
    𝚪;
  });
})();
```

Now we emit:

```ts
({} as typeof import("dsl-path")).template(
  function(
    𝚪: import("dsl-path").ResolveContext<MyComponent>,
    χ: typeof import("dsl-path")
  ) {
    // template contents
    𝚪; χ;
  }
);
```

Removing the IIFE layer means that the type of `𝚪` can be inferred based on where the template is being assigned/passed, which is how writing `const Foo: TemplateComponent<Signature> = hbs...` works above. Accordingly, we no longer annotate `𝚪` during emit if we don't have a definite context type (as we would in a class body).

## Other Notes

This work is the first step to supporting Ember's "template-only components", since it gets our ducks in a row for templates with no backing class. From here, we can also make the changes necessary to support typechecking for templates in rendering tests before tackling standalone template files.