### PR TITLE
Support Ember rendering tests

### DIFF
--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -7,7 +7,7 @@ describe('Environments', () => {
     test('locating a single tag', () => {
       let env = new GlintEnvironment('test-env', {
         tags: {
-          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
+          'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
         },
       });
 
@@ -17,9 +17,9 @@ describe('Environments', () => {
     test('locating one of several tags', () => {
       let env = new GlintEnvironment('test-env', {
         tags: {
-          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
-          'another-env': { tagMe: { typesSource: 'over-here' } },
-          'and-this-one': { hbs: { typesSource: '✨' } },
+          'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
+          'another-env': { tagMe: { capturesOuterScope: false, typesSource: 'over-here' } },
+          'and-this-one': { hbs: { capturesOuterScope: false, typesSource: '✨' } },
         },
       });
 
@@ -29,7 +29,7 @@ describe('Environments', () => {
     test('checking a module with no tags in use', () => {
       let env = new GlintEnvironment('test-env', {
         tags: {
-          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
+          'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
         },
       });
 
@@ -38,7 +38,12 @@ describe('Environments', () => {
 
     test('getting specified template tag config', () => {
       let tags = {
-        '@glimmerx/component': { hbs: { typesSource: '@glint/environment-glimmerx/-private/dsl' } },
+        '@glimmerx/component': {
+          hbs: {
+            capturesOuterScope: false,
+            typesSource: '@glint/environment-glimmerx/-private/dsl',
+          },
+        },
       };
 
       let env = new GlintEnvironment('test-env', { tags });

--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -7,11 +7,14 @@ export type GlintEnvironmentConfig = {
   template?: GlintTemplateConfig;
 };
 
+export type GlintTagConfig = {
+  readonly typesSource: string;
+  readonly capturesOuterScope: boolean;
+};
+
 export type GlintTagsConfig = {
   readonly [importSource: string]: {
-    readonly [importSpecifier: string]: {
-      readonly typesSource: string;
-    };
+    readonly [importSpecifier: string]: GlintTagConfig;
   };
 };
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,7 +3,12 @@ import { cosmiconfigSync } from 'cosmiconfig';
 import { GlintConfig } from './config';
 
 export { GlintConfig } from './config';
-export { GlintEnvironment, GlintEnvironmentConfig, PathCandidate } from './environment';
+export {
+  GlintEnvironment,
+  GlintEnvironmentConfig,
+  GlintTagConfig,
+  PathCandidate,
+} from './environment';
 
 /**
  * Loads glint configuration, starting from the given directory

--- a/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
@@ -1,4 +1,9 @@
-import { Context, EmptyObject, TemplateContext } from '@glint/template/-private/integration';
+import {
+  Context,
+  EmptyObject,
+  HasContext,
+  TemplateContext,
+} from '@glint/template/-private/integration';
 import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
 
@@ -21,4 +26,17 @@ declare module '@ember/controller' {
   export default interface Controller {
     [Context]: TemplateContext<this, ModelField<this['model']>, EmptyObject, null>;
   }
+}
+
+type TestTemplate<T> = new () => HasContext<TemplateContext<T, EmptyObject, EmptyObject, null>>;
+
+declare module '@ember/test-helpers' {
+  export function render<T>(template: TestTemplate<T>): Promise<void>;
+}
+
+// Declaring that `TemplateFactory` is a valid `TestTemplate` prevents vanilla `tsc` from freaking out
+// about `hbs` not returning a valid type for `render`. Glint itself will never see `hbs` get used, as
+// it's transformed to the template DSL before typechecking.
+declare module 'ember-cli-htmlbars' {
+  interface TemplateFactory extends TestTemplate<any> {}
 }

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -2,6 +2,14 @@ import { GlintEnvironmentConfig, PathCandidate } from '@glint/config';
 
 export default function glimmerxEnvironment(): GlintEnvironmentConfig {
   return {
+    tags: {
+      'ember-cli-htmlbars': {
+        hbs: {
+          typesSource: '@glint/environment-ember-loose/-private/dsl',
+          capturesOuterScope: false,
+        },
+      },
+    },
     template: {
       typesPath: '@glint/environment-ember-loose/-private/dsl',
 

--- a/packages/environment-ember-loose/-private/index.ts
+++ b/packages/environment-ember-loose/-private/index.ts
@@ -1,1 +1,7 @@
+// Import the scaffolding for the template registry and our merged declarations
+// for third party modules so that vanilla TS will see those as long as authors
+// have `import '@glint/environment-ember-loose'` somewhere in their project.
+import type {} from '../registry';
+import type {} from './dsl/integration-declarations';
+
 export { ComponentSignature, ComponentLike, ComponentWithBoundArgs } from './utilities';

--- a/packages/environment-glimmerx/-private/environment/index.ts
+++ b/packages/environment-glimmerx/-private/environment/index.ts
@@ -6,11 +6,13 @@ export default function glimmerxEnvironment(): GlintEnvironmentConfig {
       '@glimmerx/component': {
         hbs: {
           typesSource: '@glint/environment-glimmerx/-private/dsl',
+          capturesOuterScope: true,
         },
       },
       '@glint/environment-glimmerx/component': {
         hbs: {
           typesSource: '@glint/environment-glimmerx/-private/dsl',
+          capturesOuterScope: true,
         },
       },
     },

--- a/packages/vscode/__fixtures__/ember-app/tests/integration/component-test.ts
+++ b/packages/vscode/__fixtures__/ember-app/tests/integration/component-test.ts
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import type { TestContext } from 'ember-test-helpers';
+
+module('Integration | component test', function (hooks) {
+  setupRenderingTest(hooks);
+
+  interface MyTestContext extends TestContext {
+    message: string;
+  }
+
+  test('typechecking', async function (this: MyTestContext, assert) {
+    this.message = 'hi';
+
+    await render<MyTestContext>(hbs`
+      {{this.message}}
+    `);
+
+    assert.equal(this.element.textContent?.trim(), 'message');
+  });
+});

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -24,35 +24,61 @@ describe('Smoke test: Ember', () => {
     }
   });
 
-  test('introducing an error', async () => {
-    let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
-    let templateURI = Uri.file(`${rootDir}/app/components/colocated-layout.hbs`);
+  describe('diagnostics for errors', () => {
+    test('component template', async () => {
+      let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
+      let templateURI = Uri.file(`${rootDir}/app/components/colocated-layout.hbs`);
 
-    // Open the script and the template
-    let scriptEditor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
-    await window.showTextDocument(templateURI, { viewColumn: ViewColumn.Two });
+      // Open the script and the template
+      let scriptEditor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
+      await window.showTextDocument(templateURI, { viewColumn: ViewColumn.Two });
 
-    // Ensure neither has any diagnostic messages
-    expect(languages.getDiagnostics(scriptURI)).toEqual([]);
-    expect(languages.getDiagnostics(templateURI)).toEqual([]);
+      // Ensure neither has any diagnostic messages
+      expect(languages.getDiagnostics(scriptURI)).toEqual([]);
+      expect(languages.getDiagnostics(templateURI)).toEqual([]);
 
-    // Comment out a property in the script that's referenced in the template
-    await scriptEditor.edit((edit) => {
-      edit.insert(new Position(3, 2), '// ');
+      // Comment out a property in the script that's referenced in the template
+      await scriptEditor.edit((edit) => {
+        edit.insert(new Position(3, 2), '// ');
+      });
+
+      // Wait for a diagnostic to appear in the template
+      await waitUntil(() => languages.getDiagnostics(templateURI).length);
+
+      // Ensure the diagnostic is the error we expect
+      expect(languages.getDiagnostics(scriptURI)).toEqual([]);
+      expect(languages.getDiagnostics(templateURI)).toMatchObject([
+        {
+          message: "Property 'message' does not exist on type 'ColocatedLayoutComponent'.",
+          source: 'glint:ts(2339)',
+          range: new Range(0, 7, 0, 14),
+        },
+      ]);
     });
 
-    // Wait for a diagnostic to appear in the template
-    await waitUntil(() => languages.getDiagnostics(templateURI).length);
+    test('rendering test', async () => {
+      let scriptURI = Uri.file(`${rootDir}/tests/integration/component-test.ts`);
+      let scriptEditor = await window.showTextDocument(scriptURI);
 
-    // Ensure the diagnostic is the error we expect
-    expect(languages.getDiagnostics(scriptURI)).toEqual([]);
-    expect(languages.getDiagnostics(templateURI)).toMatchObject([
-      {
-        message: "Property 'message' does not exist on type 'ColocatedLayoutComponent'.",
-        source: 'glint:ts(2339)',
-        range: new Range(0, 7, 0, 14),
-      },
-    ]);
+      // Ensure everything is clean to start
+      expect(languages.getDiagnostics(scriptURI)).toEqual([]);
+
+      // Delete a character "message" in `{{this.message}}`
+      await scriptEditor.edit((edit) => {
+        edit.delete(new Range(17, 17, 17, 19));
+      });
+
+      // Wait for a diagnostic to appear
+      await waitUntil(() => languages.getDiagnostics(scriptURI).length);
+
+      expect(languages.getDiagnostics(scriptURI)).toMatchObject([
+        {
+          message: "Property 'messe' does not exist on type 'MyTestContext'.",
+          source: 'glint:ts(2339)',
+          range: new Range(17, 13, 17, 18),
+        },
+      ]);
+    });
   });
 
   describe('component layout', () => {

--- a/test-packages/ts-ember-app/tests/integration/components/bar-test.ts
+++ b/test-packages/ts-ember-app/tests/integration/components/bar-test.ts
@@ -2,11 +2,12 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import type { TestContext } from 'ember-test-helpers';
 
-module('Integration | Component | bar', function(hooks) {
+module('Integration | Component | bar', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     await render(hbs`<Bar @grault={{1234}} />`);
 
     if (!this.element.textContent) {
@@ -16,11 +17,11 @@ module('Integration | Component | bar', function(hooks) {
     assert.equal(this.element.textContent.trim(), 'BAR-1234');
   });
 
-  test('it renders with incorrect arg type', async function(assert) {
-    // typechecking here would be :100:
-    // (but then we need a way to @ts-ignore for tests
-    //  where we *intentionally* use bad args :thinking:)
-    await render(hbs`<Bar @grault="hello" />`);
+  test('it renders with incorrect arg type', async function (assert) {
+    await render(hbs`
+      {{! @glint-expect-error: bad type }}
+      <Bar @grault="hello" />
+    `);
 
     if (!this.element.textContent) {
       throw new Error('No text content!');
@@ -29,9 +30,11 @@ module('Integration | Component | bar', function(hooks) {
     assert.equal(this.element.textContent.trim(), 'BAR-hello');
   });
 
-  test('it renders with incorrect args', async function(assert) {
-    // also here
-    await render(hbs`<Bar @plugh={{1234}} />`);
+  test('it renders with incorrect args', async function (assert) {
+    await render(hbs`
+      {{! @glint-expect-error: bad arg name }}
+      <Bar @plugh={{1234}} />
+    `);
 
     if (!this.element.textContent) {
       throw new Error('No text content!');
@@ -40,14 +43,35 @@ module('Integration | Component | bar', function(hooks) {
     assert.equal(this.element.textContent.trim(), 'BAR-');
   });
 
-  test('it renders with missing args', async function(assert) {
-    // and here
-    await render(hbs`<Bar />`);
+  test('it renders with missing args', async function (assert) {
+    await render(hbs`
+      {{! @glint-expect-error: missing arg }}
+      <Bar />
+    `);
 
     if (!this.element.textContent) {
       throw new Error('No text content!');
     }
 
     assert.equal(this.element.textContent.trim(), 'BAR-');
+  });
+
+  module('with a custom test context', function () {
+    interface MyTestContext extends TestContext {
+      message: string;
+    }
+
+    test('types work as expected', async function (this: MyTestContext, assert) {
+      this.message = 'hello';
+
+      await render<MyTestContext>(hbs`
+        <Bar @grault={{this.message.length}} />
+
+        {{! @glint-expect-error: bad arg type }}
+        <Bar @grault={{this.message}} />
+      `);
+
+      assert.deepEqual(this.element.textContent?.trim().split(/\s+/), ['BAR-5', 'BAR-hello']);
+    });
   });
 });

--- a/test-packages/ts-ember-app/tests/integration/components/ember-component-test.ts
+++ b/test-packages/ts-ember-app/tests/integration/components/ember-component-test.ts
@@ -3,37 +3,34 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | ember', function(hooks) {
+module('Integration | Component | ember', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     await render(hbs`<EmberComponent @required="foo" />`);
 
     if (!this.element.textContent) {
       throw new Error('No text content!');
     }
 
-    assert.deepEqual(
-      this.element.textContent.trim().split(/\s+/),
-      ['foo','defaultValue','foo']
-    );
+    assert.deepEqual(this.element.textContent.trim().split(/\s+/), ['foo', 'defaultValue', 'foo']);
   });
 
-  test('it renders with incorrect arg type', async function(assert) {
+  test('it renders with incorrect arg type', async function (assert) {
     await render(hbs`<EmberComponent @required=1 />`);
 
     if (!this.element.textContent) {
       throw new Error('No text content!');
     }
 
-    assert.deepEqual(
-      this.element.textContent.trim().split(/\s+/),
-      ['1','defaultValue','1']
-    );
+    assert.deepEqual(this.element.textContent.trim().split(/\s+/), ['1', 'defaultValue', '1']);
   });
 
-  test('it renders with missing args', async function(assert) {
-    await render(hbs`<EmberComponent />`);
+  test('it renders with missing args', async function (assert) {
+    await render(hbs`
+      {{! @glint-expect-error: missing args }}
+      <EmberComponent />
+    `);
 
     if (!this.element.textContent) {
       throw new Error('No text content!');

--- a/test-packages/ts-ember-app/tests/integration/components/qux-test.ts
+++ b/test-packages/ts-ember-app/tests/integration/components/qux-test.ts
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | qux', function(hooks) {
+module('Integration | Component | qux', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     await render(hbs`<Qux />`);
 
     if (!this.element.textContent) {


### PR DESCRIPTION
## Overview

This PR makes Glint work with `hbs`-tagged template strings used in rendering tests. 

```ts
import { render } from '@ember/test-helpers';
import { hbs } from 'ember-cli-htmlbars';

test('MyComponent works', async function (assert) {
  // If `@arg` is declared to be a string, you'll get a squiggle here
  await render(hbs`<MyComponent @arg={{123}} />`);

  assert.dom().hasText('...');
});
```

In some TypeScript codebases it's common practice to define per-module (or even per-test) context types that include additional properties. In these cases, it's possible to include the context type as a parameter to `render`:

```ts
import { render } from '@ember/test-helpers';
import { hbs } from 'ember-cli-htmlbars';
import type { TestContext } from 'ember-test-helpers';

interface MyContext extends TestContext {
  message: string;
}

test('MyComponent works', async function (this: MyContext, assert) {
  this.message = 'hello';

  await render<MyContext>(hbs`
    <MyComponent @arg={{this.message}} />
  `);

  assert.dom().hasText('...');
});
```

## Technical Details

Most of the work necessary for this was done in #194. The main addition here was giving environments the ability to specify whether a given template tag captures variables from the outer scope or not, since prior to this addition that was always the case.
