### PR TITLE
Get TS nightly green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: yarn add --dev -W typescript@next
+      - name: Configure Nightly TS
+        # Until upstream packages are ready, we need to disable strictOptionalProperties in nightly
+        run: |
+          sed 's|"strict": true,|&\n    "strictOptionalProperties": false,|' -i'' tsconfig.compileroptions.json
       - name: Build
         run: yarn build
       - name: Run Tests

--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -35,7 +35,7 @@ export type GlintTemplateConfig = {
 
 export class GlintEnvironment {
   private tagConfig: GlintTagsConfig;
-  private standaloneTemplateConfig?: GlintTemplateConfig;
+  private standaloneTemplateConfig: GlintTemplateConfig | undefined;
   private tagImportRegexp: RegExp;
 
   public constructor(public readonly name: string, config: GlintEnvironmentConfig) {

--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -36,7 +36,7 @@ describe('Language Server: Completions', () => {
         \`;
       }
 
-      class Inner extends Component<{ Args: { foo?: string; 'bar-baz'?: number } }> {}
+      class Inner extends Component<{ Args: { foo?: string; 'bar-baz'?: number | undefined } }> {}
     `;
 
     project.write('index.ts', code);

--- a/packages/core/src/cli/options.ts
+++ b/packages/core/src/cli/options.ts
@@ -1,12 +1,12 @@
 export function determineOptionsToExtend(argv: {
-  declaration?: boolean;
+  declaration?: boolean | undefined;
 }): import('typescript').CompilerOptions {
   let options: import('typescript').CompilerOptions = {};
 
   if ('declaration' in argv) {
     options.noEmit = !argv.declaration;
-    options.declaration = argv.declaration;
-    options.emitDeclarationOnly = argv.declaration;
+    options.declaration = Boolean(argv.declaration);
+    options.emitDeclarationOnly = Boolean(argv.declaration);
   } else {
     options.noEmit = true;
   }

--- a/packages/environment-ember-loose/-private/intrinsics/input.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/input.d.ts
@@ -2,20 +2,20 @@ import { AcceptsBlocks, Invokable, EmptyObject } from '@glint/template/-private/
 
 export interface CheckboxInputArgs {
   type: 'checkbox';
-  checked?: boolean;
+  checked?: boolean | undefined;
 }
 
 export interface TextInputArgs {
-  type?: string;
-  value?: string | null;
-  enter?: (value: string, event: KeyboardEvent) => void;
-  'insert-newline'?: (value: string, event: KeyboardEvent) => void;
-  'escape-press'?: (value: string, event: KeyboardEvent) => void;
-  'focus-in'?: (value: string, event: FocusEvent) => void;
-  'focus-out'?: (value: string, event: FocusEvent) => void;
-  'key-down'?: (value: string, event: KeyboardEvent) => void;
-  'key-press'?: (value: string, event: KeyboardEvent) => void;
-  'key-up'?: (value: string, event: KeyboardEvent) => void;
+  type?: string | undefined;
+  value?: string | null | undefined;
+  enter?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'insert-newline'?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'escape-press'?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'focus-in'?: ((value: string, event: FocusEvent) => void) | undefined;
+  'focus-out'?: ((value: string, event: FocusEvent) => void) | undefined;
+  'key-down'?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'key-press'?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'key-up'?: ((value: string, event: KeyboardEvent) => void) | undefined;
 }
 
 export type InputComponent = new () => Invokable<

--- a/packages/environment-ember-loose/-private/intrinsics/textarea.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/textarea.d.ts
@@ -1,13 +1,13 @@
 import { AcceptsBlocks, EmptyObject, Invokable } from '@glint/template/-private/integration';
 
 export interface TextareaArgs {
-  value?: string | null;
-  enter?: (value: string, event: KeyboardEvent) => void;
-  'insert-newline'?: (value: string, event: KeyboardEvent) => void;
-  'escape-press'?: (value: string, event: KeyboardEvent) => void;
-  'focus-in'?: (value: string, event: FocusEvent) => void;
-  'focus-out'?: (value: string, event: FocusEvent) => void;
-  'key-press'?: (value: string, event: KeyboardEvent) => void;
+  value?: string | null | undefined;
+  enter?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'insert-newline'?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'escape-press'?: ((value: string, event: KeyboardEvent) => void) | undefined;
+  'focus-in'?: ((value: string, event: FocusEvent) => void) | undefined;
+  'focus-out'?: ((value: string, event: FocusEvent) => void) | undefined;
+  'key-press'?: ((value: string, event: KeyboardEvent) => void) | undefined;
 }
 
 export type TextareaComponent = new () => Invokable<

--- a/packages/environment-ember-loose/__tests__/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/helper.test.ts
@@ -91,7 +91,7 @@ expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
 
 // Class-based helper: positional args
 {
-  type RepeatArgs<T> = [value: T, count?: number];
+  type RepeatArgs<T> = [value: T, count?: number | undefined];
   class RepeatHelper<T> extends Helper<{ PositionalArgs: RepeatArgs<T>; Return: Array<T> }> {
     compute([value, count]: RepeatArgs<T>): Array<T> {
       return Array.from({ length: count ?? 2 }, () => value);
@@ -101,7 +101,7 @@ expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
   let repeat = resolve(RepeatHelper);
 
   expectTypeOf(repeat).toEqualTypeOf<{
-    <T>(args: EmptyObject, value: T, count?: number): Array<T>;
+    <T>(args: EmptyObject, value: T, count?: number | undefined): Array<T>;
   }>();
 
   repeat(

--- a/packages/template/-private/keywords/in-element.d.ts
+++ b/packages/template/-private/keywords/in-element.d.ts
@@ -1,5 +1,5 @@
 import { AcceptsBlocks, DirectInvokable } from '../integration';
 
 export type InElementKeyword = DirectInvokable<{
-  (args: { insertBefore?: null }, element: Element): AcceptsBlocks<{ default: [] }>;
+  (args: { insertBefore?: null | undefined }, element: Element): AcceptsBlocks<{ default: [] }>;
 }>;

--- a/packages/template/__tests__/tsconfig.json
+++ b/packages/template/__tests__/tsconfig.json
@@ -1,9 +1,6 @@
 {
+  "extends": "../../../tsconfig.compileroptions.json",
   "compilerOptions": {
-    "target": "es2019",
-    "module": "commonjs",
-    "strict": true,
-    "esModuleInterop": true,
     "noEmit": true,
     "lib": ["dom"]
   }

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -51,8 +51,8 @@ export function rewriteDiagnostic<
     file: tsImpl.createSourceFile(source.filename, source.contents, tsImpl.ScriptTarget.Latest),
   };
 
-  if (hasRelatedInformation(diagnostic)) {
-    diagnostic.relatedInformation = diagnostic.relatedInformation?.map((relatedInfo) =>
+  if (hasRelatedInformation(diagnostic) && diagnostic.relatedInformation) {
+    diagnostic.relatedInformation = diagnostic.relatedInformation.map((relatedInfo) =>
       rewriteDiagnostic(tsImpl, relatedInfo, locateTransformedModule)
     );
   }
@@ -73,8 +73,8 @@ function hasRelatedInformation(
  *   template: a standalone template file
  */
 export type RewriteInput =
-  | { script?: SourceFile; template: SourceFile }
-  | { script: SourceFile; template?: SourceFile };
+  | { script?: SourceFile | undefined; template: SourceFile }
+  | { script: SourceFile; template?: SourceFile | undefined };
 
 /**
  * Given the script and/or template that together comprise a component module,

--- a/packages/transform/src/inlining/index.ts
+++ b/packages/transform/src/inlining/index.ts
@@ -10,6 +10,13 @@ export type CorrelatedSpansResult = {
   partialSpans: Array<PartialCorrelatedSpan>;
 };
 
+export type ContainingTypeInfo = {
+  inClass: boolean;
+  className: string | undefined;
+  contextType: string | undefined;
+  typeParams: string | undefined;
+};
+
 /**
  * Given an AST node for an embedded template, determines the appropriate
  * instance type to be passed to `@glint/template`'s `ResolveContext`, as well
@@ -24,9 +31,7 @@ export type CorrelatedSpansResult = {
  *       // ...
  *     })
  */
-export function getContainingTypeInfo(
-  path: NodePath<any>
-): { className?: string; inClass: boolean; contextType?: string; typeParams?: string } {
+export function getContainingTypeInfo(path: NodePath<any>): ContainingTypeInfo {
   let container = findContainingClass(path);
   let inClass = Boolean(container);
   let className = container?.id?.name;

--- a/packages/transform/src/map-template-contents.ts
+++ b/packages/transform/src/map-template-contents.ts
@@ -91,7 +91,7 @@ export type RewriteResult = {
    * Any errors discovered during rewriting, along with their location
    * in terms of the original source.
    */
-  errors: Array<{ message: string; location?: Range }>;
+  errors: Array<{ message: string; location: Range | undefined }>;
 
   /**
    * The source code and a `MappingTree` resulting from rewriting a

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -12,10 +12,10 @@ type BlockKeyword = typeof BLOCK_KEYWORDS[number];
 
 export type TemplateToTypescriptOptions = {
   typesPath: string;
-  identifiersInScope?: Array<string>;
-  contextType?: string;
-  typeParams?: string;
-  preamble?: Array<string>;
+  identifiersInScope?: Array<string> | undefined;
+  contextType?: string | undefined;
+  typeParams?: string | undefined;
+  preamble?: Array<string> | undefined;
 };
 
 /**


### PR DESCRIPTION
The new [`--strictOptionalProperties` flag](https://github.com/microsoft/TypeScript/pull/43947) landed in `typescript@next` in the past couple days, and it's enabled by default under the `--strict` umbrella.

We have a few violations of this in Glint itself which are fixed in this PR. Unfortunately, this also causes trouble in some upstream declarations as well—the two that were immediately obvious were `@glimmer/runtime` and `vscode-languageserver-protocol`.

For now we're setting `strictOptionalProperties: false` to keep things passing, but as the feature matures and makes it into a stable TypeScript release, we may want to see about getting those fixed up so we can turn the flag back on and avoid potentially accidentally breaking our own consumers.