### PR TITLE
Get TS nightly passing (once more, with feeling)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: yarn add --dev -W typescript@next
-      - name: Configure Nightly TS
-        # Until upstream packages are ready, we need to disable strictOptionalProperties in nightly
-        run: |
-          sed 's|"strict": true,|&\n    "strictOptionalProperties": false,|' -i'' tsconfig.compileroptions.json
       - name: Build
         run: yarn build
       - name: Run Tests

--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -136,7 +136,7 @@ function normalizePathCandidates(
 function tryResolve(name: string, basedir: string): string | null {
   try {
     return resolve.sync(name, { basedir });
-  } catch (error) {
+  } catch (error: any) {
     if (error?.code === 'MODULE_NOT_FOUND') {
       return null;
     }

--- a/packages/core/src/common/load-typescript.ts
+++ b/packages/core/src/common/load-typescript.ts
@@ -17,7 +17,7 @@ export function loadTypeScript(): ts {
 function tryResolve<T>(load: () => T): T | null {
   try {
     return load();
-  } catch (error) {
+  } catch (error: any) {
     if (error?.code === 'MODULE_NOT_FOUND') {
       return null;
     }

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -105,7 +105,7 @@ function buildHelpers({ languageServer, documents, connection }: BindingArgs): B
     captureErrors(callback) {
       try {
         return callback();
-      } catch (error) {
+      } catch (error: any) {
         connection.console.error(error.stack ?? error);
       }
     },


### PR DESCRIPTION
There's been some churn lately in `typescript@next` around what gets included under `strict: true`.
 - `useUnknownInCatchVariables` is in
 - `exactOptionalPropertyTypes` (née `strictOptionalProperties`) is out

This has resulted in some churn for us in the "watch for breaking changes coming down the pipe" stesp in CI, but this PR should get us green again.