### PR TITLE
Upgrade to TS 4.3 and play nicely with new flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release-it": "^14.4.1",
     "release-it-lerna-changelog": "^3.1.0",
     "release-it-yarn-workspaces": "^2.0.0",
-    "typescript": "^4.1.5"
+    "typescript": "^4.3.5"
   },
   "version": "0.5.1"
 }

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -67,21 +67,21 @@ export function normalizePath(fileName: string): string {
 
 function validateConfigInput(input: Record<string, unknown>): asserts input is GlintConfigInput {
   assert(
-    typeof input.environment === 'string',
+    typeof input['environment'] === 'string',
     'Glint config must specify an `environment` string'
   );
 
   assert(
-    Array.isArray(input.include)
-      ? input.include.every((item) => typeof item === 'string')
-      : !input.include || typeof input.include === 'string',
+    Array.isArray(input['include'])
+      ? input['include'].every((item) => typeof item === 'string')
+      : !input['include'] || typeof input['include'] === 'string',
     'If defined, `include` must be a string or array of strings'
   );
 
   assert(
-    Array.isArray(input.exclude)
-      ? input.exclude.every((item) => typeof item === 'string')
-      : !input.exclude || typeof input.exclude === 'string',
+    Array.isArray(input['exclude'])
+      ? input['exclude'].every((item) => typeof item === 'string')
+      : !input['exclude'] || typeof input['exclude'] === 'string',
     'If defined, `exclude` must be a string or array of strings'
   );
 }

--- a/packages/core/__tests__/cli/declaration.test.ts
+++ b/packages/core/__tests__/cli/declaration.test.ts
@@ -117,7 +117,7 @@ describe('CLI: emitting declarations', () => {
       }
       export default class ClassComponent extends Component<ClassComponentSignature> {
           private startupTime;
-          protected static '~template': unknown;
+          protected static '~template:ClassComponent': unknown;
       }
       "
     `);

--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -227,9 +227,10 @@ export default class TransformManager {
     });
   }
 
-  private rewriteDiagnostic(
-    diagnostic: Diagnostic
-  ): { rewrittenDiagnostic?: ts.Diagnostic; appliedDirective?: Directive } {
+  private rewriteDiagnostic(diagnostic: Diagnostic): {
+    rewrittenDiagnostic?: ts.Diagnostic;
+    appliedDirective?: Directive;
+  } {
     if (!diagnostic.file) return {};
 
     // Transform diagnostics are already targeted at the original source and so

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -55,7 +55,7 @@ expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
 {
   type RepeatArgs<T> = { value: T; count?: number };
   class RepeatHelper<T> extends Helper<{ NamedArgs: RepeatArgs<T>; Return: Array<T> }> {
-    compute(_: [], { value, count }: RepeatArgs<T>): Array<T> {
+    override compute(_: [], { value, count }: RepeatArgs<T>): Array<T> {
       return Array.from({ length: count ?? 2 }, () => value);
     }
   }
@@ -93,7 +93,7 @@ expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
 {
   type RepeatArgs<T> = [value: T, count?: number | undefined];
   class RepeatHelper<T> extends Helper<{ PositionalArgs: RepeatArgs<T>; Return: Array<T> }> {
-    compute([value, count]: RepeatArgs<T>): Array<T> {
+    override compute([value, count]: RepeatArgs<T>): Array<T> {
       return Array.from({ length: count ?? 2 }, () => value);
     }
   }
@@ -128,7 +128,7 @@ expectTypeOf(Helper.extend).toEqualTypeOf(UpstreamEmberHelper.extend);
 // Class-based helpers can return undefined
 {
   class MaybeStringHelper extends Helper<{ Return: string | undefined }> {
-    compute(): string | undefined {
+    override compute(): string | undefined {
       if (Math.random() > 0.5) {
         return 'ok';
       }

--- a/packages/environment-ember-loose/__tests__/type-tests/integration-declarations.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/integration-declarations.test.ts
@@ -5,7 +5,7 @@ import { EmptyObject } from '@glint/template/-private/integration';
 import { ResolveContext } from '../../-private/dsl';
 
 class TestRoute extends Route {
-  async model(): Promise<{ message: string }> {
+  override async model(): Promise<{ message: string }> {
     return { message: 'hello' };
   }
 }

--- a/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
@@ -26,7 +26,7 @@ import { BoundModifier } from '@glint/template/-private/integration';
       return this.args.named.multiplier;
     }
 
-    didReceiveArguments(): void {
+    override didReceiveArguments(): void {
       expectTypeOf(this.element).toEqualTypeOf<HTMLImageElement>();
 
       this.interval = window.setInterval(() => {
@@ -34,7 +34,7 @@ import { BoundModifier } from '@glint/template/-private/integration';
       }, this.multiplier * this.lengthOfInput);
     }
 
-    willDestroy(): void {
+    override willDestroy(): void {
       window.clearInterval(this.interval);
     }
   }

--- a/packages/environment-ember-loose/ember-component/helper.ts
+++ b/packages/environment-ember-loose/ember-component/helper.ts
@@ -16,7 +16,7 @@ type HelperFactory = <Positional extends unknown[] = [], Named = EmptyObject, Re
   fn: (params: Positional, hash: Named) => Return
 ) => new () => Invokable<(named: Named, ...positional: Positional) => Return>;
 
-export const helper = (emberHelper as unknown) as HelperFactory;
+export const helper = emberHelper as unknown as HelperFactory;
 
 export interface HelperSignature {
   NamedArgs?: object;

--- a/packages/environment-glimmerx/helper/index.ts
+++ b/packages/environment-glimmerx/helper/index.ts
@@ -38,5 +38,5 @@ type FnHelper = DirectInvokable<{
   ): (...rest: Args) => Ret;
 }>;
 
-export const fn = (glimmerxHelper.fn as unknown) as FnHelper;
-export const helper = (glimmerxHelper.helper as unknown) as HelperFactory;
+export const fn = glimmerxHelper.fn as unknown as FnHelper;
+export const helper = glimmerxHelper.helper as unknown as HelperFactory;

--- a/packages/environment-glimmerx/modifier/index.ts
+++ b/packages/environment-glimmerx/modifier/index.ts
@@ -16,4 +16,4 @@ type OnModifier = DirectInvokable<
   ) => BoundModifier<HTMLElement>
 >;
 
-export const on = (glimmerxModifier.on as unknown) as OnModifier;
+export const on = glimmerxModifier.on as unknown as OnModifier;

--- a/packages/template/__tests__/emit-component.test.ts
+++ b/packages/template/__tests__/emit-component.test.ts
@@ -150,7 +150,7 @@ emitComponent(resolveOrReturn(MaybeMyComponent)({ value: 'hi' }));
 
   // @ts-expect-error: unknown is an invalid component
   let unknownComponent = emitComponent({} as unknown);
-  let [unknownComponentParam] = unknownComponent.blockParams.default;
+  let [unknownComponentParam] = unknownComponent.blockParams['default'];
 
   expectTypeOf(unknownComponent.element).toBeAny();
   expectTypeOf(unknownComponentParam).toBeAny();

--- a/packages/template/__tests__/resolution.test.ts
+++ b/packages/template/__tests__/resolution.test.ts
@@ -44,9 +44,7 @@ declare function value<T>(): T;
     });
   }
 
-  type ExpectedSignature = <T>(
-    args: MyArgs<T>
-  ) => AcceptsBlocks<{
+  type ExpectedSignature = <T>(args: MyArgs<T>) => AcceptsBlocks<{
     body: [boolean, T];
   }>;
 

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -35,7 +35,7 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        |  ts(195:825):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams.default;\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(195:828):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
         | | Mapping: Identifier
         | |  hbs(0:0):
@@ -43,7 +43,7 @@ describe('Debug utilities', () => {
         | |
         | | Mapping: BlockStatement
         | |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        | |  ts(436:802):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams.default;\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
+        | |  ts(436:805):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
         | |
         | | | Mapping: PathExpression
         | | |  hbs(3:7):     each
@@ -81,66 +81,66 @@ describe('Debug utilities', () => {
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(67:82):   {{add index 1}}
-        | | |  ts(599:659):  χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
+        | | |  ts(602:662):  χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(69:72):   add
-        | | | |  ts(627:643):  χ.Globals[\\"add\\"]
+        | | | |  ts(630:646):  χ.Globals[\\"add\\"]
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(69:72):   add
-        | | | | |  ts(638:641):  add
+        | | | | |  ts(641:644):  add
         | | | | |
         | | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(73:78):   index
-        | | | |  ts(649:654):  index
+        | | | |  ts(652:657):  index
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(73:78):   index
-        | | | | |  ts(649:654):  index
+        | | | | |  ts(652:657):  index
         | | | | |
         | | | |
         | | | | Mapping: NumberLiteral
         | | | |  hbs(79:80):   1
-        | | | |  ts(656:657):  1
+        | | | |  ts(659:660):  1
         | | | |
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(84:100):  {{this.message}}
-        | | |  ts(661:718):  χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}))
+        | | |  ts(664:721):  χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(86:98):   this.message
-        | | | |  ts(697:712):  𝚪.this.message
+        | | | |  ts(700:715):  𝚪.this.message
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(86:90):   this
-        | | | | |  ts(700:704):  this
+        | | | | |  ts(703:707):  this
         | | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(91:98):   message
-        | | | | |  ts(705:712):  message
+        | | | | |  ts(708:715):  message
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(102:112): {{target}}
-        | | |  ts(720:768):  χ.emitValue(χ.resolveOrReturn(target)({}))
+        | | |  ts(723:771):  χ.emitValue(χ.resolveOrReturn(target)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(104:110): target
-        | | | |  ts(756:762):  target
+        | | | |  ts(759:765):  target
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(104:110): target
-        | | | | |  ts(756:762):  target
+        | | | | |  ts(759:765):  target
         | | | | |
         | | | |
         | | |
         | | | Mapping: Identifier
         | | |  hbs(117:121): each
-        | | |  ts(791:795):  each
+        | | |  ts(794:798):  each
         | | |
         | |
         |"

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -35,112 +35,112 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        |  ts(183:813):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams.default;\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(195:825):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams.default;\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
         | | Mapping: Identifier
         | |  hbs(0:0):
-        | |  ts(343:354):  MyComponent
+        | |  ts(355:366):  MyComponent
         | |
         | | Mapping: BlockStatement
         | |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        | |  ts(424:790):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams.default;\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
+        | |  ts(436:802):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams.default;\\\\n      χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitValue(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
         | |
         | | | Mapping: PathExpression
         | | |  hbs(3:7):     each
-        | | |  ts(469:486):  χ.Globals[\\"each\\"]
+        | | |  ts(481:498):  χ.Globals[\\"each\\"]
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(3:7):     each
-        | | | |  ts(480:484):  each
+        | | | |  ts(492:496):  each
         | | | |
         | | |
         | | | Mapping: SubExpression
         | | |  hbs(8:43):    (array \\"world\\" \\"planet\\" \\"universe\\")
-        | | |  ts(492:523):  [\\"world\\", \\"planet\\", \\"universe\\"]
+        | | |  ts(504:535):  [\\"world\\", \\"planet\\", \\"universe\\"]
         | | |
         | | | | Mapping: StringLiteral
         | | | |  hbs(15:22):   \\"world\\"
-        | | | |  ts(493:500):  \\"world\\"
+        | | | |  ts(505:512):  \\"world\\"
         | | | |
         | | | | Mapping: StringLiteral
         | | | |  hbs(23:31):   \\"planet\\"
-        | | | |  ts(502:510):  \\"planet\\"
+        | | | |  ts(514:522):  \\"planet\\"
         | | | |
         | | | | Mapping: StringLiteral
         | | | |  hbs(32:42):   \\"universe\\"
-        | | | |  ts(512:522):  \\"universe\\"
+        | | | |  ts(524:534):  \\"universe\\"
         | | | |
         | | |
         | | | Mapping: Identifier
         | | |  hbs(48:54):   target
-        | | |  ts(546:552):  target
+        | | |  ts(558:564):  target
         | | |
         | | | Mapping: Identifier
         | | |  hbs(55:60):   index
-        | | |  ts(554:559):  index
+        | | |  ts(566:571):  index
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(67:82):   {{add index 1}}
-        | | |  ts(587:647):  χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
+        | | |  ts(599:659):  χ.emitValue(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(69:72):   add
-        | | | |  ts(615:631):  χ.Globals[\\"add\\"]
+        | | | |  ts(627:643):  χ.Globals[\\"add\\"]
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(69:72):   add
-        | | | | |  ts(626:629):  add
+        | | | | |  ts(638:641):  add
         | | | | |
         | | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(73:78):   index
-        | | | |  ts(637:642):  index
+        | | | |  ts(649:654):  index
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(73:78):   index
-        | | | | |  ts(637:642):  index
+        | | | | |  ts(649:654):  index
         | | | | |
         | | | |
         | | | | Mapping: NumberLiteral
         | | | |  hbs(79:80):   1
-        | | | |  ts(644:645):  1
+        | | | |  ts(656:657):  1
         | | | |
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(84:100):  {{this.message}}
-        | | |  ts(649:706):  χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}))
+        | | |  ts(661:718):  χ.emitValue(χ.resolveOrReturn(𝚪.this.message)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(86:98):   this.message
-        | | | |  ts(685:700):  𝚪.this.message
+        | | | |  ts(697:712):  𝚪.this.message
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(86:90):   this
-        | | | | |  ts(688:692):  this
+        | | | | |  ts(700:704):  this
         | | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(91:98):   message
-        | | | | |  ts(693:700):  message
+        | | | | |  ts(705:712):  message
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(102:112): {{target}}
-        | | |  ts(708:756):  χ.emitValue(χ.resolveOrReturn(target)({}))
+        | | |  ts(720:768):  χ.emitValue(χ.resolveOrReturn(target)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(104:110): target
-        | | | |  ts(744:750):  target
+        | | | |  ts(756:762):  target
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(104:110): target
-        | | | | |  ts(744:750):  target
+        | | | | |  ts(756:762):  target
         | | | | |
         | | | |
         | | |
         | | | Mapping: Identifier
         | | |  hbs(117:121): each
-        | | |  ts(779:783):  each
+        | | |  ts(791:795):  each
         | | |
         | |
         |"

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -181,7 +181,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
-        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         }) as unknown;
         }"
@@ -210,7 +210,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         class MyComponent extends Component {
-        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         }) as unknown;
         }
@@ -239,7 +239,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent<K extends string> extends Component<{ value: K }> {
-        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         }) as unknown;
         }"
@@ -277,7 +277,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class extends Component {
-        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        protected static '~template:undefined' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         });
         }"
@@ -393,7 +393,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
-        protected static '~template' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         }) as unknown;
         }

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -278,11 +278,11 @@ describe('rewriteTemplate', () => {
             {
               const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"doAThing\\"])({}));
               {
-                const [ok] = 𝛄.blockParams.default;
+                const [ok] = 𝛄.blockParams[\\"default\\"];
                 χ.emitValue(χ.resolveOrReturn(ok)({}));
               }
               {
-                const [] = 𝛄.blockParams.else;
+                const [] = 𝛄.blockParams[\\"else\\"];
                 χ.emitValue(χ.resolveOrReturn(𝚪.args.nevermind)({}));
               }
               χ.Globals[\\"doAThing\\"];
@@ -689,7 +689,7 @@ describe('rewriteTemplate', () => {
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}));
           {
-            const [bar, baz] = 𝛄.blockParams.default;
+            const [bar, baz] = 𝛄.blockParams[\\"default\\"];
             χ.emitValue(χ.resolveOrReturn(bar)({}));
             χ.emitValue(χ.resolveOrReturn(baz)({}));
           }
@@ -711,12 +711,12 @@ describe('rewriteTemplate', () => {
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}));
           {
-            const [bar, baz] = 𝛄.blockParams.default;
+            const [bar, baz] = 𝛄.blockParams[\\"default\\"];
             χ.emitValue(χ.resolveOrReturn(bar)({}));
             χ.emitValue(χ.resolveOrReturn(baz)({}));
           }
           {
-            const [] = 𝛄.blockParams.else;
+            const [] = 𝛄.blockParams[\\"else\\"];
             χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
           }
           χ.Globals[\\"foo\\"];
@@ -737,12 +737,12 @@ describe('rewriteTemplate', () => {
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"foo\\"])({}));
           {
-            const [bar, baz] = 𝛄.blockParams.default;
+            const [bar, baz] = 𝛄.blockParams[\\"default\\"];
             χ.emitValue(χ.resolveOrReturn(bar)({}));
             χ.emitValue(χ.resolveOrReturn(baz)({}));
           }
           {
-            const [] = 𝛄.blockParams.else;
+            const [] = 𝛄.blockParams[\\"else\\"];
             χ.emitValue(χ.resolveOrReturn(𝚪.args.oh)({}));
           }
           χ.Globals[\\"foo\\"];
@@ -826,7 +826,7 @@ describe('rewriteTemplate', () => {
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
           𝛄;
           {
-            const [bar] = 𝛄.blockParams.default;
+            const [bar] = 𝛄.blockParams[\\"default\\"];
             χ.emitValue(χ.resolveOrReturn(bar)({}));
           }
           χ.Globals[\\"Foo\\"];
@@ -898,16 +898,16 @@ describe('rewriteTemplate', () => {
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
           𝛄;
           {
-            const [h] = 𝛄.blockParams.head;
+            const [h] = 𝛄.blockParams[\\"head\\"];
             χ.emitValue(χ.resolveOrReturn(h)({}));
           }
           {
-            const [b] = 𝛄.blockParams.body;
+            const [b] = 𝛄.blockParams[\\"body\\"];
             {
               const 𝛄 = χ.emitComponent(χ.resolve(b?.contents)({}));
               𝛄;
               {
-                const [] = 𝛄.blockParams.default;
+                const [] = 𝛄.blockParams[\\"default\\"];
               }
               b?.contents;
             }
@@ -941,7 +941,7 @@ describe('rewriteTemplate', () => {
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
           𝛄;
           {
-            const [NS] = 𝛄.blockParams.default;
+            const [NS] = 𝛄.blockParams[\\"default\\"];
             {
               const 𝛄 = χ.emitComponent(χ.resolve(NS?.Nested?.Custom)({}));
               χ.applyAttributes(𝛄.element, {

--- a/packages/transform/src/inlining/companion-file.ts
+++ b/packages/transform/src/inlining/companion-file.ts
@@ -8,8 +8,6 @@ import { templateToTypescript } from '../template-to-typescript';
 import { Directive, SourceFile, TransformError } from '../transformed-module';
 import { assert, isJsScript } from '../util';
 
-const STANDALONE_TEMPLATE_FIELD = `'~template'`;
-
 export function calculateCompanionTemplateSpans(
   exportDeclarationPath: NodePath | null,
   script: SourceFile,
@@ -52,9 +50,14 @@ export function calculateCompanionTemplateSpans(
       useJsDoc: isJsScript(script.filename),
     });
 
+    // This allows us to avoid issues with `noImplicitOverride` for subclassed components,
+    // but is ultimately kind of a kludge. TS 4.4 will support class static blocks, at
+    // which point we won't need to invent a field at all and we can remove this.
+    let standaloneTemplateField = `'~template:${className}'`;
+
     pushTransformedTemplate(rewriteResult, {
       insertionPoint: target.end - 1,
-      prefix: `protected static ${STANDALONE_TEMPLATE_FIELD} = `,
+      prefix: `protected static ${standaloneTemplateField} = `,
       suffix: ';\n',
     });
   } else {

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -356,9 +356,11 @@ export function templateToTypescript(
       }
     }
 
-    function tagNameToPathContents(
-      node: AST.ElementNode
-    ): { start: number; kind: PathKind; path: Array<string> } {
+    function tagNameToPathContents(node: AST.ElementNode): {
+      start: number;
+      kind: PathKind;
+      path: Array<string>;
+    } {
       let tagName = node.tag;
       let start = template.indexOf(tagName, rangeForNode(node).start);
 

--- a/packages/transform/src/transformed-module.ts
+++ b/packages/transform/src/transformed-module.ts
@@ -146,9 +146,10 @@ export default class TransformedModule {
     return { start, end };
   }
 
-  private determineOriginalOffsetAndSpan(
-    transformedOffset: number
-  ): { originalOffset: number; correlatedSpan: CorrelatedSpan } {
+  private determineOriginalOffsetAndSpan(transformedOffset: number): {
+    originalOffset: number;
+    correlatedSpan: CorrelatedSpan;
+  } {
     for (let span of this.correlatedSpans) {
       if (
         transformedOffset >= span.transformedStart &&

--- a/test-packages/ts-ember-app/app/routes/classic-route.ts
+++ b/test-packages/ts-ember-app/app/routes/classic-route.ts
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default class ClassicRoute extends Route {
-  async model(): Promise<{ foo: string }> {
+  override async model(): Promise<{ foo: string }> {
     return { foo: 'hi' };
   }
 }

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -55,8 +55,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit": "^2.16.0",
-    "qunit-dom": "^1.5.0",
-    "typescript": "^4.1.3"
+    "qunit-dom": "^1.5.0"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/test-packages/ts-ember-app/tsconfig.json
+++ b/test-packages/ts-ember-app/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noEmitOnError": false,
     "noEmit": true,
     "inlineSourceMap": true,

--- a/test-packages/ts-ember-app/tsconfig.json
+++ b/test-packages/ts-ember-app/tsconfig.json
@@ -13,6 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
+    "noImplicitOverride": true,
     "noEmitOnError": false,
     "noEmit": true,
     "inlineSourceMap": true,

--- a/tsconfig.compileroptions.json
+++ b/tsconfig.compileroptions.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,
+    "noImplicitOverride": true,
     "esModuleInterop": true,
     "composite": true,
     "declaration": true,

--- a/tsconfig.compileroptions.json
+++ b/tsconfig.compileroptions.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "strict": true,
     "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
     "composite": true,
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,10 +2377,10 @@
   dependencies:
     "@types/sizzle" "*"
 
-"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
-  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
+"@types/json-schema@^7.0.4", "@types/json-schema@^7.0.7":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
+  integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
 "@types/keyv@*":
   version "3.1.1"
@@ -2557,73 +2557,72 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.9.0.tgz#8fde15743413661fdc086c9f1f5d74a80b856113"
-  integrity sha512-WrVzGMzzCrgrpnQMQm4Tnf+dk+wdl/YbgIgd5hKGa2P+lnJ2MON+nQnbwgbxtN9QDLi8HO+JAq0/krMnjQK6Cw==
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.4.tgz#e73c8cabbf3f08dee0e1bda65ed4e622ae8f8921"
+  integrity sha512-s1oY4RmYDlWMlcV0kKPBaADn46JirZzvvH7c2CtAqxCY96S538JRBAzt83RrfkDheV/+G/vWNK0zek+8TB3Gmw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.9.0"
-    "@typescript-eslint/scope-manager" "4.9.0"
-    debug "^4.1.1"
+    "@typescript-eslint/experimental-utils" "4.28.4"
+    "@typescript-eslint/scope-manager" "4.28.4"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.0.tgz#23a296b85d243afba24e75a43fd55aceda5141f0"
-  integrity sha512-0p8GnDWB3R2oGhmRXlEnCvYOtaBCijtA5uBfH5GxQKsukdSQyI4opC4NGTUb88CagsoNQ4rb/hId2JuMbzWKFQ==
+"@typescript-eslint/experimental-utils@4.28.4":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.4.tgz#9c70c35ebed087a5c70fb0ecd90979547b7fec96"
+  integrity sha512-OglKWOQRWTCoqMSy6pm/kpinEIgdcXYceIcH3EKWUl4S8xhFtN34GQRaAvTIZB9DD94rW7d/U7tUg3SYeDFNHA==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.9.0"
-    "@typescript-eslint/types" "4.9.0"
-    "@typescript-eslint/typescript-estree" "4.9.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.28.4"
+    "@typescript-eslint/types" "4.28.4"
+    "@typescript-eslint/typescript-estree" "4.28.4"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.9.0.tgz#bb65f1214b5e221604996db53ef77c9d62b09249"
-  integrity sha512-QRSDAV8tGZoQye/ogp28ypb8qpsZPV6FOLD+tbN4ohKUWHD2n/u0Q2tIBnCsGwQCiD94RdtLkcqpdK4vKcLCCw==
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.4.tgz#bc462dc2779afeefdcf49082516afdc3e7b96fab"
+  integrity sha512-4i0jq3C6n+og7/uCHiE6q5ssw87zVdpUj1k6VlVYMonE3ILdFApEzTWgppSRG4kVNB/5jxnH+gTeKLMNfUelQA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.9.0"
-    "@typescript-eslint/types" "4.9.0"
-    "@typescript-eslint/typescript-estree" "4.9.0"
-    debug "^4.1.1"
+    "@typescript-eslint/scope-manager" "4.28.4"
+    "@typescript-eslint/types" "4.28.4"
+    "@typescript-eslint/typescript-estree" "4.28.4"
+    debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.9.0.tgz#5eefe305d6b71d1c85af6587b048426bfd4d3708"
-  integrity sha512-q/81jtmcDtMRE+nfFt5pWqO0R41k46gpVLnuefqVOXl4QV1GdQoBWfk5REcipoJNQH9+F5l+dwa9Li5fbALjzg==
+"@typescript-eslint/scope-manager@4.28.4":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.4.tgz#bdbce9b6a644e34f767bd68bc17bb14353b9fe7f"
+  integrity sha512-ZJBNs4usViOmlyFMt9X9l+X0WAFcDH7EdSArGqpldXu7aeZxDAuAzHiMAeI+JpSefY2INHrXeqnha39FVqXb8w==
   dependencies:
-    "@typescript-eslint/types" "4.9.0"
-    "@typescript-eslint/visitor-keys" "4.9.0"
+    "@typescript-eslint/types" "4.28.4"
+    "@typescript-eslint/visitor-keys" "4.28.4"
 
-"@typescript-eslint/types@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.9.0.tgz#3fe8c3632abd07095c7458f7451bd14c85d0033c"
-  integrity sha512-luzLKmowfiM/IoJL/rus1K9iZpSJK6GlOS/1ezKplb7MkORt2dDcfi8g9B0bsF6JoRGhqn0D3Va55b+vredFHA==
+"@typescript-eslint/types@4.28.4":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.4.tgz#41acbd79b5816b7c0dd7530a43d97d020d3aeb42"
+  integrity sha512-3eap4QWxGqkYuEmVebUGULMskR6Cuoc/Wii0oSOddleP4EGx1tjLnZQ0ZP33YRoMDCs5O3j56RBV4g14T4jvww==
 
-"@typescript-eslint/typescript-estree@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.0.tgz#38a98df6ee281cfd6164d6f9d91795b37d9e508c"
-  integrity sha512-rmDR++PGrIyQzAtt3pPcmKWLr7MA+u/Cmq9b/rON3//t5WofNR4m/Ybft2vOLj0WtUzjn018ekHjTsnIyBsQug==
+"@typescript-eslint/typescript-estree@4.28.4":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.4.tgz#252e6863278dc0727244be9e371eb35241c46d00"
+  integrity sha512-z7d8HK8XvCRyN2SNp+OXC2iZaF+O2BTquGhEYLKLx5k6p0r05ureUtgEfo5f6anLkhCxdHtCf6rPM1p4efHYDQ==
   dependencies:
-    "@typescript-eslint/types" "4.9.0"
-    "@typescript-eslint/visitor-keys" "4.9.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
+    "@typescript-eslint/types" "4.28.4"
+    "@typescript-eslint/visitor-keys" "4.28.4"
+    debug "^4.3.1"
+    globby "^11.0.3"
     is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.0.tgz#f284e9fac43f2d6d35094ce137473ee321f266c8"
-  integrity sha512-sV45zfdRqQo1A97pOSx3fsjR+3blmwtdCt8LDrXgCX36v4Vmz4KHrhpV6Fo2cRdXmyumxx11AHw0pNJqCNpDyg==
+"@typescript-eslint/visitor-keys@4.28.4":
+  version "4.28.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.4.tgz#92dacfefccd6751cbb0a964f06683bfd72d0c4d3"
+  integrity sha512-NIAXAdbz1XdOuzqkJHjNKXKj8QQ4cv5cxR/g0uQhCYf/6//XrmfpaYsM7PnBcNbfvTDLUkqQ5TPNm1sozDdTWg==
   dependencies:
-    "@typescript-eslint/types" "4.9.0"
+    "@typescript-eslint/types" "4.28.4"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -5431,7 +5430,14 @@ debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -6647,9 +6653,9 @@ eslint-config-prettier@^6.10.1:
     get-stdin "^6.0.0"
 
 eslint-config-prettier@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.0.0.tgz#c1ae4106f74e6c0357f44adb076771d032ac0e97"
-  integrity sha512-8Y8lGLVPPZdaNA7JXqnvETVC7IiVRgAP6afQu9gOQRn90YY3otMNh+x7Vr2vMePQntF+5erdSUBqSzCmU/AxaQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
+  integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
 
 eslint-plugin-ember@^9.3.0:
   version "9.6.0"
@@ -6683,9 +6689,9 @@ eslint-plugin-node@^11.1.0:
     semver "^6.1.0"
 
 eslint-plugin-prettier@^3.1.2, eslint-plugin-prettier@^3.2.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
-  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
+  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -6718,6 +6724,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
@@ -7957,10 +7970,22 @@ globby@10.0.0:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@11.0.2, globby@^11.0.1, globby@^11.0.2:
+globby@11.0.2:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
   integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.1, globby@^11.0.2, globby@^11.0.3:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -11813,9 +11838,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.0.2, prettier@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-error@^2.1.1:
   version "2.1.1"
@@ -14076,10 +14101,10 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tsutils@^3.17.1:
-  version "3.17.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
-  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14164,10 +14164,10 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0-alpha.4.tgz#fd97ab63807c3392af5d0ac5f4754254a4fcd634"
   integrity sha512-woA2UUWSvx8ugkEjPN8DMuNjukBp8NQeLmz+LRXbEsQIvhLR8LSlD+8Qxdk7NmgE8xeJabJdU8zSrO4ozijGjg==
 
-typescript@^4.1.3, typescript@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This upgrades the Glint codebase to `typescript@4.3` and ensures we play nicely with `noImplicitOverride` and `noPropertyAccessFromIndexSignature`.

For `noImplicitOverride`, we could run afoul when defining a template on a subclass of some other component that already had an associated template. Since we can't know during emit whether or not to use `override`, for now we include the class name as part of the template key to avoid collisions. Though it's not included in the TS 4.4 Beta blog post, [class static blocks](https://github.com/tc39/proposal-class-static-block) look to be [landing as part of that release](https://github.com/microsoft/TypeScript/pull/43370), at which point we can make use of those for template definitions and the need for a field name goes away entirely.

For `noPropertyAccessFromIndexSignature`, the main culprit I was able to identify where we might trigger that inappropriately was the case of accessing named block params, in particular in the presence of prior type errors, since that could cause `𝛄.blockParams` to fall back to the base type with an index signature rather than properly resolving. We now always access block params with `[]` notation.