### PR TITLE
Add `checkStandaloneTemplates` configuration option

### DIFF
--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -4,6 +4,7 @@ import { GlintEnvironment } from './environment';
 
 export type GlintConfigInput = {
   environment: string;
+  checkStandaloneTemplates?: boolean;
   include?: string | Array<string>;
   exclude?: string | Array<string>;
 };
@@ -15,6 +16,7 @@ export type GlintConfigInput = {
 export class GlintConfig {
   public readonly rootDir: string;
   public readonly environment: GlintEnvironment;
+  public readonly checkStandaloneTemplates: boolean;
 
   private includeMatchers: Array<IMinimatch>;
   private excludeMatchers: Array<IMinimatch>;
@@ -24,6 +26,7 @@ export class GlintConfig {
 
     this.rootDir = normalizePath(rootDir);
     this.environment = GlintEnvironment.load(config.environment, { rootDir });
+    this.checkStandaloneTemplates = config.checkStandaloneTemplates ?? true;
 
     let include = Array.isArray(config.include)
       ? config.include
@@ -69,6 +72,12 @@ function validateConfigInput(input: Record<string, unknown>): asserts input is G
   assert(
     typeof input['environment'] === 'string',
     'Glint config must specify an `environment` string'
+  );
+
+  assert(
+    input['checkStandaloneTemplates'] === undefined ||
+      typeof input['checkStandaloneTemplates'] === 'boolean',
+    'If defined, `checkStandaloneTemplates` must be a boolean'
   );
 
   assert(

--- a/packages/core/__tests__/utils/project.ts
+++ b/packages/core/__tests__/utils/project.ts
@@ -60,6 +60,8 @@ export default class Project {
         module: 'es2015',
         moduleResolution: 'node',
         skipLibCheck: true,
+        allowJs: true,
+        checkJs: false,
         ...compilerOptions,
       },
     };

--- a/packages/core/__tests__/utils/project.ts
+++ b/packages/core/__tests__/utils/project.ts
@@ -39,7 +39,9 @@ export default class Project {
     let rootFileNames = glob('**/*.{ts,js,hbs}', {
       cwd: this.rootDir,
       absolute: true,
-    }).map((file) => (isTemplate(file) ? synthesizedModulePathForTemplate(file) : file));
+    }).map((file) =>
+      isTemplate(file) ? synthesizedModulePathForTemplate(file, glintConfig) : file
+    );
 
     return (this.server = new GlintLanguageServer(
       ts,

--- a/packages/core/src/common/document-cache.ts
+++ b/packages/core/src/common/document-cache.ts
@@ -45,7 +45,7 @@ export default class DocumentCache {
     }
 
     if (isTemplate(path)) {
-      return synthesizedModulePathForTemplate(path);
+      return synthesizedModulePathForTemplate(path, this.glintConfig);
     }
   }
 
@@ -127,8 +127,9 @@ export function templatePathForSynthesizedModule(path: string): string {
   return path.replace(SCRIPT_EXTENSION_REGEX, '.hbs');
 }
 
-export function synthesizedModulePathForTemplate(path: string): string {
-  return path.replace(TEMPLATE_EXTENSION_REGEX, '.ts');
+export function synthesizedModulePathForTemplate(path: string, config: GlintConfig): string {
+  let extension = config.checkStandaloneTemplates ? '.ts' : '.js';
+  return path.replace(TEMPLATE_EXTENSION_REGEX, extension);
 }
 
 export function isTemplate(path: string): boolean {

--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -301,14 +301,15 @@ export default class TransformManager {
           documents.documentExists(templatePath) &&
           documents.getCompanionDocumentPath(templatePath) === filename
         ) {
-          // The `.ts` file we were asked for doesn't exist, but a corresponding `.hbs` one does, and
+          // The script we were asked for doesn't exist, but a corresponding template does, and
           // it doesn't have a companion script elsewhere.
+          let script = { filename, contents: '' };
           let template = {
             filename: templatePath,
             contents: documents.getDocumentContents(templatePath),
           };
 
-          transformedModule = rewriteModule({ template }, glintConfig.environment);
+          transformedModule = rewriteModule({ script, template }, glintConfig.environment);
         }
       }
     }

--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -200,7 +200,9 @@ export default class TransformManager {
     return this.ts.sys
       .readDirectory(rootDir, allExtensions, excludes, includes, depth)
       .map((filename) =>
-        isTemplate(filename) ? synthesizedModulePathForTemplate(filename) : filename
+        isTemplate(filename)
+          ? synthesizedModulePathForTemplate(filename, this.glintConfig)
+          : filename
       );
   };
 

--- a/packages/core/src/language-server/index.ts
+++ b/packages/core/src/language-server/index.ts
@@ -18,18 +18,20 @@ const configPath =
   ts.findConfigFile(process.cwd(), ts.sys.fileExists);
 const { fileNames, options } = parseConfigFile(ts, configPath);
 
-const baseProjectRoots = new Set(fileNames);
-const getRootFileNames = (): Array<string> => {
-  return fileNames.concat(
-    documents
-      .all()
-      .map((doc) => uriToFilePath(doc.uri))
-      .map((path) => (isTemplate(path) ? synthesizedModulePathForTemplate(path) : path))
-      .filter((path) => isScript(path) && !baseProjectRoots.has(path))
-  );
-};
-
 if (glintConfig) {
+  const baseProjectRoots = new Set(fileNames);
+  const getRootFileNames = (): Array<string> => {
+    return fileNames.concat(
+      documents
+        .all()
+        .map((doc) => uriToFilePath(doc.uri))
+        .map((path) =>
+          isTemplate(path) ? synthesizedModulePathForTemplate(path, glintConfig) : path
+        )
+        .filter((path) => isScript(path) && !baseProjectRoots.has(path))
+    );
+  };
+
   const languageServer = new GlintLanguageServer(ts, glintConfig, getRootFileNames, options);
 
   bindLanguageServer({ languageServer, documents, connection });

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -50,19 +50,15 @@ describe('Source-to-source offset mapping', () => {
     contents: string;
     backing: 'class' | 'opaque' | 'none';
   }): RewrittenTestModule {
-    let script: SourceFile | undefined;
-
-    if (backing === 'class') {
-      script = {
-        filename: 'test.ts',
-        contents: 'export default class MyComponent {}',
-      };
-    } else if (backing === 'opaque') {
-      script = {
-        filename: 'test.ts',
-        contents: 'export default templateOnly();',
-      };
-    }
+    let script = {
+      filename: 'script.ts',
+      contents:
+        backing === 'class'
+          ? 'export default class MyComponent {}'
+          : backing === 'opaque'
+          ? 'export default templateOnly();'
+          : '',
+    };
 
     let template = {
       filename: 'test.hbs',

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -72,10 +72,7 @@ function hasRelatedInformation(
  *           embedded templates depending on the environment
  *   template: a standalone template file
  */
-export type RewriteInput =
-  | { script?: undefined; template: SourceFile }
-  | { script: SourceFile; template?: undefined }
-  | { script: SourceFile; template: SourceFile };
+export type RewriteInput = { script: SourceFile; template?: SourceFile };
 
 /**
  * Given the script and/or template that together comprise a component module,
@@ -90,14 +87,6 @@ export function rewriteModule(
   { script, template }: RewriteInput,
   environment: GlintEnvironment
 ): TransformedModule | null {
-  if (!script) {
-    assert(template, '`rewriteModule` requires at least a `script` or a `template`');
-    script = {
-      filename: template.filename.replace(/\.hbs$/, '.ts'),
-      contents: '',
-    };
-  }
-
   let { errors, directives, partialSpans } = calculateCorrelatedSpans(
     script,
     template,

--- a/packages/transform/src/inlining/companion-file.ts
+++ b/packages/transform/src/inlining/companion-file.ts
@@ -28,6 +28,7 @@ export function calculateCompanionTemplateSpans(
     return { errors, directives, partialSpans };
   }
 
+  let useJsDoc = isJsScript(script.filename);
   let targetPath = findCompanionTemplateTarget(exportDeclarationPath);
   if (targetPath?.isClass()) {
     let { className, contextType, typeParams } = getContainingTypeInfo(targetPath);
@@ -47,7 +48,7 @@ export function calculateCompanionTemplateSpans(
       typesPath,
       contextType,
       typeParams,
-      useJsDoc: isJsScript(script.filename),
+      useJsDoc,
     });
 
     // This allows us to avoid issues with `noImplicitOverride` for subclassed components,
@@ -67,7 +68,11 @@ export function calculateCompanionTemplateSpans(
       contextType = `typeof import('./${moduleName}').default`;
     }
 
-    let rewriteResult = templateToTypescript(template.contents, { typesPath, contextType });
+    let rewriteResult = templateToTypescript(template.contents, {
+      typesPath,
+      contextType,
+      useJsDoc,
+    });
 
     pushTransformedTemplate(rewriteResult, {
       insertionPoint: script.contents.length,


### PR DESCRIPTION
In most scenarios, a template inherits the "typedness" of the script it's attached to. If the backing module is TS, anything Glint sees as illegal usage in the template will get a red squiggle. If it's JS, we'll never give any squiggles, only provide go-to-definition, hover info, etc.

With template-only components, though, we have no way of knowing whether the author intends for the template to be typechecked or not. Currently we always treat standalone templates as targets for typechecking, but that's of course undesirable in JS-only projects.

This PR adds a `checkStandaloneTemplates` flag that users can specify in `.glintrc` to specify whether standalone templates should be typechecked or not.

This option should likely be documented as part of the larger "how to use Glint in JS projects" docs effort described in #201, as it doesn't really make sense outside that context. Does that seem reasonable to you @erinsinger93?