### PR TITLE
Ensure `{{component}}` works with template-only components

### DIFF
--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -5,8 +5,9 @@ import {
   ResolveContext,
   emitComponent,
 } from '@glint/environment-ember-loose/-private/dsl';
-import { EmptyObject } from '@glint/template/-private/integration';
+import { AcceptsBlocks, EmptyObject } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
+import { ComponentKeyword } from '../../-private/intrinsics/component';
 
 {
   const NoArgsComponent = templateOnlyComponent();
@@ -97,4 +98,29 @@ import { expectTypeOf } from 'expect-type';
     expectTypeOf(𝚪.element).toEqualTypeOf<YieldingComponentSignature['Element']>();
     expectTypeOf(𝚪.yields).toEqualTypeOf<YieldingComponentSignature['Yields']>();
   });
+}
+
+// Template-only components can be the target of `{{component}}`
+{
+  interface CurriedComponentSignature {
+    Args: {
+      a: string;
+      b: number;
+    };
+  }
+
+  const CurriedComponent = templateOnlyComponent<CurriedComponentSignature>();
+  const componentKeyword = null as unknown as ComponentKeyword<{
+    'curried-component': typeof CurriedComponent;
+  }>;
+
+  const CurriedWithNothing = resolve(componentKeyword)({}, 'curried-component');
+  expectTypeOf(resolve(CurriedWithNothing)).toEqualTypeOf<
+    (args: { a: string; b: number }) => AcceptsBlocks<EmptyObject>
+  >();
+
+  const CurriedWithA = resolve(componentKeyword)({ a: 'hi' }, 'curried-component');
+  expectTypeOf(resolve(CurriedWithA)).toEqualTypeOf<
+    (args: { a?: string; b: number }) => AcceptsBlocks<EmptyObject>
+  >();
 }

--- a/packages/environment-ember-loose/ember-component/template-only.ts
+++ b/packages/environment-ember-loose/ember-component/template-only.ts
@@ -4,7 +4,7 @@ import type {
   TemplateContext,
   Context,
   AcceptsBlocks,
-  InvokeDirect,
+  Invoke,
 } from '@glint/template/-private/integration';
 import type { ComponentSignature } from '../-private/utilities';
 
@@ -16,11 +16,9 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
 
-export type TemplateOnlyComponent<T extends ComponentSignature = {}> = {
+export type TemplateOnlyComponent<T extends ComponentSignature = {}> = new () => {
   [Context]: TemplateContext<void, Get<T, 'Args'>, Get<T, 'Yields'>, Get<T, 'Element', null>>;
-  [InvokeDirect]: (
-    args: Get<T, 'Args'>
-  ) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
+  [Invoke]: (args: Get<T, 'Args'>) => AcceptsBlocks<Get<T, 'Yields'>, Get<T, 'Element', null>>;
 };
 
 const templateOnly: TemplateOnlyComponentFactory = Ember._templateOnlyComponent;

--- a/packages/template/-private/dsl/types.d.ts
+++ b/packages/template/-private/dsl/types.d.ts
@@ -15,10 +15,14 @@ export type ElementForTagName<Name extends string> = Name extends keyof HTMLElem
   : Element;
 
 /**
- * Given the instance type of a component backing class, produces the appropriate
+ * Given the constructor or instance type of a component backing class, produces the appropriate
  * `TemplateContext` type for its template.
  */
-export type ResolveContext<T> = T extends HasContext<infer Context> ? Context : unknown;
+export type ResolveContext<T> = T extends HasContext<infer Context>
+  ? Context
+  : T extends Constructor<HasContext<infer Context>>
+  ? Context
+  : unknown;
 
 // This encompasses both @glimmer/runtime and @ember/template's notion of `SafeString`s,
 // and this coverage is tested in `emit-value.test.ts`.


### PR DESCRIPTION
Currently the `{{component}}` keyword will give a type error when used with a `templateOnlyComponent()`, as the latter is declared as a `DirectInvokable`, which is generally reserved for special constructs like `{{#each}}` and `{{#let}}`.

This makes template-only components regular invokables, allowing `{{component}}` to work with them.