### PR TITLE
Fix extension smoke test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
     tags:
       - '*'
 
+  # early issue detection: run CI weekly on Sundays
+  schedule:
+    - cron: '0 6 * * 0'
+
 env:
   CI: true
 

--- a/packages/vscode/__tests__/support/launch-from-cli.js
+++ b/packages/vscode/__tests__/support/launch-from-cli.js
@@ -5,17 +5,25 @@ const os = require('os');
 const { runTests } = require('vscode-test');
 
 async function main() {
-  let dataDir = path.join(os.tmpdir(), `user-data-${Math.random()}`);
+  let emptyTempDir = path.join(os.tmpdir(), `user-data-${Math.random()}`);
 
   try {
     await runTests({
       extensionDevelopmentPath: path.resolve(__dirname, '../..'),
       extensionTestsPath: path.resolve(__dirname, 'vscode-runner.js'),
       launchArgs: [
-        '--disable-extensions',
+        // Don't show the "hey do you trust this folder?" prompt
         '--disable-workspace-trust',
+        // Explicitly turn off the built-in TS extension
+        '--disable-extension',
+        'vscode.typescript-language-features',
+        // Point at an empty directory so no third-party extensions load
+        '--extensions-dir',
+        emptyTempDir,
+        // Point at an empty directory so we don't have to contend with any local user preferences
         '--user-data-dir',
-        dataDir,
+        emptyTempDir,
+        // Load the Ember and GlimmerX app fixtures
         `${__dirname}/../../__fixtures__/ember-app`,
         `${__dirname}/../../__fixtures__/js-glimmerx-app`,
       ],


### PR DESCRIPTION
As of VSCode 1.62.0, something [deep in the internals of the built-in `vscode.typescript-language-features` extension](https://github.com/microsoft/vscode/blob/6ae9e9d86cb9facd5f041c6c8c2dfc629b84017d/extensions/typescript-language-features/src/typescriptServiceClient.ts#L1066) triggers an unhandled promise rejection upon opening a `.ts` file. The line in question is nothing new, but my guess (based on the version this started in) is that it's likely some change to either the extension or text document lifecycle introduced during recent work to make VSCode run more happily in the browser.

Regardless of the reason, the unhandled `undefined` rejection ultimately bubbles up through Jest as a test failure during whatever test happens to be running when it happens, leading to a whole cascade of messiness.

The simplest solution is just to ensure we've disabled `vscode.typescript-language-features` in the instance of Code we spawn to run our smoke tests. Notably, `--disable-extensions` does the _opposite_ of that and ensures built-in extensions activate, even if they've been explicitly turned off via their own flag, so we instead now point it at an empty `--extensions-dir`, which has the same effect of disabling all third-party extensions.

Finally, I'm adding a line to our CI config (which I thought was already there) to run once weekly regardless of repo activity so that this kind of change doesn't sneak up on someone who's trying to get actual work done 😅 