### PR TITLE
Move file add/delete tests into the LS suite

### DIFF
--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -54,19 +54,10 @@ describe('Language Server: Completions', () => {
       character: 12,
     });
 
-    expect(completions).toMatchObject([
-      {
-        kind: CompletionItemKind.Field,
-        label: 'foo',
-      },
-      {
-        kind: CompletionItemKind.Field,
-        label: 'bar-baz',
-      },
-    ]);
+    let labels = completions?.map((completion) => completion.label);
+    expect(new Set(labels)).toEqual(new Set(['foo', 'bar-baz']));
 
-    let details = server.getCompletionDetails(completions![1]);
-
+    let details = server.getCompletionDetails(completions!.find((c) => c.label === 'bar-baz')!);
     expect(details.detail).toEqual("(property) 'bar-baz'?: number | undefined");
   });
 

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -9,9 +9,7 @@ import {
   extensions,
   Location,
 } from 'vscode';
-import { promises as fs } from 'fs';
 import path from 'path';
-import { stripIndent } from 'common-tags';
 import { waitUntil } from './helpers/async';
 
 describe('Smoke test: Ember', () => {
@@ -139,83 +137,6 @@ describe('Smoke test: Ember', () => {
       expect(positions.length).toBe(1);
       expect(positions[0].uri.fsPath).toEqual(scriptURI.fsPath);
       expect(positions[0].range).toEqual(new Range(3, 10, 3, 17));
-    });
-
-    describe('template-only', () => {
-      const scriptURI = Uri.file(`${rootDir}/app/components/template-only.ts`);
-      const templateURI = Uri.file(`${rootDir}/app/components/template-only.hbs`);
-
-      afterEach(async () => {
-        await fs.rm(scriptURI.fsPath, { force: true });
-      });
-
-      function writeBackingModule(): Promise<void> {
-        return fs.writeFile(
-          scriptURI.fsPath,
-          stripIndent`
-            import templateOnly from '@glint/environment-ember-loose/ember-component/template-only';
-
-            interface TemplateOnlySignature {
-              Args: { foo: string };
-            }
-
-            export default templateOnly<TemplateOnlySignature>();
-          `
-        );
-      }
-
-      test('adding a backing module', async () => {
-        await window.showTextDocument(templateURI);
-        await waitUntil(() => languages.getDiagnostics(templateURI).length);
-
-        expect(languages.getDiagnostics(templateURI)).toMatchObject([
-          {
-            message: "Property 'foo' does not exist on type 'EmptyObject'.",
-            source: 'glint:ts(2339)',
-            range: new Range(0, 3, 0, 6),
-          },
-        ]);
-
-        await writeBackingModule();
-        await waitUntil(() => !languages.getDiagnostics(templateURI).length);
-
-        let positions = (await commands.executeCommand(
-          'vscode.executeDefinitionProvider',
-          templateURI,
-          new Position(0, 4)
-        )) as Array<Location>;
-
-        expect(positions.length).toBe(1);
-        expect(positions[0].uri.fsPath).toEqual(scriptURI.fsPath);
-        expect(positions[0].range).toEqual(new Range(3, 10, 3, 13));
-      });
-
-      test('removing a backing module', async () => {
-        await writeBackingModule();
-        await window.showTextDocument(templateURI);
-        await waitUntil(() => extensions.getExtension('typed-ember.glint-vscode')?.isActive);
-
-        let positions = (await commands.executeCommand(
-          'vscode.executeDefinitionProvider',
-          templateURI,
-          new Position(0, 4)
-        )) as Array<Location>;
-
-        expect(positions.length).toBe(1);
-        expect(positions[0].uri.fsPath).toEqual(scriptURI.fsPath);
-        expect(positions[0].range).toEqual(new Range(3, 10, 3, 13));
-
-        await fs.rm(scriptURI.fsPath);
-        await waitUntil(() => languages.getDiagnostics(templateURI).length);
-
-        expect(languages.getDiagnostics(templateURI)).toMatchObject([
-          {
-            message: "Property 'foo' does not exist on type 'EmptyObject'.",
-            source: 'glint:ts(2339)',
-            range: new Range(0, 3, 0, 6),
-          },
-        ]);
-      });
     });
   });
 


### PR DESCRIPTION
We ask a lot already of the Actions runners in CI when we launch full VS Code instances to run our extension smoke tests, but recently it seems file system notifications have been a bit flaky there.

There's no reason those tests _really_ need to be part of that suite, though, since 99% of what they're testing is logic in the language server itself that we can trigger by testing against an in-memory instance and explicitly sending a "hey this file changed" notification. While this means we're no longer testing that that hook is wired up in the VSC extension correctly, I think that small loss in coverage is outweighed by keeping the test suite stable and avoiding "testing the framework" with the extension system's file watching infrastructure.

I also tweaked a completions test to avoid caring about the ordering of results, as it's changed in TS nightly and we don't actually care what order they come back in.