### PR TITLE
Support multiple active environments in a project

### DIFF
--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -5,7 +5,7 @@ import { GlintEnvironment } from '../src';
 describe('Environments', () => {
   describe('template tags config', () => {
     test('locating a single tag', () => {
-      let env = new GlintEnvironment('test-env', {
+      let env = new GlintEnvironment(['test-env'], {
         tags: {
           'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
         },
@@ -15,7 +15,7 @@ describe('Environments', () => {
     });
 
     test('locating one of several tags', () => {
-      let env = new GlintEnvironment('test-env', {
+      let env = new GlintEnvironment(['test-env'], {
         tags: {
           'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
           'another-env': { tagMe: { capturesOuterScope: false, typesSource: 'over-here' } },
@@ -27,7 +27,7 @@ describe('Environments', () => {
     });
 
     test('checking a module with no tags in use', () => {
-      let env = new GlintEnvironment('test-env', {
+      let env = new GlintEnvironment(['test-env'], {
         tags: {
           'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
         },
@@ -46,7 +46,7 @@ describe('Environments', () => {
         },
       };
 
-      let env = new GlintEnvironment('test-env', { tags });
+      let env = new GlintEnvironment(['test-env'], { tags });
 
       expect(env.getConfiguredTemplateTags()).toBe(tags);
     });
@@ -54,7 +54,7 @@ describe('Environments', () => {
 
   describe('standalone template config', () => {
     test('no standalone template support', () => {
-      let env = new GlintEnvironment('test-env', {});
+      let env = new GlintEnvironment(['test-env'], {});
 
       expect(env.getTypesForStandaloneTemplate()).toBeUndefined();
       expect(env.getPossibleScriptPaths('hello.hbs')).toEqual([]);
@@ -62,7 +62,7 @@ describe('Environments', () => {
     });
 
     test('reflecting specified configuration', () => {
-      let env = new GlintEnvironment('test-env', {
+      let env = new GlintEnvironment(['test-env'], {
         template: {
           typesPath: '@glint/test-env/types',
           getPossibleTemplatePaths: (script) => [
@@ -103,7 +103,7 @@ describe('Environments', () => {
       const envDir = `${testDir}/node_modules/@glint/environment-test-env`;
 
       fs.mkdirSync(envDir, { recursive: true });
-      fs.writeFileSync(`${envDir}/env.js`, 'module.exports = () => ({ tags: "hello" });');
+      fs.writeFileSync(`${envDir}/env.js`, 'module.exports = () => ({ tags: { hello: {} } });');
       fs.writeFileSync(
         `${envDir}/package.json`,
         JSON.stringify({
@@ -114,14 +114,17 @@ describe('Environments', () => {
 
       let env = GlintEnvironment.load('test-env', { rootDir: testDir });
 
-      expect(env.getConfiguredTemplateTags()).toEqual('hello');
+      expect(env.getConfiguredTemplateTags()).toEqual({ hello: {} });
     });
 
     test('loading an environment from some other package', () => {
       const envDir = `${testDir}/node_modules/some-other-environment`;
 
       fs.mkdirSync(envDir, { recursive: true });
-      fs.writeFileSync(`${envDir}/third-party-env.js`, 'module.exports = () => ({ tags: "hi" });');
+      fs.writeFileSync(
+        `${envDir}/third-party-env.js`,
+        'module.exports = () => ({ tags: { hi: {} } });'
+      );
       fs.writeFileSync(
         `${envDir}/package.json`,
         JSON.stringify({
@@ -132,7 +135,7 @@ describe('Environments', () => {
 
       let env = GlintEnvironment.load('some-other-environment', { rootDir: testDir });
 
-      expect(env.getConfiguredTemplateTags()).toEqual('hi');
+      expect(env.getConfiguredTemplateTags()).toEqual({ hi: {} });
     });
 
     test('loading an environment from an explicit path', () => {
@@ -141,12 +144,13 @@ describe('Environments', () => {
       fs.mkdirSync(envDir, { recursive: true });
       fs.writeFileSync(
         `${envDir}/my-internal-env.js`,
-        'module.exports = () => ({ tags: "internal" });'
+        'module.exports = () => ({ tags: { internal: {} } });'
       );
 
       let env = GlintEnvironment.load('./lib/my-internal-env', { rootDir: testDir });
 
-      expect(env.getConfiguredTemplateTags()).toEqual('internal');
+      expect(env.getConfiguredTemplateTags()).toEqual({ internal: {} });
+    });
     });
   });
 });

--- a/packages/config/__tests__/load-config.test.ts
+++ b/packages/config/__tests__/load-config.test.ts
@@ -11,7 +11,7 @@ describe('loadConfig', () => {
     fs.mkdirSync(testDir);
     fs.writeFileSync(
       `${testDir}/local-env.js`,
-      `module.exports = () => ({ tags: { test: true } });\n`
+      `module.exports = () => ({ tags: { test: {} } });\n`
     );
   });
 
@@ -34,7 +34,7 @@ describe('loadConfig', () => {
     let config = loadConfig(`${testDir}/deeply/nested/directory`);
 
     expect(config.rootDir).toBe(normalizePath(`${testDir}/deeply`));
-    expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: true });
+    expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: {} });
     expect(config.includesFile(`${testDir}/deeply/index.ts`)).toBe(false);
     expect(config.includesFile(`${testDir}/deeply/index.root.ts`)).toBe(false);
     expect(config.includesFile(`${testDir}/deeply/index.nested.ts`)).toBe(true);
@@ -60,7 +60,7 @@ describe('loadConfig', () => {
 
       let config = loadConfig(testDir);
 
-      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: true });
+      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: {} });
       expect(config.includesFile(`${testDir}/index.ts`)).toBe(false);
       expect(config.includesFile(`${testDir}/index.from-pkg.ts`)).toBe(true);
     });
@@ -73,7 +73,7 @@ describe('loadConfig', () => {
 
       let config = loadConfig(testDir);
 
-      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: true });
+      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: {} });
       expect(config.includesFile(`${testDir}/index.ts`)).toBe(false);
       expect(config.includesFile(`${testDir}/index.extensionless.ts`)).toBe(true);
     });
@@ -86,7 +86,7 @@ describe('loadConfig', () => {
 
       let config = loadConfig(testDir);
 
-      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: true });
+      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: {} });
       expect(config.includesFile(`${testDir}/index.ts`)).toBe(false);
       expect(config.includesFile(`${testDir}/index.jsrc.ts`)).toBe(true);
     });
@@ -99,7 +99,7 @@ describe('loadConfig', () => {
 
       let config = loadConfig(testDir);
 
-      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: true });
+      expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: {} });
       expect(config.includesFile(`${testDir}/index.ts`)).toBe(false);
       expect(config.includesFile(`${testDir}/index.config.ts`)).toBe(true);
     });

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -3,7 +3,7 @@ import { Minimatch, IMinimatch } from 'minimatch';
 import { GlintEnvironment } from './environment';
 
 export type GlintConfigInput = {
-  environment: string;
+  environment: string | Array<string>;
   checkStandaloneTemplates?: boolean;
   include?: string | Array<string>;
   exclude?: string | Array<string>;
@@ -70,8 +70,10 @@ export function normalizePath(fileName: string): string {
 
 function validateConfigInput(input: Record<string, unknown>): asserts input is GlintConfigInput {
   assert(
-    typeof input['environment'] === 'string',
-    'Glint config must specify an `environment` string'
+    Array.isArray(input['environment'])
+      ? input['environment'].every((env) => typeof env === 'string')
+      : typeof input['environment'] === 'string',
+    'Glint config must specify an `environment` that is a string or an array of strings'
   );
 
   assert(

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -114,7 +114,7 @@ describe('rewriteModule', () => {
     });
 
     test('outer variable capture', () => {
-      let testEnvironment = new GlintEnvironment('test', {
+      let testEnvironment = new GlintEnvironment(['test'], {
         tags: {
           '@glint/test-env': {
             hbsCapture: { typesSource: '@glint/test-env', capturesOuterScope: true },

--- a/packages/transform/src/inlining/companion-file.ts
+++ b/packages/transform/src/inlining/companion-file.ts
@@ -22,7 +22,9 @@ export function calculateCompanionTemplateSpans(
     errors.push({
       source: template,
       location: { start: 0, end: template.contents.length },
-      message: `Glint environment ${environment.name} does not support standalone template files`,
+      message: `No active Glint environment (${environment.names.join(
+        ', '
+      )}) supports standalone template files`,
     });
 
     return { errors, directives, partialSpans };


### PR DESCRIPTION
This change allows for users to specify multiple `environment` values in their Glint config.

This is the first step toward being able to create an `ember-template-imports` Glint environment. Currently, even a "totally `template-imports`" project will still have loose-mode templates for things like routes, so projects would typically want to make use of both the `template-imports` environment _and_ `@glint/environment-ember-loose` in the same project.

A few notes:
 - only one active environment can determine how standalone `.hbs` files are handled
 - only one active environment can determine how a particular imported template tag behaves

If either of those rules is violated, an error is raised when Glint boots up and loads the configuration.

Subsequent work will enable environments to preprocess modules in order to support custom syntax such as `<template>`.