### PR TITLE
Add `ResolveOrReturn` utility type to `@glint/template`

### DIFF
--- a/packages/environment-glimmerx/-private/dsl/index.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/index.d.ts
@@ -19,6 +19,7 @@ export { Globals } from './globals';
  * further details on resolution.
  */
 
+import { ResolveOrReturn } from '@glint/template/-private/dsl';
 import {
   BoundModifier,
   DirectInvokable,
@@ -45,14 +46,4 @@ export declare function resolve<Args extends unknown[], T>(
   item: (...args: Args) => T
 ): (named: EmptyObject, ...args: Args) => T;
 
-export declare function resolveOrReturn<T extends DirectInvokable>(item: T): T[typeof InvokeDirect];
-export declare function resolveOrReturn<Args extends unknown[], Instance extends Invokable>(
-  item: new (...args: Args) => Instance
-): (...args: Parameters<Instance[typeof Invoke]>) => ReturnType<Instance[typeof Invoke]>;
-export declare function resolveOrReturn<Value, Args extends unknown[], T extends Value>(
-  item: (value: Value, ...args: Args) => value is T
-): (named: EmptyObject, value: Value, ...args: Args) => value is T;
-export declare function resolveOrReturn<Args extends unknown[], T>(
-  item: (...args: Args) => T
-): (named: EmptyObject, ...args: Args) => T;
-export declare function resolveOrReturn<T>(item: T): (args: EmptyObject) => T;
+export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;

--- a/packages/environment-glimmerx/__tests__/resolve.test.ts
+++ b/packages/environment-glimmerx/__tests__/resolve.test.ts
@@ -1,0 +1,14 @@
+import { expectTypeOf } from 'expect-type';
+import { resolve, resolveOrReturn } from '@glint/environment-glimmerx/-private/dsl';
+import { EmptyObject } from '@glint/template/-private/integration';
+
+{
+  const shout = (arg: string): string => arg.toUpperCase();
+
+  expectTypeOf(resolve(shout)).toEqualTypeOf<(named: EmptyObject, arg: string) => string>();
+  expectTypeOf(resolveOrReturn(shout)).toEqualTypeOf<(named: EmptyObject, arg: string) => string>();
+
+  // @ts-expect-error: strings are not resolvable
+  resolve('hello');
+  expectTypeOf(resolveOrReturn('hello')).toEqualTypeOf<(named: EmptyObject) => string>();
+}

--- a/packages/template/-private/dsl/resolve.d.ts
+++ b/packages/template/-private/dsl/resolve.d.ts
@@ -1,4 +1,5 @@
-import { DirectInvokable, EmptyObject, Invokable, Invoke, InvokeDirect } from '../integration';
+import { DirectInvokable, Invokable, Invoke, InvokeDirect } from '../integration';
+import { ResolveOrReturn } from './types';
 
 /*
  * We have multiple ways of representing invokable values, dictated by certain constraints
@@ -45,8 +46,4 @@ export declare function resolve<Args extends unknown[], Instance extends Invokab
  * value of the appropriate type.
  */
 
-export declare function resolveOrReturn<T extends DirectInvokable>(item: T): T[typeof InvokeDirect];
-export declare function resolveOrReturn<Args extends unknown[], Instance extends Invokable>(
-  item: (new (...args: Args) => Instance) | null | undefined
-): (...args: Parameters<Instance[typeof Invoke]>) => ReturnType<Instance[typeof Invoke]>;
-export declare function resolveOrReturn<T>(item: T): (args: EmptyObject) => T;
+export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;

--- a/packages/template/-private/dsl/types.d.ts
+++ b/packages/template/-private/dsl/types.d.ts
@@ -1,6 +1,12 @@
-import { HasContext } from '@glint/template/-private/integration';
+import { EmptyObject, HasContext } from '@glint/template/-private/integration';
 
 type Constructor<T> = new (...args: any) => T;
+
+/**
+ * A utility for constructing the type of an environment's `resolveOrReturn` from
+ * the type of its `resolve` function.
+ */
+export type ResolveOrReturn<T> = T & (<U>(item: U) => (args: EmptyObject) => U);
 
 /**
  * Given a tag name, returns an appropriate `Element` subtype.


### PR DESCRIPTION
In beginning to play around with an `glint-environment-ember-template-imports` package, I got exasperated with the tedium and error-prone-ness of having to define types for both `resolve` and `resolveOrReturn`.

On reflection, we should be able to trivially define the latter in terms of the former, so this PR introduces a utility type to `@glint/template` to enable just that and lessen the burden on environment maintainers.