### PR TITLE
Deal with dependency drift issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           run: yarn test
 
+  # The Windows runner can be super flaky both with Yarn installs and
+  # when launching browser tests, so we allow for retries in those steps.
   test-windows:
     name: Test Windows
     runs-on: windows-latest
@@ -61,11 +63,19 @@ jobs:
         with:
           node-version: 12
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 2
+          timeout_minutes: 10
+          command: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
       - name: Run Tests
-        run: yarn test
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 2
+          timeout_minutes: 15
+          command: yarn test
 
   test-floating-deps:
     name: Test Floating Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,27 @@ jobs:
       - name: Run Tests
         run: yarn test
 
-  test-versions:
+  test-floating-deps:
+    name: Test Floating Dependencies
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Dependencies
+        run: yarn install --no-lockfile
+      - name: Build
+        run: yarn build
+      - name: Run Tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn test
+
+  test-ts-nightly:
     name: Test TypeScript Nightly
     needs: [test]
     runs-on: ubuntu-latest

--- a/packages/core/bin/glint-language-server.js
+++ b/packages/core/bin/glint-language-server.js
@@ -1,3 +1,10 @@
 #!/usr/bin/env node
 /* eslint-disable */
+
+// Despite the fact that we're only using Babel for parsing,
+// it implicitly loads Browserslist, which can trigger a
+// warning to stdout (breaking our LSP interactions) for
+// users with an older lockfile.
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = 'true';
+
 require('../lib/language-server');

--- a/packages/core/bin/glint.js
+++ b/packages/core/bin/glint.js
@@ -1,3 +1,9 @@
 #!/usr/bin/env node
 /* eslint-disable */
+
+// Despite the fact that we're only using Babel for parsing,
+// it implicitly loads Browserslist, which can trigger a
+// warning for users with an older lockfile.
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = 'true';
+
 require('../lib/cli');

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -34,5 +34,5 @@ const optionsToExtend = determineOptionsToExtend(argv);
 if (argv.watch) {
   performWatch(ts, glintConfig, tsconfigPath, optionsToExtend);
 } else {
-  performCheck(ts, argv._, glintConfig, tsconfigPath, optionsToExtend);
+  performCheck(ts, argv._.map(String), glintConfig, tsconfigPath, optionsToExtend);
 }

--- a/packages/transform/src/inlining/index.ts
+++ b/packages/transform/src/inlining/index.ts
@@ -40,8 +40,9 @@ export function getContainingTypeInfo(path: NodePath<any>): ContainingTypeInfo {
 
   let typeParamsNode = container?.typeParameters;
   if (t.isTSTypeParameterDeclaration(typeParamsNode)) {
-    typeParams = generate(typeParamsNode).code;
-    contextType += `<${typeParamsNode.params.map((param) => param.name).join(', ')}>`;
+    let { params } = typeParamsNode;
+    typeParams = `<${params.map((param) => generate(param).code).join(', ')}>`;
+    contextType += `<${params.map((param) => param.name).join(', ')}>`;
   }
 
   return { contextType, typeParams, className, inClass };

--- a/packages/transform/src/inlining/index.ts
+++ b/packages/transform/src/inlining/index.ts
@@ -49,7 +49,7 @@ export function getContainingTypeInfo(path: NodePath<any>): ContainingTypeInfo {
 }
 
 function findContainingClass(path: NodePath<any>): t.Class | null {
-  let current: NodePath<any> = path;
+  let current: NodePath<any> | null = path;
   do {
     if (t.isClass(current.node)) {
       return current.node;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,15 +4344,15 @@ browserify-zlib@^0.2.0:
     pako "~1.0.5"
 
 browserslist@^4.0.0, browserslist@^4.16.6:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
-  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3"
+  integrity sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==
   dependencies:
-    caniuse-lite "^1.0.30001219"
-    colorette "^1.2.2"
-    electron-to-chromium "^1.3.723"
+    caniuse-lite "^1.0.30001286"
+    electron-to-chromium "^1.4.17"
     escalade "^3.1.1"
-    node-releases "^1.1.71"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -4587,10 +4587,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219:
+caniuse-lite@^1.0.0:
   version "1.0.30001245"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz#45b941bbd833cb0fa53861ff2bae746b3c6ca5d4"
   integrity sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==
+
+caniuse-lite@^1.0.30001286:
+  version "1.0.30001299"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz#d753bf6444ed401eb503cbbe17aa3e1451b5a68c"
+  integrity sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4957,11 +4962,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-colorette@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 colors@^1.4.0:
   version "1.4.0"
@@ -5849,10 +5849,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.723:
-  version "1.3.779"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.779.tgz#de55492a756deec63424f89fbe62aec9776f0e6d"
-  integrity sha512-nreave0y/1Qhmo8XtO6C/LpawNyC6U26+q7d814/e+tIqUK073pM+4xW7WUXyqCRa5K4wdxHmNMBAi8ap9nEew==
+electron-to-chromium@^1.4.17:
+  version "1.4.44"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz#8a41923afdd6ef5ddabe001626036ba5d1d64ae6"
+  integrity sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==
 
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.3"
@@ -10966,10 +10966,10 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^1.1.71:
-  version "1.1.73"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
-  integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+node-releases@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
+  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
 node-watch@0.7.1:
   version "0.7.1"
@@ -11677,6 +11677,11 @@ picocolors@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
   integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"


### PR DESCRIPTION
A few separate but related issues have popped up as our upstream dependencies (specifically the Babel-related ones) have evolved lately:
 - Browserslist gets cranky when it's not on a recent enough version. We don't actually care because we aren't doing transpilation for real targets, but Babel ends up implicitly loading it on startup, which can trigger the warning. Accordingly, we disable the warning in the entrypoint to the language server and CLI executables.
 - [babel/babel#14113](https://github.com/babel/babel/pull/14113) made `generate(someTSTypeParameterDeclarationNode)` throw, as it now cares about details of its parent node. Babel should maybe handle that more gracefully, but it's trivial for us to work around by generating code for the declarations individually rather than altogether.

The Browserslist issue was a ticking timebomb we would have hit eventually regardless, but a few different consumers ran into the `@babel/generator` just from refreshing other random dependencies and happening to get a Babel update. To help get ahead of that situation in the future, I'm also adding a floating dependencies scenario to our CI config.