### PR TITLE
A small bug bash 🐛 

### DIFF
--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -104,6 +104,20 @@ function buildHelpers({ languageServer, documents, connection }: BindingArgs): B
           const diagnostics = languageServer.getDiagnostics(uri);
           connection.sendDiagnostics({ uri, diagnostics });
         } catch (error) {
+          connection.sendDiagnostics({
+            uri,
+            diagnostics: [
+              {
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+                message:
+                  'Glint encountered an error computing diagnostics for this file. ' +
+                  'This is likely a bug in Glint; please file an issue, including any ' +
+                  'code and/or steps to follow to reproduce the error.\n\n' +
+                  errorMessage(error),
+              },
+            ],
+          });
+
           connection.console.error(`Error getting diagnostics for ${uri}.\n${errorMessage(error)}`);
         }
       }

--- a/packages/environment-ember-loose/-private/dsl/globals.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/globals.d.ts
@@ -42,7 +42,7 @@ interface Keywords {
 
     [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component
    */
-  component: ComponentKeyword<Registry>;
+  component: ComponentKeyword<Globals>;
 
   /**
     Execute the `debugger` statement in the current template's context.

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/component.test.ts
@@ -3,6 +3,7 @@ import {
   resolve,
   applySplattributes,
   emitComponent,
+  Globals,
 } from '@glint/environment-ember-loose/-private/dsl';
 import Component from '@glint/environment-ember-loose/ember-component';
 import { ComponentKeyword } from '@glint/environment-ember-loose/-private/intrinsics/component';
@@ -267,3 +268,14 @@ emitComponent(
     foo: 'bar',
   })
 );
+
+{
+  // This 'real' version of `{{component}}` uses the definition available to downstream consumers,
+  // rather than the one above that's tied to our isolated testing registry so we can ensure
+  // appropriate global values are available to consumers.
+  const realComponentKeyword = resolve(Globals['component']);
+
+  expectTypeOf(realComponentKeyword({}, 'input')).toEqualTypeOf(Globals.input);
+  expectTypeOf(realComponentKeyword({}, 'link-to')).toEqualTypeOf(Globals['link-to']);
+  expectTypeOf(realComponentKeyword({}, 'textarea')).toEqualTypeOf(Globals['textarea']);
+}

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -530,4 +530,38 @@ describe('Diagnostic offset mapping', () => {
       ],
     });
   });
+
+  test('with a companion template', () => {
+    let script = { filename: 'test.ts', contents: '' };
+    let template = {
+      filename: 'test.hbs',
+      contents: stripIndent`
+        {{foo-bar type 'in'}}
+      `,
+    };
+
+    let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment)!;
+    let category = ts.DiagnosticCategory.Error;
+    let messageText = '`foo-bar` is no good';
+    let code = 1234;
+
+    let original: ts.DiagnosticWithLocation = {
+      category,
+      code,
+      messageText,
+      file: { fileName: 'test.ts' } as ts.SourceFile,
+      start: transformedModule?.transformedContents.indexOf('foo-bar'),
+      length: 7,
+    };
+
+    let rewritten = rewriteDiagnostic(ts, original, () => transformedModule);
+
+    expect(rewritten).toMatchObject({
+      category,
+      code,
+      messageText,
+      start: template.contents.indexOf('foo-bar'),
+      length: 7,
+    });
+  });
 });

--- a/packages/transform/src/util.ts
+++ b/packages/transform/src/util.ts
@@ -1,3 +1,6 @@
+import type ts from 'typescript';
+import { SourceFile } from './transformed-module';
+
 export function unreachable(value: never, message = 'unreachable code'): never {
   throw new Error(`[@glint/transform] Internal error: ${message}`);
 }
@@ -10,4 +13,11 @@ export function assert(test: unknown, message = 'Internal error'): asserts test 
 
 export function isJsScript(uriOrFilePath: string): boolean {
   return uriOrFilePath.endsWith('.js');
+}
+
+export function createSyntheticSourceFile(tsImpl: typeof ts, source: SourceFile): ts.SourceFile {
+  return Object.assign(tsImpl.createSourceFile(source.filename, '', tsImpl.ScriptTarget.Latest), {
+    text: source.contents,
+    end: source.contents.length,
+  });
 }


### PR DESCRIPTION
This is the result of chasing down a handful of bugs in the issue tracker that seemed like they'd be easy to squash. It includes fixes for:
 - #216 
 - #211

It also adds a warning to files when something goes wrong when we try to emit diagnostics. This won't necessarily catch a case where we should be emitting diagnostics but aren't because we think everything is fine, but it _will_ flag the situation to the user if an exception is being thrown and we know for a fact something is wrong, which we believe may be the case in #215.