### PR TITLE
Support custom file extensions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,7 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
-        "${workspaceFolder}/test-packages/ts-ember-app",
-        "${workspaceFolder}/test-packages/ts-glimmerx-app",
-        "${workspaceFolder}/test-packages/js-glimmerx-app"
+        "${workspaceFolder}/test-packages/glint-test-packages.code-workspace"
       ]
     }
   ]

--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -11,7 +11,9 @@ describe('Environments', () => {
         },
       });
 
-      expect(env.moduleMayHaveTagImports('import foo from "my-cool-environment"\n')).toBe(true);
+      expect(
+        env.moduleMayHaveEmbeddedTemplates('foo.ts', 'import foo from "my-cool-environment"\n')
+      ).toBe(true);
     });
 
     test('locating one of several tags', () => {
@@ -23,7 +25,9 @@ describe('Environments', () => {
         },
       });
 
-      expect(env.moduleMayHaveTagImports('import foo from "another-env"\n')).toBe(true);
+      expect(env.moduleMayHaveEmbeddedTemplates('foo.ts', 'import foo from "another-env"\n')).toBe(
+        true
+      );
     });
 
     test('checking a module with no tags in use', () => {
@@ -33,7 +37,9 @@ describe('Environments', () => {
         },
       });
 
-      expect(env.moduleMayHaveTagImports('import { hbs } from "another-env"\n')).toBe(false);
+      expect(
+        env.moduleMayHaveEmbeddedTemplates('foo.ts', 'import { hbs } from "another-env"\n')
+      ).toBe(false);
     });
 
     test('getting specified template tag config', () => {
@@ -84,6 +90,42 @@ describe('Environments', () => {
         { path: 'hello.ts', deferTo: [] },
         { path: 'hello.js', deferTo: [] },
       ]);
+    });
+  });
+
+  describe('extensions config', () => {
+    let env = new GlintEnvironment(['test'], {
+      extensions: {
+        '.ts': { kind: 'typed-script' },
+        '.gts': { kind: 'typed-script' },
+        '.hbs': { kind: 'template' },
+      },
+    });
+
+    test('listing configured extensions', () => {
+      expect(env.getConfiguredFileExtensions()).toEqual(['.ts', '.gts', '.hbs']);
+    });
+
+    test('identifying scripts and templates', () => {
+      expect(env.isTemplate('foo.hbs')).toBeTruthy();
+      expect(env.isTemplate('foo.ts')).toBeFalsy();
+      expect(env.isTypedScript('foo.ts')).toBeTruthy();
+      expect(env.isTypedScript('foo.gts')).toBeTruthy();
+      expect(env.isTypedScript('foo.js')).toBeFalsy();
+      expect(env.isUntypedScript('foo.ts')).toBeFalsy();
+      expect(env.isUntypedScript('foo.hbs')).toBeFalsy();
+      expect(env.isScript('foo.ts')).toBeTruthy();
+      expect(env.isScript('foo.gts')).toBeTruthy();
+      expect(env.isScript('foo.js')).toBeFalsy();
+      expect(env.isScript('foo.hbs')).toBeFalsy();
+    });
+
+    test('fetching config for an extension', () => {
+      expect(env.getConfigForExtension('.js')).toBeUndefined();
+      expect(env.getConfigForExtension('.hbs')).toEqual({ kind: 'template' });
+      expect(env.getConfigForExtension('.gts')).toEqual({
+        kind: 'typed-script',
+      });
     });
   });
 

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -56,6 +56,23 @@ export class GlintConfig {
     );
   }
 
+  // Given the path of a template or script (potentially with a custom extension),
+  // returns the corresponding .js or .ts path we present to the TS language service.
+  public getSynthesizedScriptPathForTS(filename: string): string {
+    let extension = path.extname(filename);
+    let filenameWithoutExtension = filename.slice(0, filename.lastIndexOf(extension));
+    switch (this.environment.getSourceKind(filename)) {
+      case 'template':
+        return `${filenameWithoutExtension}${this.checkStandaloneTemplates ? '.ts' : '.js'}`;
+      case 'typed-script':
+        return `${filenameWithoutExtension}.ts`;
+      case 'untyped-script':
+        return `${filenameWithoutExtension}.js`;
+      default:
+        return filename;
+    }
+  }
+
   private buildMatchers(globs: Array<string>): Array<IMinimatch> {
     return globs.map((glob) => new Minimatch(normalizePath(path.resolve(this.rootDir, glob))));
   }

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -28,11 +28,12 @@ export class GlintConfig {
     this.environment = GlintEnvironment.load(config.environment, { rootDir });
     this.checkStandaloneTemplates = config.checkStandaloneTemplates ?? true;
 
+    let extensions = this.environment.getConfiguredFileExtensions();
     let include = Array.isArray(config.include)
       ? config.include
       : config.include
       ? [config.include]
-      : ['**/*.ts', '**/*.js', '**/*.hbs'];
+      : extensions.map((ext) => `**/*${ext}`);
 
     let exclude = Array.isArray(config.exclude)
       ? config.exclude

--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -235,6 +235,29 @@ describe('CLI: single-pass typechecking', () => {
     `);
   });
 
+  test('reports diagnostics from custom extensions', async () => {
+    project.write('.glintrc', `environment: custom-test`);
+
+    project.write(
+      'my-component.custom',
+      stripIndent`
+        export let x: string = 123;
+      `
+    );
+
+    let checkResult = await project.check({ reject: false });
+
+    expect(checkResult.exitCode).toBe(1);
+    expect(checkResult.stdout).toEqual('');
+    expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
+      "my-component.custom:1:12 - error TS2322: Type 'number' is not assignable to type 'string'.
+
+      1 export let x: string = 123;
+                   ~
+      "
+    `);
+  });
+
   test('reports correct diagnostics given @glint-expect-error and @glint-ignore directives', async () => {
     project.write('.glintrc', 'environment: ember-loose\n');
 

--- a/packages/core/__tests__/language-server/custom-extensions.test.ts
+++ b/packages/core/__tests__/language-server/custom-extensions.test.ts
@@ -1,0 +1,179 @@
+import Project from '../utils/project';
+import { stripIndent } from 'common-tags';
+
+describe('Language Server: custom file extensions', () => {
+  let project!: Project;
+
+  beforeEach(async () => {
+    jest.setTimeout(20_000);
+    project = await Project.create();
+  });
+
+  afterEach(async () => {
+    await project.destroy();
+  });
+
+  test('reporting diagnostics', () => {
+    let contents = 'let identifier: string = 123;';
+
+    project.write('.glintrc', `environment: custom-test`);
+    project.write('index.custom', contents);
+
+    let server = project.startLanguageServer();
+
+    expect(server.getDiagnostics(project.fileURI('index.custom'))).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "message": "Type 'number' is not assignable to type 'string'.",
+          "range": Object {
+            "end": Object {
+              "character": 14,
+              "line": 0,
+            },
+            "start": Object {
+              "character": 4,
+              "line": 0,
+            },
+          },
+          "severity": 1,
+          "source": "glint:ts(2322)",
+          "tags": Array [],
+        },
+      ]
+    `);
+
+    server.openFile(project.fileURI('index.custom'), contents);
+
+    expect(server.getDiagnostics(project.fileURI('index.custom'))).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "message": "Type 'number' is not assignable to type 'string'.",
+          "range": Object {
+            "end": Object {
+              "character": 14,
+              "line": 0,
+            },
+            "start": Object {
+              "character": 4,
+              "line": 0,
+            },
+          },
+          "severity": 1,
+          "source": "glint:ts(2322)",
+          "tags": Array [],
+        },
+      ]
+    `);
+
+    server.updateFile(project.fileURI('index.custom'), contents.replace('123', '"hi"'));
+
+    expect(server.getDiagnostics(project.fileURI('index.custom'))).toEqual([]);
+  });
+
+  test('providing hover info', () => {
+    let contents = 'let identifier = "hello";';
+
+    project.write('.glintrc', `environment: custom-test`);
+    project.write('index.custom', contents);
+
+    let server = project.startLanguageServer();
+    let hover = server.getHover(project.fileURI('index.custom'), { line: 0, character: 8 });
+
+    expect(hover).toMatchInlineSnapshot(`
+      Object {
+        "contents": Array [
+          Object {
+            "language": "ts",
+            "value": "let identifier: string",
+          },
+        ],
+        "range": Object {
+          "end": Object {
+            "character": 14,
+            "line": 0,
+          },
+          "start": Object {
+            "character": 4,
+            "line": 0,
+          },
+        },
+      }
+    `);
+
+    project.write('index.custom', contents.replace('"hello"', '123'));
+    server.fileDidChange(project.fileURI('index.custom'));
+
+    hover = server.getHover(project.fileURI('index.custom'), { line: 0, character: 8 });
+
+    expect(hover).toMatchInlineSnapshot(`
+      Object {
+        "contents": Array [
+          Object {
+            "language": "ts",
+            "value": "let identifier: number",
+          },
+        ],
+        "range": Object {
+          "end": Object {
+            "character": 14,
+            "line": 0,
+          },
+          "start": Object {
+            "character": 4,
+            "line": 0,
+          },
+        },
+      }
+    `);
+  });
+
+  test('resolving conflicts beween overlapping extensions', () => {
+    let contents = 'export let identifier = 123`;';
+
+    project.write('.glintrc', `environment: custom-test`);
+    project.write('index.ts', contents);
+    project.write('index.custom', contents);
+
+    project.write(
+      'consumer.ts',
+      stripIndent`
+        import { identifier } from './index';
+
+        identifier;
+      `
+    );
+
+    let consumerURI = project.fileURI('consumer.ts');
+    let server = project.startLanguageServer();
+
+    let definitions = server.getDefinition(consumerURI, { line: 2, character: 4 });
+    let diagnostics = server.getDiagnostics(consumerURI);
+
+    expect(definitions).toMatchObject([{ uri: project.fileURI('index.ts') }]);
+    expect(diagnostics).toEqual([]);
+
+    project.remove('index.ts');
+    server.fileDidChange(project.fileURI('index.ts'));
+
+    definitions = server.getDefinition(consumerURI, { line: 2, character: 4 });
+    diagnostics = server.getDiagnostics(consumerURI);
+
+    expect(definitions).toMatchObject([{ uri: project.fileURI('index.custom') }]);
+    expect(diagnostics).toEqual([]);
+
+    project.remove('index.custom');
+    server.fileDidChange(project.fileURI('index.custom'));
+
+    diagnostics = server.getDiagnostics(consumerURI);
+
+    expect(diagnostics).toMatchObject([
+      {
+        source: 'glint:ts(2306)',
+        range: {
+          start: { line: 0, character: 27 },
+          end: { line: 0, character: 36 },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -298,12 +298,12 @@ describe('Language Server: Diagnostics', () => {
     `;
 
     project.write('.glintrc', 'environment: ember-loose\n');
-    project.write('index.ts', script);
-    project.write('index.hbs', template);
+    project.write('controllers/foo.ts', script);
+    project.write('templates/foo.hbs', template);
 
     let server = project.startLanguageServer();
-    let scriptDiagnostics = server.getDiagnostics(project.fileURI('index.ts'));
-    let templateDiagnostics = server.getDiagnostics(project.fileURI('index.hbs'));
+    let scriptDiagnostics = server.getDiagnostics(project.fileURI('controllers/foo.ts'));
+    let templateDiagnostics = server.getDiagnostics(project.fileURI('templates/foo.hbs'));
 
     expect(scriptDiagnostics).toMatchInlineSnapshot(`
       Array [
@@ -349,14 +349,14 @@ describe('Language Server: Diagnostics', () => {
       ]
     `);
 
-    server.openFile(project.fileURI('index.hbs'), template);
+    server.openFile(project.fileURI('templates/foo.hbs'), template);
     server.updateFile(
-      project.fileURI('index.hbs'),
+      project.fileURI('templates/foo.hbs'),
       template.replace('startupTimee', 'startupTime')
     );
 
-    expect(server.getDiagnostics(project.fileURI('index.ts'))).toEqual([]);
-    expect(server.getDiagnostics(project.fileURI('index.hbs'))).toEqual([]);
+    expect(server.getDiagnostics(project.fileURI('controllers/foo.ts'))).toEqual([]);
+    expect(server.getDiagnostics(project.fileURI('templates/foo.hbs'))).toEqual([]);
   });
 
   test('honors @glint-ignore and @glint-expect-error', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "@glint/config": "^0.6.3",
     "@glint/transform": "^0.6.3",
     "resolve": "^1.17.0",
+    "uuid": "^8.3.2",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-uri": "^3.0.2",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.13",
     "@types/resolve": "^1.17.1",
+    "@types/uuid": "^8.3.4",
     "execa": "^4.0.1",
     "jest": "^26.4.2",
     "strip-ansi": "^6.0.0",

--- a/packages/transform/src/inlining/companion-file.ts
+++ b/packages/transform/src/inlining/companion-file.ts
@@ -6,7 +6,7 @@ import { RewriteResult } from '../map-template-contents';
 import MappingTree, { ParseError } from '../mapping-tree';
 import { templateToTypescript } from '../template-to-typescript';
 import { Directive, SourceFile, TransformError } from '../transformed-module';
-import { assert, isJsScript } from '../util';
+import { assert } from '../util';
 
 export function calculateCompanionTemplateSpans(
   exportDeclarationPath: NodePath | null,
@@ -30,7 +30,7 @@ export function calculateCompanionTemplateSpans(
     return { errors, directives, partialSpans };
   }
 
-  let useJsDoc = isJsScript(script.filename);
+  let useJsDoc = environment.isUntypedScript(script.filename);
   let targetPath = findCompanionTemplateTarget(exportDeclarationPath);
   if (targetPath?.isClass()) {
     let { className, contextType, typeParams } = getContainingTypeInfo(targetPath);

--- a/packages/transform/src/inlining/tagged-strings.ts
+++ b/packages/transform/src/inlining/tagged-strings.ts
@@ -3,7 +3,7 @@ import { GlintEnvironment, GlintTagConfig } from '@glint/config';
 import { CorrelatedSpansResult, getContainingTypeInfo, PartialCorrelatedSpan } from '.';
 import { templateToTypescript } from '../template-to-typescript';
 import { Directive, SourceFile, TransformError, Range } from '../transformed-module';
-import { assert, isJsScript } from '../util';
+import { assert } from '../util';
 
 export function calculateTaggedTemplateSpans(
   path: NodePath<t.TaggedTemplateExpression>,
@@ -51,7 +51,7 @@ export function calculateTaggedTemplateSpans(
       identifiersInScope,
       typeParams,
       contextType,
-      useJsDoc: isJsScript(script.filename),
+      useJsDoc: environment.isUntypedScript(script.filename),
     });
 
     if (inClass && !className) {

--- a/packages/transform/src/util.ts
+++ b/packages/transform/src/util.ts
@@ -11,10 +11,6 @@ export function assert(test: unknown, message = 'Internal error'): asserts test 
   }
 }
 
-export function isJsScript(uriOrFilePath: string): boolean {
-  return uriOrFilePath.endsWith('.js');
-}
-
 export function createSyntheticSourceFile(tsImpl: typeof ts, source: SourceFile): ts.SourceFile {
   return Object.assign(tsImpl.createSourceFile(source.filename, '', tsImpl.ScriptTarget.Latest), {
     text: source.contents,

--- a/packages/vscode/__fixtures__/custom-app/.glintrc.yml
+++ b/packages/vscode/__fixtures__/custom-app/.glintrc.yml
@@ -1,0 +1,1 @@
+environment: custom-test

--- a/packages/vscode/__fixtures__/custom-app/package.json
+++ b/packages/vscode/__fixtures__/custom-app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-js-glimmerx-app",
+  "private": true
+}

--- a/packages/vscode/__fixtures__/custom-app/src/index.custom
+++ b/packages/vscode/__fixtures__/custom-app/src/index.custom
@@ -1,0 +1,1 @@
+let foo: string = 'hello';

--- a/packages/vscode/__fixtures__/custom-app/tsconfig.json
+++ b/packages/vscode/__fixtures__/custom-app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../tsconfig.compileroptions.json"
+}

--- a/packages/vscode/__tests__/smoketest-custom.test.ts
+++ b/packages/vscode/__tests__/smoketest-custom.test.ts
@@ -1,0 +1,43 @@
+import { commands, languages, ViewColumn, window, Uri, Range } from 'vscode';
+import path from 'path';
+import { waitUntil } from './helpers/async';
+
+describe('Smoke test: Custom Environment', () => {
+  jest.setTimeout(30_000);
+
+  const rootDir = path.resolve(__dirname, '../__fixtures__/custom-app');
+
+  afterEach(async () => {
+    while (window.activeTextEditor) {
+      await commands.executeCommand('workbench.action.files.revert');
+      await commands.executeCommand('workbench.action.closeActiveEditor');
+    }
+  });
+
+  describe('diagnostics for errors', () => {
+    test('with a custom extension', async () => {
+      let scriptURI = Uri.file(`${rootDir}/src/index.custom`);
+      let scriptEditor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
+
+      // Ensure we have a clean bill of health
+      expect(languages.getDiagnostics(scriptURI)).toEqual([]);
+
+      // Replace a string with a number
+      await scriptEditor.edit((edit) => {
+        edit.replace(new Range(0, 18, 0, 25), '123');
+      });
+
+      // Wait for the diagnostic to show up
+      await waitUntil(() => languages.getDiagnostics(scriptURI).length);
+
+      // Verify it's what we expect
+      expect(languages.getDiagnostics(scriptURI)).toMatchObject([
+        {
+          message: "Type 'number' is not assignable to type 'string'.",
+          source: 'glint:ts(2322)',
+          range: new Range(0, 4, 0, 7),
+        },
+      ]);
+    });
+  });
+});

--- a/packages/vscode/__tests__/support/launch-from-cli.js
+++ b/packages/vscode/__tests__/support/launch-from-cli.js
@@ -23,9 +23,10 @@ async function main() {
         // Point at an empty directory so we don't have to contend with any local user preferences
         '--user-data-dir',
         emptyTempDir,
-        // Load the Ember and GlimmerX app fixtures
+        // Load the app fixtures
         `${__dirname}/../../__fixtures__/ember-app`,
         `${__dirname}/../../__fixtures__/js-glimmerx-app`,
+        `${__dirname}/../../__fixtures__/custom-app`,
       ],
     });
   } catch (error) {

--- a/test-packages/glint-environment-custom-test/env.js
+++ b/test-packages/glint-environment-custom-test/env.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+/** @type {() => import('@glint/config').GlintEnvironmentConfig} */
+module.exports = () => ({
+  extensions: {
+    '.custom': {
+      kind: 'typed-script',
+    },
+  },
+});

--- a/test-packages/glint-environment-custom-test/package.json
+++ b/test-packages/glint-environment-custom-test/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "glint-environment-custom-test",
+  "version": "0.6.3",
+  "license": "MIT",
+  "private": true,
+  "description": "Used by the @glint/core test suite and `ts-custom-app`",
+  "glint-environment": "./env.js",
+  "scripts": {
+    "test": "true",
+    "lint": "true"
+  }
+}

--- a/test-packages/glint-test-packages.code-workspace
+++ b/test-packages/glint-test-packages.code-workspace
@@ -1,0 +1,16 @@
+{
+  "folders": [
+    {
+      "path": "ts-ember-app"
+    },
+    {
+      "path": "ts-glimmerx-app"
+    },
+    {
+      "path": "js-glimmerx-app"
+    },
+    {
+      "path": "ts-custom-app"
+    }
+  ]
+}

--- a/test-packages/ts-custom-app/.gitignore
+++ b/test-packages/ts-custom-app/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.tsbuildinfo

--- a/test-packages/ts-custom-app/.glintrc.yml
+++ b/test-packages/ts-custom-app/.glintrc.yml
@@ -1,0 +1,1 @@
+environment: custom-test

--- a/test-packages/ts-custom-app/package.json
+++ b/test-packages/ts-custom-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ts-custom-app",
+  "version": "0.6.3",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "lint": "true",
+    "test": "glint"
+  }
+}

--- a/test-packages/ts-custom-app/src/index.custom
+++ b/test-packages/ts-custom-app/src/index.custom
@@ -1,0 +1,1 @@
+let x: number = 123;

--- a/test-packages/ts-custom-app/tsconfig.json
+++ b/test-packages/ts-custom-app/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.compileroptions.json",
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,6 +2518,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/vscode@^1.52.0":
   version "1.53.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.53.0.tgz#47b53717af6562f2ad05171bc9c8500824a3905c"


### PR DESCRIPTION
## Overview

This PR enables Glint environments to declare that additional file extensions should be supported when typechecking projects.

Note that this change does _not_ allow for custom syntax yet—files with custom extensions must nevertheless still be valid JS/TS or Handlebars, depending on the extension's declared kind. Support for preprocessing of custom extensions will come in a following PR; there was enough complexity in this change to warrant landing it on its own.

## Details

There are two major changes here, and the rest is largely adapting to those changes as they ripple out through the codebase.

The first is introducing a notion of custom extension configuration to `GlintEnvironment`, allowing the active environment to answer questions like "is this file a template?". This in turn means the rest of Glint needs to refer to the environment to determine how to treat different files, rather than using static utility functions.

The second change is updating the `DocumentCache` to allow a many-to-one mapping of paths to a single document, which corresponds to an actual resolvable module. For instance, with the GJS proposal, `components/foo.gts` and `components/foo.ts` would both correspond to the import specifier `components/foo`, and at runtime only one of them would 'win out' if both were present. Even putting the potential for conflict resolution aside, the TS language service deals exclusively in `.js` and `.ts` files, so when we see `foo.gts` on disk, we present it to the language service as `foo.ts`, meaning we must later be able to map back to `foo.gts` when we get e.g. a diagnostic for that module from the language service.

In addition to those two changes in Glint itself, this PR also introduces `test-packages/glint-environment-custom-test` and `test-packages/ts-custom-app`. The former is a Glint environment that defines a `.custom` file extension which is treated as TS, and the latter is a test application that makes use of that environment.