### PR TITLE
Overhaul global scope management

### DIFF
--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -7,7 +7,7 @@ describe('Environments', () => {
     test('locating a single tag', () => {
       let env = new GlintEnvironment(['test-env'], {
         tags: {
-          'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
+          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
         },
       });
 
@@ -19,9 +19,9 @@ describe('Environments', () => {
     test('locating one of several tags', () => {
       let env = new GlintEnvironment(['test-env'], {
         tags: {
-          'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
-          'another-env': { tagMe: { capturesOuterScope: false, typesSource: 'over-here' } },
-          'and-this-one': { hbs: { capturesOuterScope: false, typesSource: '✨' } },
+          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
+          'another-env': { tagMe: { typesSource: 'over-here' } },
+          'and-this-one': { hbs: { typesSource: '✨' } },
         },
       });
 
@@ -33,7 +33,7 @@ describe('Environments', () => {
     test('checking a module with no tags in use', () => {
       let env = new GlintEnvironment(['test-env'], {
         tags: {
-          'my-cool-environment': { hbs: { capturesOuterScope: false, typesSource: 'whatever' } },
+          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
         },
       });
 
@@ -46,7 +46,6 @@ describe('Environments', () => {
       let tags = {
         '@glimmerx/component': {
           hbs: {
-            capturesOuterScope: false,
             typesSource: '@glint/environment-glimmerx/-private/dsl',
           },
         },

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -3,7 +3,7 @@ import { Minimatch, IMinimatch } from 'minimatch';
 import { GlintEnvironment } from './environment';
 
 export type GlintConfigInput = {
-  environment: string | Array<string>;
+  environment: string | Array<string> | Record<string, unknown>;
   checkStandaloneTemplates?: boolean;
   include?: string | Array<string>;
   exclude?: string | Array<string>;
@@ -90,8 +90,10 @@ function validateConfigInput(input: Record<string, unknown>): asserts input is G
   assert(
     Array.isArray(input['environment'])
       ? input['environment'].every((env) => typeof env === 'string')
-      : typeof input['environment'] === 'string',
-    'Glint config must specify an `environment` that is a string or an array of strings'
+      : typeof input['environment'] === 'string' ||
+          (typeof input['environment'] === 'object' && input['environment']),
+    'Glint config must specify an `environment` that is a string, array of strings, or an object ' +
+      'mapping environment names to their config.'
   );
 
   assert(

--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -25,7 +25,7 @@ export type GlintExtensionsConfig = {
 
 export type GlintTagConfig = {
   typesSource: string;
-  capturesOuterScope: boolean;
+  globals?: Array<string>;
 };
 
 export type GlintTagsConfig = {

--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -16,21 +16,21 @@ describe('Language Server: Completions', () => {
 
   test('querying a standalone template', () => {
     project.write('.glintrc', 'environment: ember-loose');
-    project.write('index.hbs', '<Foo as |foo|>{{fo}}</Foo>');
+    project.write('index.hbs', '<LinkT />');
 
     let server = project.startLanguageServer();
     let completions = server.getCompletions(project.fileURI('index.hbs'), {
       line: 0,
-      character: 17,
+      character: 6,
     });
 
-    let completion = completions?.find((item) => item.label === 'foo');
+    let completion = completions?.find((item) => item.label === 'LinkTo');
 
-    expect(completion?.kind).toEqual(CompletionItemKind.Variable);
+    expect(completion?.kind).toEqual(CompletionItemKind.Field);
 
     let details = server.getCompletionDetails(completion!);
 
-    expect(details.detail).toEqual('const foo: any');
+    expect(details.detail).toEqual('(property) Globals.LinkTo: LinkToComponent');
   });
 
   test('passing component args', () => {
@@ -151,33 +151,6 @@ describe('Language Server: Completions', () => {
     let details = server.getCompletionDetails(letterCompletion!);
 
     expect(details.detail).toEqual('const letter: string');
-  });
-
-  test('globals', () => {
-    let code = stripIndent`
-      import Component, { hbs } from '@glint/environment-glimmerx/component';
-
-      export default class MyComponent extends Component {
-        static template = hbs\`
-          {{deb}}
-        \`;
-      }
-    `;
-
-    project.write('index.ts', code);
-
-    let server = project.startLanguageServer();
-    let completions = server.getCompletions(project.fileURI('index.ts'), {
-      line: 4,
-      character: 9,
-    });
-
-    let completion = completions?.find((completion) => completion.label === 'debugger');
-
-    expect(completion).toMatchObject({
-      kind: CompletionItemKind.Field,
-      label: 'debugger',
-    });
   });
 
   test('referencing module-scope identifiers', async () => {

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -17,7 +17,6 @@ export default function glimmerxEnvironment(): GlintEnvironmentConfig {
       'ember-cli-htmlbars': {
         hbs: {
           typesSource: '@glint/environment-ember-loose/-private/dsl',
-          capturesOuterScope: false,
         },
       },
     },

--- a/packages/environment-glimmerx/-private/environment/index.ts
+++ b/packages/environment-glimmerx/-private/environment/index.ts
@@ -1,20 +1,33 @@
-import { GlintEnvironmentConfig } from '@glint/config';
+import { GlintEnvironmentConfig, GlintTagConfig } from '@glint/config';
 
-export default function glimmerxEnvironment(): GlintEnvironmentConfig {
+export default function glimmerxEnvironment(
+  config: Record<string, unknown>
+): GlintEnvironmentConfig {
+  let additionalGlobals = Array.isArray(config['additionalGlobals'])
+    ? config['additionalGlobals']
+    : [];
+
+  let tagConfig: GlintTagConfig = {
+    typesSource: '@glint/environment-glimmerx/-private/dsl',
+    globals: [
+      'debugger',
+      'each',
+      'has-block',
+      'has-block-params',
+      'if',
+      'in-element',
+      'let',
+      'unless',
+      'with',
+      'yield',
+      ...additionalGlobals,
+    ],
+  };
+
   return {
     tags: {
-      '@glimmerx/component': {
-        hbs: {
-          typesSource: '@glint/environment-glimmerx/-private/dsl',
-          capturesOuterScope: true,
-        },
-      },
-      '@glint/environment-glimmerx/component': {
-        hbs: {
-          typesSource: '@glint/environment-glimmerx/-private/dsl',
-          capturesOuterScope: true,
-        },
-      },
+      '@glimmerx/component': { hbs: tagConfig },
+      '@glint/environment-glimmerx/component': { hbs: tagConfig },
     },
   };
 }

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -14,18 +14,11 @@ describe('Source-to-source offset mapping', () => {
     transformedModule: TransformedModule;
   };
 
-  function rewriteInlineTemplate({
-    contents,
-    identifiersInScope = [],
-  }: {
-    contents: string;
-    identifiersInScope?: string[];
-  }): RewrittenTestModule {
+  function rewriteInlineTemplate({ contents }: { contents: string }): RewrittenTestModule {
     let script = {
       filename: 'test.ts',
       contents: stripIndent`
         import Component, { hbs } from '@glint/environment-glimmerx/component';
-        import { ${identifiersInScope.join(', ')} } from 'dummy';
 
         export default class MyComponent extends Component {
           static template = hbs\`
@@ -180,7 +173,6 @@ describe('Source-to-source offset mapping', () => {
     describe('path segments', () => {
       test('simple in-scope paths', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['foo'],
           contents: '{{foo.bar}}',
         });
         expectTokenMapping(module, 'foo');
@@ -217,7 +209,6 @@ describe('Source-to-source offset mapping', () => {
     describe('keys', () => {
       test('named params to mustaches', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['foo', 'hello'],
           contents: '{{foo bar=hello}}',
         });
         expectTokenMapping(module, 'foo');
@@ -227,7 +218,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('named spinal-case params to mustaches', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['foo', 'hello'],
           contents: '{{foo bar-baz=hello}}',
         });
         expectTokenMapping(module, 'foo');
@@ -237,7 +227,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('component args', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['Foo', 'hello'],
           contents: '<Foo @bar={{hello}} />',
         });
         expectTokenMapping(module, 'Foo');
@@ -247,7 +236,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('spinal-case component args', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['Foo', 'hello'],
           contents: '<Foo @bar-baz={{hello}} />',
         });
         expectTokenMapping(module, 'Foo');
@@ -257,7 +245,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('named blocks', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['Foo'],
           contents: '<Foo><:blockName>hi</:blockName></Foo>',
         });
         expectTokenMapping(module, 'Foo');
@@ -266,7 +253,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('spinal-case named blocks', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['Foo'],
           contents: '<Foo><:block-name>hi</:block-name></Foo>',
         });
         expectTokenMapping(module, 'Foo');
@@ -294,7 +280,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('angle bracket params', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['Foo'],
           contents: '<Foo as |bar baz|></Foo>',
         });
         expectTokenMapping(module, 'Foo');
@@ -306,7 +291,6 @@ describe('Source-to-source offset mapping', () => {
     describe('block mustaches', () => {
       test('simple identifiers', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['foo'],
           contents: '{{#foo}}{{/foo}}',
         });
         expectTokenMapping(module, 'foo', { occurrence: 0 });
@@ -315,7 +299,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('simple paths', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['foo'],
           contents: '{{#foo.bar}}{{/foo.bar}}',
         });
         expectTokenMapping(module, 'foo', { occurrence: 0 });
@@ -344,7 +327,6 @@ describe('Source-to-source offset mapping', () => {
     describe('angle bracket components', () => {
       test('simple identifiers', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['Foo'],
           contents: '<Foo></Foo>',
         });
         expectTokenMapping(module, 'Foo', { occurrence: 0 });
@@ -353,7 +335,6 @@ describe('Source-to-source offset mapping', () => {
 
       test('simple paths', () => {
         let module = rewriteInlineTemplate({
-          identifiersInScope: ['foo'],
           contents: '<foo.bar></foo.bar>',
         });
         expectTokenMapping(module, 'foo', { occurrence: 0 });
@@ -490,8 +471,8 @@ describe('Diagnostic offset mapping', () => {
       code,
       messageText,
       file: transformedContentsFile,
-      start: transformedModule.transformedContents.indexOf('"foo"'),
-      length: 5,
+      start: transformedModule.transformedContents.indexOf('foo'),
+      length: 3,
     };
 
     let rewritten = rewriteDiagnostic(ts, original, () => transformedModule);

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -117,8 +117,9 @@ describe('rewriteModule', () => {
       let testEnvironment = new GlintEnvironment(['test'], {
         tags: {
           '@glint/test-env': {
-            hbsCapture: { typesSource: '@glint/test-env', capturesOuterScope: true },
-            hbsIgnore: { typesSource: '@glint/test-env', capturesOuterScope: false },
+            hbsCaptureAll: { typesSource: '@glint/test-env', globals: [] },
+            hbsCaptureSome: { typesSource: '@glint/test-env', globals: ['global'] },
+            hbsCaptureNone: { typesSource: '@glint/test-env' },
           },
         },
       });
@@ -126,12 +127,13 @@ describe('rewriteModule', () => {
       let script = {
         filename: 'test.ts',
         contents: stripIndent`
-          import { hbsCapture, hbsIgnore } from '@glint/test-env';
+          import { hbsCaptureAll, hbsCaptureSome, hbsCaptureNone } from '@glint/test-env';
 
           const message = 'hello';
 
-          hbsCapture\`{{message}}\`;
-          hbsIgnore\`{{message}}\`;
+          hbsCaptureAll\`{{global}} {{message}}\`;
+          hbsCaptureSome\`{{global}} {{message}}\`;
+          hbsCaptureNone\`{{global}} {{message}}\`;
         `,
       };
 
@@ -139,17 +141,25 @@ describe('rewriteModule', () => {
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
-        "import { hbsCapture, hbsIgnore } from '@glint/test-env';
+        "import { hbsCaptureAll, hbsCaptureSome, hbsCaptureNone } from '@glint/test-env';
 
         const message = 'hello';
 
         ({} as typeof import(\\"@glint/test-env\\")).template(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
-          hbsCapture;
+          hbsCaptureAll;
+          χ.emitValue(χ.resolveOrReturn(global)({}));
           χ.emitValue(χ.resolveOrReturn(message)({}));
           𝚪; χ;
         });
         ({} as typeof import(\\"@glint/test-env\\")).template(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
-          hbsIgnore;
+          hbsCaptureSome;
+          χ.emitValue(χ.resolveOrReturn(χ.Globals[\\"global\\"])({}));
+          χ.emitValue(χ.resolveOrReturn(message)({}));
+          𝚪; χ;
+        });
+        ({} as typeof import(\\"@glint/test-env\\")).template(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
+          hbsCaptureNone;
+          χ.emitValue(χ.resolveOrReturn(χ.Globals[\\"global\\"])({}));
           χ.emitValue(χ.resolveOrReturn(χ.Globals[\\"message\\"])({}));
           𝚪; χ;
         });"

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -390,7 +390,7 @@ describe('rewriteTemplate', () => {
           {{log (array 1 true "free")}}
         `;
 
-        expect(templateBody(template, { identifiersInScope: ['log'] })).toMatchInlineSnapshot(
+        expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
           `"χ.emitValue(χ.resolve(log)({}, [1, true, \\"free\\"]));"`
         );
       });
@@ -423,7 +423,7 @@ describe('rewriteTemplate', () => {
           {{log (hash a=1 b="ok")}}
         `;
 
-        expect(templateBody(template, { identifiersInScope: ['log'] })).toMatchInlineSnapshot(`
+        expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
           "χ.emitValue(χ.resolve(log)({}, ({
             a: 1,
             b: \\"ok\\",
@@ -445,28 +445,25 @@ describe('rewriteTemplate', () => {
         });
 
         test('in-scope identifier', () => {
-          let identifiersInScope = ['message'];
           let template = '{{message}}';
 
-          expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(
+          expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
             `"χ.emitValue(χ.resolveOrReturn(message)({}));"`
           );
         });
 
         test('chained path', () => {
-          let identifiersInScope = ['obj'];
           let template = '{{obj.foo.bar}}';
 
-          expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(
+          expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
             `"χ.emitValue(χ.resolveOrReturn(obj?.foo?.bar)({}));"`
           );
         });
 
         test('chained path with a spinal-case key', () => {
-          let identifiersInScope = ['obj'];
           let template = '{{obj.foo-bar.baz}}';
 
-          expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(
+          expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
             `"χ.emitValue(χ.resolveOrReturn(obj?.[\\"foo-bar\\"]?.baz)({}));"`
           );
         });
@@ -496,10 +493,9 @@ describe('rewriteTemplate', () => {
         });
 
         test('passed as an attr', () => {
-          let identifiersInScope = ['Foo', 'helper'];
           let template = '<Foo data-bar={{helper param=true}} />';
 
-          expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+          expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
             "{
               const 𝛄 = χ.emitComponent(χ.resolve(Foo)({}));
               χ.applyAttributes(𝛄.element, {
@@ -510,10 +506,9 @@ describe('rewriteTemplate', () => {
         });
 
         test('passed as an @arg', () => {
-          let identifiersInScope = ['Foo', 'helper'];
           let template = '<Foo @bar={{helper param=true}} />';
 
-          expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+          expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
             "{
               const 𝛄 = χ.emitComponent(χ.resolve(Foo)({ bar: χ.resolve(helper)({ param: true }) }));
               𝛄;
@@ -558,10 +553,9 @@ describe('rewriteTemplate', () => {
         });
 
         test('as an @arg value', () => {
-          let identifiersInScope = ['Greet'];
           let template = '<Greet @message={{@arg}} />';
 
-          expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+          expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
             "{
               const 𝛄 = χ.emitComponent(χ.resolve(Greet)({ message: 𝚪.args.arg }));
               𝛄;
@@ -607,28 +601,25 @@ describe('rewriteTemplate', () => {
 
     describe('helper and inline-curly component invocations', () => {
       test('positional params', () => {
-        let identifiersInScope = ['doSomething'];
         let template = '{{doSomething "hello" 123}}';
 
-        expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(
+        expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
           `"χ.emitValue(χ.resolve(doSomething)({}, \\"hello\\", 123));"`
         );
       });
 
       test('named params', () => {
-        let identifiersInScope = ['doSomething'];
         let template = '{{doSomething a=123 b="ok"}}';
 
-        expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(
+        expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
           `"χ.emitValue(χ.resolve(doSomething)({ a: 123, b: \\"ok\\" }));"`
         );
       });
 
       test('named and positional params', () => {
-        let identifiersInScope = ['doSomething'];
         let template = '{{doSomething "one" true 3 four=4}}';
 
-        expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(
+        expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(
           `"χ.emitValue(χ.resolve(doSomething)({ four: 4 }, \\"one\\", true, 3));"`
         );
       });
@@ -637,10 +628,9 @@ describe('rewriteTemplate', () => {
 
   describe('modifiers', () => {
     test('on a plain element', () => {
-      let identifiersInScope = ['modifier'];
       let template = `<div {{modifier foo="bar"}}></div>`;
 
-      expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+      expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitElement(\\"div\\");
           χ.applyModifier(𝛄.element, χ.resolve(modifier)({ foo: \\"bar\\" }));
@@ -649,10 +639,9 @@ describe('rewriteTemplate', () => {
     });
 
     test('on a component', () => {
-      let identifiersInScope = ['MyComponent', 'modifier'];
       let template = `<MyComponent {{modifier foo="bar"}}/>`;
 
-      expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+      expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(MyComponent)({}));
           χ.applyModifier(𝛄.element, χ.resolve(modifier)({ foo: \\"bar\\" }));
@@ -663,10 +652,9 @@ describe('rewriteTemplate', () => {
 
   describe('subexpressions', () => {
     test('resolution', () => {
-      let identifiersInScope = ['concat', 'foo'];
       let template = `<div data-attr={{concat (foo 1) (foo true)}}></div>`;
 
-      expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+      expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitElement(\\"div\\");
           χ.applyAttributes(𝛄.element, {
@@ -835,10 +823,9 @@ describe('rewriteTemplate', () => {
     });
 
     test('with splattributes', () => {
-      let identifiersInScope = ['Foo'];
       let template = '<Foo ...attributes />';
 
-      expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+      expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(Foo)({}));
           χ.applySplattributes(𝚪.element, 𝛄.element);
@@ -847,10 +834,9 @@ describe('rewriteTemplate', () => {
     });
 
     test('with a path for a name', () => {
-      let identifiersInScope = ['foo'];
       let template = '<foo.bar @arg="hello" />';
 
-      expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+      expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(foo?.bar)({ arg: \\"hello\\" }));
           𝛄;
@@ -918,10 +904,9 @@ describe('rewriteTemplate', () => {
     });
 
     test('with concat args', () => {
-      let identifiersInScope = ['Foo', 'baz'];
       let template = `<Foo @arg="bar-{{baz}}" />`;
 
-      expect(templateBody(template, { identifiersInScope })).toMatchInlineSnapshot(`
+      expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitComponent(χ.resolve(Foo)({ arg: \`\${χ.emitValue(χ.resolveOrReturn(baz)({}))}\` }));
           𝛄;

--- a/packages/transform/src/inlining/tagged-strings.ts
+++ b/packages/transform/src/inlining/tagged-strings.ts
@@ -21,7 +21,7 @@ export function calculateTaggedTemplateSpans(
 
   let tagConfig = getConfigForTag(tag, environment);
   if (tagConfig) {
-    let { typesSource, capturesOuterScope } = tagConfig;
+    let { typesSource, globals } = tagConfig;
     let tagName = tag.node.name;
     let { quasis } = path.node.quasi;
 
@@ -44,11 +44,10 @@ export function calculateTaggedTemplateSpans(
     let preamble = [`${tagName};`];
 
     let { inClass, className, typeParams, contextType } = getContainingTypeInfo(path);
-    let identifiersInScope = capturesOuterScope ? Object.keys(path.scope.getAllBindings()) : [];
     let transformedTemplate = templateToTypescript(template, {
       typesPath: typesSource,
       preamble,
-      identifiersInScope,
+      globals,
       typeParams,
       contextType,
       useJsDoc: environment.isUntypedScript(script.filename),

--- a/packages/transform/src/scope-stack.ts
+++ b/packages/transform/src/scope-stack.ts
@@ -28,20 +28,6 @@ export default class ScopeStack {
     return this.top.has(identifier);
   }
 
-  public hasMatchingBinding(prefix: string): boolean {
-    if (this.hasBinding(prefix)) {
-      return true;
-    }
-
-    for (let identifier of this.top) {
-      if (identifier.startsWith(prefix)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   private get top(): Set<string> {
     return this.stack[0];
   }


### PR DESCRIPTION
## Overview

This change overhauls the way environments declare how their exported tags handle assumptions about scope capture and template globals.

Today, we track the set of statically-known identifiers in scope as we traverse a template, potentially seeding that scope with the available set of JS identifiers depending on whether the environment's tag config declares `capturesOuterScope: true`. We then assume anything that _doesn't_ appear in that scope must be global.

## The Problem

Today's approach largely works, but by default it means autocomplete doesn't work for non-global identifiers, since upon seeing `{{fo}}` we'd emit `Globals['fo']` even if `foo` is an in-scope block param. We've baked in some heuristic workarounds for this, but they lead to issues like #182.

Additionally, this approach requires us to do a full scope analysis of every JS/TS file we parse in order to populate the initial set of in-scope variables for a template. Babel spends a nontrivial amount of time doing this analysis for us.

## This Change

With this change, environments that support scope capture (like GlimmerX) can now supply a static list of known globals, allowing us to assume anything else is a local identifier without needing to do scope analysis. Environments that have no scope capture and instead rely on global resolution (like loose-mode Ember) can provide no `globals` array and have everything assumed global as today (though without the problematic heuristic mentioned above).

## Technical Details

This is a breaking change in that it alters the public interface that environment packages expose to Glint in a backwards-incompatible way. It will also produce slightly different behavior for completions in strict-mode environments.

One notable caveat to this change is that strict-mode environments must be able to statically enumerate the template globals they make available. If a consumer adds additional globals (either by registering them with the VM at runtime or as build-time template macros), they need a way to inform the environment of that. Accordingly, this PR also allows environments to accept custom configuration.

```yml
# Today's setup; will continue to work:
environment: glimmerx

# With this change, users can also do the following:
environment:
  glimmerx:
    additionalGlobals: ['abc', 'def']
```

In anticipation of environment-specific configuration, environments today already export a function that returns their definition. With this change, that function will receive any custom user config (or `{}` otherwise) as its first argument when invoked. The GlimmerX environment has been updated to accept exactly the `additionalGlobals` config as shown here, but any arbitrary key-value data will be passed along.

Fixes #182 