### PR TITLE
Use TS for script parsing rather than Babel

### DIFF
--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -297,7 +297,7 @@ export default class TransformManager {
               }
             : undefined;
 
-          transformedModule = rewriteModule({ script, template }, environment);
+          transformedModule = rewriteModule(this.ts, { script, template }, environment);
         }
       } else {
         let templatePath = templatePathForSynthesizedModule(filename);
@@ -313,7 +313,7 @@ export default class TransformManager {
             contents: documents.getDocumentContents(templatePath, encoding),
           };
 
-          transformedModule = rewriteModule({ script, template }, glintConfig.environment);
+          transformedModule = rewriteModule(this.ts, { script, template }, glintConfig.environment);
         }
       }
     }

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -1,3 +1,4 @@
+import ts from 'typescript';
 import { rewriteModule } from '../src';
 import { stripIndent } from 'common-tags';
 import { GlintEnvironment } from '@glint/config';
@@ -26,6 +27,7 @@ describe('Debug utilities', () => {
       };
 
       let transformedModule = rewriteModule(
+        ts,
         { script, template },
         GlintEnvironment.load('ember-loose')
       );
@@ -174,7 +176,7 @@ describe('Debug utilities', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script }, GlintEnvironment.load('glimmerx'));
+      let transformedModule = rewriteModule(ts, { script }, GlintEnvironment.load('glimmerx'));
 
       expect(transformedModule?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
@@ -305,7 +307,7 @@ describe('Debug utilities', () => {
         `.replace(/\n/g, '\r\n'),
       };
 
-      let transformedModule = rewriteModule({ script }, GlintEnvironment.load('glimmerx'));
+      let transformedModule = rewriteModule(ts, { script }, GlintEnvironment.load('glimmerx'));
 
       expect(transformedModule?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -28,7 +28,7 @@ describe('Source-to-source offset mapping', () => {
       `,
     };
 
-    let transformedModule = rewriteModule({ script }, glimmerxEnvironment);
+    let transformedModule = rewriteModule(ts, { script }, glimmerxEnvironment);
     if (!transformedModule) {
       throw new Error('Expected module to have rewritten contents');
     }
@@ -58,7 +58,7 @@ describe('Source-to-source offset mapping', () => {
       contents: contents,
     };
 
-    let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+    let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
     if (!transformedModule) {
       throw new Error('Expected module to have rewritten contents');
     }
@@ -398,7 +398,7 @@ describe('Source-to-source offset mapping', () => {
       `,
     };
 
-    const rewritten = rewriteModule({ script: source }, glimmerxEnvironment)!;
+    const rewritten = rewriteModule(ts, { script: source }, glimmerxEnvironment)!;
 
     test('bounds that cross a rewritten span', () => {
       let originalStart = source.contents.indexOf('// start');
@@ -458,7 +458,7 @@ describe('Diagnostic offset mapping', () => {
     `,
   };
 
-  const transformedModule = rewriteModule({ script: source }, glimmerxEnvironment);
+  const transformedModule = rewriteModule(ts, { script: source }, glimmerxEnvironment);
   assert(transformedModule);
 
   test('without related information', () => {
@@ -540,7 +540,7 @@ describe('Diagnostic offset mapping', () => {
       `,
     };
 
-    let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment)!;
+    let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment)!;
     let category = ts.DiagnosticCategory.Error;
     let messageText = '`foo-bar` is no good';
     let code = 1234;

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -1,3 +1,4 @@
+import ts from 'typescript';
 import { rewriteModule } from '../src';
 import { stripIndent } from 'common-tags';
 import { GlintEnvironment } from '@glint/config';
@@ -17,7 +18,7 @@ describe('rewriteModule', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script }, glimmerxEnvironment);
+      let transformedModule = rewriteModule(ts, { script }, glimmerxEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -42,7 +43,7 @@ describe('rewriteModule', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script }, glimmerxEnvironment);
+      let transformedModule = rewriteModule(ts, { script }, glimmerxEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -67,7 +68,7 @@ describe('rewriteModule', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script }, glimmerxEnvironment);
+      let transformedModule = rewriteModule(ts, { script }, glimmerxEnvironment);
 
       expect(transformedModule?.errors).toEqual([
         {
@@ -104,7 +105,7 @@ describe('rewriteModule', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script }, glimmerxEnvironment);
+      let transformedModule = rewriteModule(ts, { script }, glimmerxEnvironment);
 
       expect(transformedModule?.errors.length).toBe(1);
       expect(transformedModule?.transformedContents).toBe(script.contents);
@@ -137,7 +138,7 @@ describe('rewriteModule', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script }, testEnvironment);
+      let transformedModule = rewriteModule(ts, { script }, testEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -185,7 +186,7 @@ describe('rewriteModule', () => {
         contents: stripIndent``,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -214,7 +215,7 @@ describe('rewriteModule', () => {
         contents: stripIndent``,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -243,7 +244,7 @@ describe('rewriteModule', () => {
         contents: stripIndent``,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -271,14 +272,14 @@ describe('rewriteModule', () => {
         contents: stripIndent``,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([
         {
           message: 'Classes with an associated template must have a name',
           source: script,
           location: {
-            start: script.contents.indexOf('class'),
+            start: script.contents.indexOf('export default'),
             end: script.contents.lastIndexOf('}') + 1,
           },
         },
@@ -308,7 +309,7 @@ describe('rewriteModule', () => {
         contents: stripIndent`{{hello}}`,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -337,7 +338,7 @@ describe('rewriteModule', () => {
         contents: stripIndent``,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -364,15 +365,15 @@ describe('rewriteModule', () => {
         contents: stripIndent`{{hello}}`,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "export default Foo;
-        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<typeof import('./test').default>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           χ.emitValue(χ.resolveOrReturn(χ.Globals[\\"hello\\"])({}));
           𝚪; χ;
-        });
+        }) as unknown;
         "
       `);
     });
@@ -397,7 +398,7 @@ describe('rewriteModule', () => {
         contents: stripIndent``,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
@@ -432,7 +433,7 @@ describe('rewriteModule', () => {
         `,
       };
 
-      let transformedModule = rewriteModule({ script, template }, emberLooseEnvironment);
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
       expect(transformedModule?.errors.length).toBe(1);
       expect(transformedModule?.transformedContents).toBe(script.contents);

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -18,14 +18,10 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@babel/core": "^7.11.6",
-    "@babel/plugin-proposal-decorators": "7.10.5",
-    "@babel/preset-typescript": "^7.10.4",
     "@glimmer/syntax": "^0.68.1",
     "@glint/config": "^0.6.3"
   },
   "devDependencies": {
-    "@types/babel__core": "^7.1.7",
     "@types/common-tags": "^1.8.0",
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.13",

--- a/packages/transform/src/util.ts
+++ b/packages/transform/src/util.ts
@@ -1,6 +1,8 @@
 import type ts from 'typescript';
 import { SourceFile } from './transformed-module';
 
+export type TSLib = typeof ts;
+
 export function unreachable(value: never, message = 'unreachable code'): never {
   throw new Error(`[@glint/transform] Internal error: ${message}`);
 }
@@ -11,8 +13,8 @@ export function assert(test: unknown, message = 'Internal error'): asserts test 
   }
 }
 
-export function createSyntheticSourceFile(tsImpl: typeof ts, source: SourceFile): ts.SourceFile {
-  return Object.assign(tsImpl.createSourceFile(source.filename, '', tsImpl.ScriptTarget.Latest), {
+export function createSyntheticSourceFile(ts: TSLib, source: SourceFile): ts.SourceFile {
+  return Object.assign(ts.createSourceFile(source.filename, '', ts.ScriptTarget.Latest), {
     text: source.contents,
     end: source.contents.length,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
   integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
 
-"@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.11.6", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.13.8", "@babel/core@^7.3.4", "@babel/core@^7.5.5", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
+"@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.13.8", "@babel/core@^7.3.4", "@babel/core@^7.5.5", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
   integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
@@ -69,7 +69,7 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.10.5", "@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.14.6", "@babel/helper-create-class-features-plugin@^7.5.5", "@babel/helper-create-class-features-plugin@^7.8.3":
+"@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.14.6", "@babel/helper-create-class-features-plugin@^7.5.5", "@babel/helper-create-class-features-plugin@^7.8.3":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz#f114469b6c06f8b5c59c6c4e74621f5085362542"
   integrity sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==
@@ -282,15 +282,6 @@
     "@babel/helper-create-class-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-proposal-decorators@7.10.5":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.5.tgz#42898bba478bc4b1ae242a703a953a7ad350ffb4"
-  integrity sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.10.5"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-decorators" "^7.10.4"
-
 "@babel/plugin-proposal-decorators@^7.13.5", "@babel/plugin-proposal-decorators@^7.8.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.14.5.tgz#59bc4dfc1d665b5a6749cf798ff42297ed1b2c1d"
@@ -411,7 +402,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-decorators@^7.10.4", "@babel/plugin-syntax-decorators@^7.14.5":
+"@babel/plugin-syntax-decorators@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.14.5.tgz#eafb9c0cbe09c8afeb964ba3a7bbd63945a72f20"
   integrity sha512-c4sZMRWL4GSvP1EXy0woIP7m4jkVcEuG8R1TOZxPBPtp4FSM/kiPZub9UIs/Jrb5ZAOzvTUSGYrWsrSu1JvoPw==
@@ -896,7 +887,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-typescript@^7.10.1", "@babel/preset-typescript@^7.10.4":
+"@babel/preset-typescript@^7.10.1":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.10.4.tgz#7d5d052e52a682480d6e2cc5aa31be61c8c25e36"
   integrity sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==


### PR DESCRIPTION
## Background

Today we use Babel to parse files we expect to need to perform transformation on. This brings some niceties, like a sensible AST design and built-in scope analysis that allows us to ask questions like "does identifier _X_ refer to export _Y_ from module _Z_?".

However, it also comes with costs. Version drift in Babel has produced issues like #244, and even with the work in #95 to minimize extra work the parser does, Babel's `parseSync` is roughly 7-8x slower than TypeScript's `createSourceFile`.

<details>
<summary>The quick, totally unscientific comparison</summary>

Comparing 5000 runs of:

```js
babel.parseSync(source, {
  filename: 'test.ts',
  babelrc: false,
  configFile: false,
  code: false,
  presets: ['@babel/preset-typescript']
});
```

To:

```js
ts.createSourceFile(
  source,
  'test.ts',
  ts.ScriptTarget.Latest,
  true /* setParentNodes */
);
```

Where `source` is the string containing:
```ts
import Component, { hbs } from '@glimmerx/component';

export interface GreetingSignature {
  Args: { message: string; target?: string };
}

export default class Greeting extends Component<GreetingSignature> {
  private get target(): string {
    return this.args.target ?? 'World';
  }

  public static template = hbs`
    {{@message}}, {{this.target}}!
  `;
}
```
</details>

## This Change

This PR removes all use of Babel from Glint, instead relying on TypeScript itself for parsing.

By dropping Babel, we eliminate a large chunk of our runtime dependency tree, along with the associated weight and potential for drift that come with that. The tradeoff, however, is that we now need to do a certain amount of analysis ourselves that Babel previously did for us automatically.

The particular place this is noticeable is in the code where we locate the component class that a standalone `.hbs` template should be associated with. Authoring components like this is common enough in the community that we want to make sure we support it rather than insisting on `export default class ...`:

```ts
class MyComponent extends Component {
  // ...
}

// ...

export default MyComponent;
```

Previously, we could interrogate Babel for the scope where the exported `MyComponent` identifier resides to find out whether it pointed to another declaration in the module. Now we need to do that legwork ourselves, though that ultimately still requires far less work than the full scope analysis Babel performs during parsing.

Bonus good thing: the Babel types can produce horrible (re)check times during editing, so getting those out is a DX win for anyone working on Glint.
Bonus less-good thing: I personally find a lot of TypeScript's AST design choices pretty weird and unintuitive (e.g. `export default` and `export =` are the same node type), but in the end ASTExplorer has us covered, so this isn't a huge deal.