### PR TITLE
Handle FS events more robustly

### DIFF
--- a/packages/core/__tests__/cli/custom-extensions.test.ts
+++ b/packages/core/__tests__/cli/custom-extensions.test.ts
@@ -1,0 +1,124 @@
+import { stripIndent } from 'common-tags';
+import stripAnsi from 'strip-ansi';
+import os from 'os';
+import Project from '../utils/project';
+
+describe('CLI: custom extensions', () => {
+  let project!: Project;
+  beforeEach(async () => {
+    jest.setTimeout(20_000);
+    project = await Project.create();
+  });
+
+  afterEach(async () => {
+    await project.destroy();
+  });
+
+  test('reporting one-shot diagnostics', async () => {
+    let code = 'let identifier: string = 123;';
+
+    project.write('.glintrc', 'environment: custom-test');
+    project.write('index.custom', code);
+
+    let result = await project.check({ reject: false });
+
+    expect(result.exitCode).toBe(1);
+    expect(stripAnsi(result.stderr)).toMatchInlineSnapshot(`
+      "index.custom:1:5 - error TS2322: Type 'number' is not assignable to type 'string'.
+
+      1 let identifier: string = 123;
+            ~~~~~~~~~~
+      "
+    `);
+  });
+
+  test('reporting watched diagnostics', async () => {
+    let code = 'let identifier: string = 123;';
+
+    project.write('.glintrc', 'environment: custom-test');
+    project.write('index.custom', code);
+
+    let watch = project.watch();
+    let output = await watch.awaitOutput('Watching for file changes.');
+
+    await watch.terminate();
+
+    let stripped = stripAnsi(output);
+    let error = stripped.slice(
+      stripped.indexOf('index.custom'),
+      stripped.lastIndexOf(`~~~${os.EOL}`) + 3
+    );
+
+    expect(output).toMatch('Found 1 error.');
+    expect(error.replace(/\r/g, '')).toMatchInlineSnapshot(`
+      "index.custom:1:5 - error TS2322: Type 'number' is not assignable to type 'string'.
+
+      1 let identifier: string = 123;
+            ~~~~~~~~~~"
+    `);
+  });
+
+  describe('external file changes', () => {
+    beforeEach(() => {
+      project.write('.glintrc', `environment: custom-test`);
+      project.write(
+        'index.custom',
+        stripIndent`
+          import { foo } from "./other";
+          console.log(foo - 1);
+        `
+      );
+    });
+
+    test('adding a missing module', async () => {
+      let watch = project.watch();
+      let output = await watch.awaitOutput('Watching for file changes.');
+
+      expect(output).toMatch('Found 1 error.');
+      expect(output).toMatch(
+        "Cannot find module './other' or its corresponding type declarations."
+      );
+
+      project.write('other.custom', 'export const foo = 123;');
+
+      await watch.awaitOutput('Found 0 errors.');
+      await watch.terminate();
+    });
+
+    test('changing an imported module', async () => {
+      project.write('other.custom', 'export const foo = 123;');
+
+      let watch = project.watch();
+      let output = await watch.awaitOutput('Watching for file changes.');
+
+      expect(output).toMatch('Found 0 errors.');
+
+      project.write('other.custom', 'export const foo = "hi";');
+      output = await watch.awaitOutput('Watching for file changes.');
+
+      expect(output).toMatch('Found 1 error.');
+      expect(output).toMatch('TS2362');
+
+      await watch.terminate();
+    });
+
+    test('removing an imported module', async () => {
+      project.write('other.custom', 'export const foo = 123;');
+
+      let watch = project.watch();
+      let output = await watch.awaitOutput('Watching for file changes.');
+
+      expect(output).toMatch('Found 0 errors.');
+
+      project.remove('other.custom');
+      output = await watch.awaitOutput('Watching for file changes.');
+
+      expect(output).toMatch('Found 1 error.');
+      expect(output).toMatch(
+        "Cannot find module './other' or its corresponding type declarations."
+      );
+
+      await watch.terminate();
+    });
+  });
+});

--- a/packages/core/__tests__/language-server/custom-extensions.test.ts
+++ b/packages/core/__tests__/language-server/custom-extensions.test.ts
@@ -101,7 +101,7 @@ describe('Language Server: custom file extensions', () => {
     `);
 
     project.write('index.custom', contents.replace('"hello"', '123'));
-    server.fileDidChange(project.fileURI('index.custom'));
+    server.watchedFileDidChange(project.fileURI('index.custom'));
 
     hover = server.getHover(project.fileURI('index.custom'), { line: 0, character: 8 });
 
@@ -127,7 +127,7 @@ describe('Language Server: custom file extensions', () => {
     `);
   });
 
-  test('resolving conflicts beween overlapping extensions', () => {
+  test('resolving conflicts between overlapping extensions', () => {
     let contents = 'export let identifier = 123`;';
 
     project.write('.glintrc', `environment: custom-test`);
@@ -153,7 +153,7 @@ describe('Language Server: custom file extensions', () => {
     expect(diagnostics).toEqual([]);
 
     project.remove('index.ts');
-    server.fileDidChange(project.fileURI('index.ts'));
+    server.watchedFileDidChange(project.fileURI('index.ts'));
 
     definitions = server.getDefinition(consumerURI, { line: 2, character: 4 });
     diagnostics = server.getDiagnostics(consumerURI);
@@ -162,13 +162,13 @@ describe('Language Server: custom file extensions', () => {
     expect(diagnostics).toEqual([]);
 
     project.remove('index.custom');
-    server.fileDidChange(project.fileURI('index.custom'));
+    server.watchedFileWasRemoved(project.fileURI('index.custom'));
 
     diagnostics = server.getDiagnostics(consumerURI);
 
     expect(diagnostics).toMatchObject([
       {
-        source: 'glint:ts(2306)',
+        source: 'glint:ts(2307)',
         range: {
           start: { line: 0, character: 27 },
           end: { line: 0, character: 36 },

--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -169,7 +169,7 @@ describe('Language Server: Diagnostics', () => {
       ]);
 
       project.write('component.ts', scriptContents);
-      server.fileDidChange(project.fileURI('component.ts'));
+      server.watchedFileDidChange(project.fileURI('component.ts'));
 
       diagnostics = server.getDiagnostics(project.fileURI('component.hbs'));
 
@@ -198,7 +198,7 @@ describe('Language Server: Diagnostics', () => {
       expect(diagnostics).toEqual([]);
 
       project.remove('component.ts');
-      server.fileDidChange(project.fileURI('component.ts'));
+      server.watchedFileWasRemoved(project.fileURI('component.ts'));
 
       diagnostics = server.getDiagnostics(project.fileURI('component.hbs'));
 

--- a/packages/core/src/cli/perform-check.ts
+++ b/packages/core/src/cli/perform-check.ts
@@ -50,6 +50,7 @@ function createCompilerHost(
   transformManager: TransformManager
 ): ts.CompilerHost {
   let host = ts.createCompilerHost(options);
+  host.fileExists = transformManager.fileExists;
   host.readFile = transformManager.readTransformedFile;
   host.readDirectory = transformManager.readDirectory;
   return host;

--- a/packages/core/src/cli/perform-watch.ts
+++ b/packages/core/src/cli/perform-watch.ts
@@ -30,6 +30,8 @@ function sysForWatchCompilerHost(
   return {
     ...ts.sys,
     readDirectory: transformManager.readDirectory,
+    watchDirectory: transformManager.watchDirectory,
+    fileExists: transformManager.fileExists,
     watchFile: transformManager.watchTransformedFile,
     readFile: transformManager.readTransformedFile,
   };

--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -185,6 +185,20 @@ export default class TransformManager {
     };
   };
 
+  public watchDirectory = (
+    path: string,
+    originalCallback: ts.DirectoryWatcherCallback,
+    recursive?: boolean,
+    options?: ts.WatchOptions
+  ): ts.FileWatcher => {
+    assert(this.ts.sys.watchDirectory);
+
+    let callback: ts.DirectoryWatcherCallback = (filename) =>
+      originalCallback(this.glintConfig.getSynthesizedScriptPathForTS(filename));
+
+    return this.ts.sys.watchDirectory(path, callback, recursive, options);
+  };
+
   public readDirectory = (
     rootDir: string,
     extensions: ReadonlyArray<string>,
@@ -197,6 +211,10 @@ export default class TransformManager {
     return this.ts.sys
       .readDirectory(rootDir, allExtensions, excludes, includes, depth)
       .map((filename) => this.glintConfig.getSynthesizedScriptPathForTS(filename));
+  };
+
+  public fileExists = (filename: string): boolean => {
+    return this.documents.documentExists(filename);
   };
 
   public readTransformedFile = (filename: string, encoding?: string): string | undefined => {

--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -304,10 +304,11 @@ export default class TransformManager {
       if (documents.documentExists(filename)) {
         let contents = documents.getDocumentContents(filename, encoding);
         let templatePath = documents.getCompanionDocumentPath(filename);
-        let mayHaveEmbeds = environment.moduleMayHaveEmbeddedTemplates(filename, contents);
+        let canonicalPath = documents.getCanonicalDocumentPath(filename);
+        let mayHaveEmbeds = environment.moduleMayHaveEmbeddedTemplates(canonicalPath, contents);
 
         if (mayHaveEmbeds || templatePath) {
-          let script = { filename, contents };
+          let script = { filename: canonicalPath, contents };
           let template = templatePath
             ? {
                 filename: templatePath,

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -1,5 +1,6 @@
 import {
   Connection,
+  FileChangeType,
   ServerCapabilities,
   TextDocuments,
   TextDocumentSyncKind,
@@ -84,7 +85,13 @@ export function bindLanguageServer(args: BindingArgs): void {
 
   connection.onDidChangeWatchedFiles(({ changes }) => {
     for (let change of changes) {
-      languageServer.fileDidChange(change.uri);
+      if (change.type === FileChangeType.Created) {
+        languageServer.watchedFileWasAdded(change.uri);
+      } else if (change.type === FileChangeType.Deleted) {
+        languageServer.watchedFileWasRemoved(change.uri);
+      } else {
+        languageServer.watchedFileDidChange(change.uri);
+      }
     }
 
     scheduleDiagnostics();

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -24,26 +24,26 @@ export const capabilities: ServerCapabilities = {
 
 export type BindingArgs = {
   languageServer: GlintLanguageServer;
-  documents: TextDocuments<TextDocument>;
+  openDocuments: TextDocuments<TextDocument>;
   connection: Connection;
 };
 
 export function bindLanguageServer(args: BindingArgs): void {
-  let { connection, languageServer, documents } = args;
+  let { connection, languageServer, openDocuments } = args;
   let { scheduleDiagnostics, captureErrors } = buildHelpers(args);
 
   connection.onInitialize(() => ({ capabilities }));
 
-  documents.onDidOpen(({ document }) => {
+  openDocuments.onDidOpen(({ document }) => {
     languageServer.openFile(document.uri, document.getText());
     scheduleDiagnostics();
   });
 
-  documents.onDidClose(({ document }) => {
+  openDocuments.onDidClose(({ document }) => {
     languageServer.closeFile(document.uri);
   });
 
-  documents.onDidChangeContent(({ document }) => {
+  openDocuments.onDidChangeContent(({ document }) => {
     languageServer.updateFile(document.uri, document.getText());
     scheduleDiagnostics();
   });
@@ -96,10 +96,10 @@ type BindingHelpers = {
   captureErrors: <T>(callback: () => T) => T | undefined;
 };
 
-function buildHelpers({ languageServer, documents, connection }: BindingArgs): BindingHelpers {
+function buildHelpers({ languageServer, openDocuments, connection }: BindingArgs): BindingHelpers {
   return {
     scheduleDiagnostics: debounce(250, () => {
-      for (let { uri } of documents.all()) {
+      for (let { uri } of openDocuments.all()) {
         try {
           const diagnostics = languageServer.getDiagnostics(uri);
           connection.sendDiagnostics({ uri, diagnostics });

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -50,6 +50,7 @@ export default class GlintLanguageServer {
           return ts.ScriptSnapshot.fromString(contents);
         }
       },
+      fileExists: this.transformManager.fileExists,
       readFile: this.transformManager.readTransformedFile,
       readDirectory: this.transformManager.readDirectory,
       getCompilationSettings: () => parsedConfig.options,
@@ -58,7 +59,6 @@ export default class GlintLanguageServer {
       getDefaultLibFileName: ts.getDefaultLibFilePath,
       // TS defaults from here down
       getCurrentDirectory: ts.sys.getCurrentDirectory,
-      fileExists: ts.sys.fileExists,
       directoryExists: ts.sys.directoryExists,
       getDirectories: ts.sys.getDirectories,
     };
@@ -74,7 +74,9 @@ export default class GlintLanguageServer {
   }
 
   public openFile(uri: string, contents: string): void {
-    this.documents.updateDocument(uriToFilePath(uri), contents);
+    let path = uriToFilePath(uri);
+    this.documents.updateDocument(path, contents);
+    this.openFileNames.add(this.glintConfig.getSynthesizedScriptPathForTS(path));
   }
 
   public updateFile(uri: string, contents: string): void {
@@ -82,11 +84,30 @@ export default class GlintLanguageServer {
   }
 
   public closeFile(uri: string): void {
-    this.documents.removeDocument(uriToFilePath(uri));
+    let path = uriToFilePath(uri);
+    this.documents.removeDocument(path);
+    this.openFileNames.delete(this.glintConfig.getSynthesizedScriptPathForTS(path));
   }
 
-  public fileDidChange(uri: string): void {
+  public watchedFileWasAdded(uri: string): void {
+    this.rootFileNames.add(this.glintConfig.getSynthesizedScriptPathForTS(uriToFilePath(uri)));
+  }
+
+  public watchedFileDidChange(uri: string): void {
     this.documents.markDocumentStale(uriToFilePath(uri));
+  }
+
+  public watchedFileWasRemoved(uri: string): void {
+    let path = uriToFilePath(uri);
+
+    this.documents.markDocumentStale(path);
+
+    // We need to be slightly careful here, because if `foo.ts` and `foo.hbs` both exist and
+    // only one is deleted, we shouldn't remove their joint document from `rootFileNames`.
+    let companionPath = this.documents.getCompanionDocumentPath(path);
+    if (!companionPath || this.glintConfig.getSynthesizedScriptPathForTS(companionPath) !== path) {
+      this.rootFileNames.delete(this.glintConfig.getSynthesizedScriptPathForTS(path));
+    }
   }
 
   public getDiagnostics(uri: string): Array<Diagnostic> {

--- a/packages/core/src/language-server/index.ts
+++ b/packages/core/src/language-server/index.ts
@@ -3,34 +3,28 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { findConfig } from '@glint/config';
 import { loadTypeScript } from '../common/load-typescript';
 import GlintLanguageServer from './glint-language-server';
-import { parseConfigFile, uriToFilePath } from './util';
+import { parseConfigFile } from './util';
 import { bindLanguageServer } from './binding';
+import DocumentCache from '../common/document-cache';
+import TransformManager from '../common/transform-manager';
 
 const connection = createConnection(process.stdin, process.stdout);
-
-const ts = loadTypeScript();
 const openDocuments = new TextDocuments(TextDocument);
 const glintConfig = findConfig(process.cwd());
-// try to find a jsconfig.json or a tsconfig.json
-const configPath =
-  ts.findConfigFile(process.cwd(), ts.sys.fileExists, 'jsconfig.json') ||
-  ts.findConfigFile(process.cwd(), ts.sys.fileExists);
-const { fileNames, options } = parseConfigFile(ts, configPath);
 
 if (glintConfig) {
-  const env = glintConfig.environment;
-  const baseProjectRoots = new Set(fileNames);
-  const getRootFileNames = (): Array<string> => {
-    return fileNames.concat(
-      documents
-        .all()
-        .map((doc) => uriToFilePath(doc.uri))
-        .map((path) => glintConfig.getSynthesizedScriptPathForTS(path))
-        .filter((path) => env.isScript(path) && !baseProjectRoots.has(path))
-    );
-  };
+  const ts = loadTypeScript();
+  const documentCache = new DocumentCache(ts, glintConfig);
+  const transformManager = new TransformManager(ts, glintConfig, documentCache);
+  const tsConfig = parseConfigFile(ts, transformManager);
 
-  const languageServer = new GlintLanguageServer(ts, glintConfig, getRootFileNames, options);
+  const languageServer = new GlintLanguageServer(
+    ts,
+    glintConfig,
+    documentCache,
+    transformManager,
+    tsConfig
+  );
 
   bindLanguageServer({ languageServer, openDocuments, connection });
 

--- a/packages/core/src/language-server/index.ts
+++ b/packages/core/src/language-server/index.ts
@@ -7,9 +7,9 @@ import { parseConfigFile, uriToFilePath } from './util';
 import { bindLanguageServer } from './binding';
 
 const connection = createConnection(process.stdin, process.stdout);
-const documents = new TextDocuments(TextDocument);
 
 const ts = loadTypeScript();
+const openDocuments = new TextDocuments(TextDocument);
 const glintConfig = findConfig(process.cwd());
 // try to find a jsconfig.json or a tsconfig.json
 const configPath =
@@ -32,9 +32,9 @@ if (glintConfig) {
 
   const languageServer = new GlintLanguageServer(ts, glintConfig, getRootFileNames, options);
 
-  bindLanguageServer({ languageServer, documents, connection });
+  bindLanguageServer({ languageServer, openDocuments, connection });
 
-  documents.listen(connection);
+  openDocuments.listen(connection);
   connection.listen();
 } else {
   connection.console.info(`No Glint config found from ${process.cwd()}`);


### PR DESCRIPTION
Working on custom syntax support in extra file extensions has revealed a few places where we haven't been handling the state of the filesystem quite correctly. Some are new and unique to custom extensions, while others have been lurking for some time.

The core of the matter came down to two things:
 - not providing custom implementations of `fileExists` and `watchDirectory`
 - being sloppy about tracking changes to `rootFiles` (which is how TS decides what to typecheck) over time in the language server

For the former, those two methods were added to `TransformManager` and plugged in appropriately to the CLI and language server.

For the latter, `GlintLanguageServer` now manages two sets of known documents: those that exist on disk and those that exist in the editor. It keeps these lists up to date over time as editor and filesystem change events come in, so that we're always prepared to give the TS language service a correct answer when it calls `getScriptFileNames` instead of one that accumulates cruft over time.