### PR TITLE
Support preprocessing for custom extensions

### DIFF
--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import os from 'os';
-import { GlintEnvironment } from '../src';
+import { GlintEnvironment, GlintExtensionPreprocess, GlintExtensionTransform } from '../src';
 
 describe('Environments', () => {
   describe('template tags config', () => {
@@ -93,10 +93,13 @@ describe('Environments', () => {
   });
 
   describe('extensions config', () => {
+    type Data = { contents: string };
+    let preprocess: GlintExtensionPreprocess<Data> = () => ({ contents: 'hi' });
+    let transform: GlintExtensionTransform<Data> = () => (node) => node;
     let env = new GlintEnvironment(['test'], {
       extensions: {
         '.ts': { kind: 'typed-script' },
-        '.gts': { kind: 'typed-script' },
+        '.gts': { kind: 'typed-script', preprocess, transform },
         '.hbs': { kind: 'template' },
       },
     });
@@ -124,6 +127,8 @@ describe('Environments', () => {
       expect(env.getConfigForExtension('.hbs')).toEqual({ kind: 'template' });
       expect(env.getConfigForExtension('.gts')).toEqual({
         kind: 'typed-script',
+        preprocess,
+        transform,
       });
     });
   });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,8 @@ export {
   GlintEnvironment,
   GlintEnvironmentConfig,
   GlintTagConfig,
+  GlintExtensionPreprocess,
+  GlintExtensionTransform,
   PathCandidate,
 } from './environment';
 

--- a/packages/vscode/__fixtures__/custom-app/src/Greeting.custom
+++ b/packages/vscode/__fixtures__/custom-app/src/Greeting.custom
@@ -1,0 +1,11 @@
+import Component from '@glint/environment-glimmerx/component';
+
+export interface GreetingSignature {
+  Args: { target: string };
+}
+
+export default class Greeting extends Component<GreetingSignature> {
+  public template = <template>
+    Hello, {{@target}}!
+  </template>;
+}

--- a/packages/vscode/__fixtures__/custom-app/src/index.custom
+++ b/packages/vscode/__fixtures__/custom-app/src/index.custom
@@ -1,1 +1,5 @@
-let foo: string = 'hello';
+import Greeting from './greeting';
+
+<template>
+  <Greeting @target="World" />
+</template>

--- a/packages/vscode/__tests__/smoketest-custom.test.ts
+++ b/packages/vscode/__tests__/smoketest-custom.test.ts
@@ -24,7 +24,7 @@ describe('Smoke test: Custom Environment', () => {
 
       // Replace a string with a number
       await scriptEditor.edit((edit) => {
-        edit.replace(new Range(0, 18, 0, 25), '123');
+        edit.replace(new Range(3, 20, 3, 27), '{{123}}');
       });
 
       // Wait for the diagnostic to show up
@@ -35,7 +35,7 @@ describe('Smoke test: Custom Environment', () => {
         {
           message: "Type 'number' is not assignable to type 'string'.",
           source: 'glint:ts(2322)',
-          range: new Range(0, 4, 0, 7),
+          range: new Range(3, 13, 3, 19),
         },
       ]);
     });

--- a/test-packages/glint-environment-custom-test/env.js
+++ b/test-packages/glint-environment-custom-test/env.js
@@ -41,12 +41,7 @@ module.exports = () => ({
                 f.createImportClause(
                   false,
                   undefined,
-                  f.createNamedImports([
-                    f.createImportSpecifier(
-                      f.createIdentifier('hbs'),
-                      f.createIdentifier(TAG_NAME)
-                    ),
-                  ])
+                  f.createNamedImports([makeImportSpecifier(f)])
                 ),
                 f.createStringLiteral('glint-environment-custom-test')
               ),
@@ -63,3 +58,18 @@ module.exports = () => ({
     },
   },
 });
+
+// 🙄 TS 4.5 prepended a new param to `createImportSpecifier`
+function makeImportSpecifier(f) {
+  let local = f.createIdentifier(TAG_NAME);
+  let foreign = f.createIdentifier('hbs');
+
+  // TS >= 4.5 (isTypeOnly, propertyName, name)
+  let node = f.createImportSpecifier(false, foreign, local);
+  if (node.propertyName === false) {
+    // TS <= 4.4 (propertyName, name)
+    node = f.createImportSpecifier(foreign, local);
+  }
+
+  return node;
+}

--- a/test-packages/glint-environment-custom-test/env.js
+++ b/test-packages/glint-environment-custom-test/env.js
@@ -1,10 +1,65 @@
 // @ts-check
 
+const TAG_NAME = '___tpl';
+
 /** @type {() => import('@glint/config').GlintEnvironmentConfig} */
 module.exports = () => ({
+  tags: {
+    'glint-environment-custom-test': {
+      hbs: {
+        typesSource: '@glint/environment-glimmerx/-private/dsl',
+        globals: [],
+      },
+    },
+  },
   extensions: {
     '.custom': {
       kind: 'typed-script',
+
+      // This environment provides a super-pared-down version of the proposed
+      // .gts format for embedded templates. Unlike full .gts, this only supports
+      // templates in expression position, with no implicit default export.
+      preprocess: (source) => ({
+        contents: source
+          .replace(/[<]template>/g, `${TAG_NAME}\``.padEnd('<template>'.length))
+          .replace(/<\/template>/g, '`'.padStart('</template>'.length)),
+        data: {
+          hasTemplates: source.includes('<' + 'template>'),
+        },
+      }),
+
+      transform: (data, { ts, context }) =>
+        function visit(original) {
+          let f = ts.factory;
+          let node = original;
+
+          if (ts.isSourceFile(node) && data.hasTemplates) {
+            node = f.updateSourceFile(node, [
+              f.createImportDeclaration(
+                [],
+                [],
+                f.createImportClause(
+                  false,
+                  undefined,
+                  f.createNamedImports([
+                    f.createImportSpecifier(
+                      f.createIdentifier('hbs'),
+                      f.createIdentifier(TAG_NAME)
+                    ),
+                  ])
+                ),
+                f.createStringLiteral('glint-environment-custom-test')
+              ),
+              ...node.statements,
+            ]);
+          }
+
+          let result = ts.visitEachChild(node, visit, context);
+          result.forEachChild((node) => {
+            Object.assign(node, { parent: result });
+          });
+          return result;
+        },
     },
   },
 });

--- a/test-packages/ts-custom-app/src/Greeting.custom
+++ b/test-packages/ts-custom-app/src/Greeting.custom
@@ -1,0 +1,15 @@
+import { TC } from '@glint/environment-glimmerx/component';
+
+const Target: TC = <template>World</template>;
+
+export interface GreetingSignature {
+  Args: {
+    message: string;
+  };
+}
+
+const Greeting: TC<GreetingSignature> = <template>
+  {{@message}}, <Target />!
+</template>
+
+export default Greeting;

--- a/test-packages/ts-custom-app/src/index.custom
+++ b/test-packages/ts-custom-app/src/index.custom
@@ -1,1 +1,5 @@
-let x: number = 123;
+import Greeting from './Greeting';
+
+export default <template>
+  <Greeting @message="hi" />
+</template>


### PR DESCRIPTION
## Overview

#251 introduced support for environments to opt custom file extensions into analysis by Glint, but required that they use syntax that Glint could already understand. For something like [the proposed `.gjs`/`.gts` format](https://github.com/emberjs/rfcs/pull/779) to work, environments need the ability to transform any custom syntax into a format that Glint can parse and operate on.

This PR provides that ability to environments as a two-phase operation. The first, `preprocess`, is a string-to-string mapping that allows for converting exotic syntax into something that the TypeScript parser can recognize. Environments can also pass any additional data they collect as part of this process on to be used in the next phase.

The second phase, `transform`, operates on a parsed `ts.SourceFile` AST. It can make further tweaks to the contents of the source file such that `ts.TaggedTemplateExpressions` appear in the appropriate positions to be subsequently processed by Glint's normal embedded template machinery.

This phase can also associate "emit metadata" with a given template node, allowing for behaviors such as prepending `export default` when a `<template>` appears as a top-level `ExpressionStatement`.

## Restrictions

Custom processing steps do not have the power to completely change the source of the modules they're operating on; Glint's transformation process essentially produces a set of mappings _within_ spans of the source that correspond to templates, but leaves anything outside that space untouched. This is an acceptable limitation for `.gts` or any other format that embeds templates within scripts, but may (or may not!) need to be revisited if we ever wish to support an inverted SFC format that embeds scripts within another wrapping syntax.

