### PR TITLE
Ensure compatibility with latest upstream Ember/Glimmer types

### DIFF
--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -43,7 +43,7 @@ import { expectTypeOf } from 'expect-type';
       expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
       expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
       expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
-      expectTypeOf(𝚪.this.args).toEqualTypeOf<EmptyObject>();
+      expectTypeOf(𝚪.this.args).toEqualTypeOf<Readonly<EmptyObject>>();
     });
   }
 
@@ -65,7 +65,7 @@ import { expectTypeOf } from 'expect-type';
     static template = template(function* <T>(𝚪: ResolveContext<YieldingComponent<T>>) {
       expectTypeOf(𝚪.this).toEqualTypeOf<YieldingComponent<T>>();
       expectTypeOf(𝚪.args).toEqualTypeOf<{ values: T[] }>();
-      expectTypeOf(𝚪.this.args).toEqualTypeOf<{ values: T[] }>();
+      expectTypeOf(𝚪.this.args).toEqualTypeOf<Readonly<{ values: T[] }>>();
 
       if (𝚪.args.values.length) {
         yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);

--- a/packages/environment-ember-loose/ember-modifier/index.ts
+++ b/packages/environment-ember-loose/ember-modifier/index.ts
@@ -30,10 +30,17 @@ export interface ModifierSignature {
   Element?: Element;
 }
 
-const Modifier = EmberModifier as AsObjectType<EmberModifierConstructor> &
-  (new <T extends ModifierSignature>(
+// Factoring this into a standalone type prevents `tsc` from expanding the
+// `ConstructorParameters` type inline when producing `.d.ts` files, which
+// breaks consumers depending on whether they're on v2 or v3 of the
+// `ember-modifier` package.
+type ModifierConstructor = {
+  new <T extends ModifierSignature>(
     ...args: ConstructorParameters<EmberModifierConstructor>
-  ) => Modifier<T>);
+  ): Modifier<T>;
+};
+
+const Modifier = EmberModifier as AsObjectType<EmberModifierConstructor> & ModifierConstructor;
 
 interface Modifier<T extends ModifierSignature>
   extends EmberModifier<{

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -31,7 +31,7 @@
     "@glint/template": "^0.7.1"
   },
   "devDependencies": {
-    "@glimmer/component": "^1.0.0",
+    "@glimmer/component": "^1.1.0",
     "@types/ember__component": "~4.0.0",
     "@types/jest": "^26.0.13",
     "ember-modifier": "^3.2.1",

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -34,7 +34,7 @@
     "@glimmer/component": "^1.0.0",
     "@types/ember__component": "~4.0.0",
     "@types/jest": "^26.0.13",
-    "ember-modifier": "^2.1.1",
+    "ember-modifier": "^3.2.1",
     "expect-type": "0.11.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.3.0"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -16,7 +16,7 @@
     "*.d.ts"
   ],
   "devDependencies": {
-    "@glimmer/component": "^1.0.2",
+    "@glimmer/component": "^1.1.0",
     "@glimmerx/component": "^0.4.2",
     "@types/ember__component": "~4.0.0",
     "expect-type": "0.11.0",

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -44,7 +44,7 @@
     "ember-cli-typescript": "^4.0.0",
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.1",
-    "ember-modifier": "^2.1.1",
+    "ember-modifier": "^3.2.1",
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.8",
-    "@glimmer/component": "^1.0.2",
+    "@glimmer/component": "^1.1.0",
     "@glimmer/tracking": "^1.0.2",
     "@glint/core": "^0.7.1",
     "@glint/environment-ember-loose": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,9 +2124,9 @@
     "@types/ember__routing" "*"
 
 "@types/ember__array@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/ember__array/-/ember__array-4.0.0.tgz#68cc7d5d2f219314187a9a068eda990787134bd4"
-  integrity sha512-C3kFMgUI/rTEIemVWc5oanjek7oLLWCQscBtkEcC7dQVr3GstXxBYHYjmAscI2vqLgjGmdibk7SYbfrde5qHjg==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ember__array/-/ember__array-4.0.1.tgz#b62126ed080b29351a5633bd28e595a5cfee27ce"
+  integrity sha512-fwrYcYmFbsEnu77Xn9z3WSAp6tqpwn8Wksx8RzGg5pib6VmFD/dkT5jefwoKtlcImsxUNEoP1VgWKrdrpGaQcg==
   dependencies:
     "@types/ember" "*"
     "@types/ember__array" "*"
@@ -2149,9 +2149,9 @@
     "@types/ember__object" "*"
 
 "@types/ember__debug@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-4.0.0.tgz#02d3d710988988e5cff094ddcd45e5364727b161"
-  integrity sha512-yY+U7veF8jYFJdm+IU+7Y/DoxVsyV/73UvFUdR0jCasMVL9vuGkVx0rXlqe6XAM2cWI1LwV7zKQzgqDC8kQD2g==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-4.0.1.tgz#1e4a8a1045484295dddc7bd4356d0b3014b0d509"
+  integrity sha512-qrKk6Ujh6oev7TSB0eB7AEmQWKCt5t84k/K3hDvJXUiLU3YueN0kyt7aPoIAkVjC111A9FqDugl9n60+N5yeEw==
   dependencies:
     "@types/ember-resolver" "*"
     "@types/ember__debug" "*"
@@ -2172,9 +2172,9 @@
   integrity sha512-1WVMR65/QTqPzMWafK2vKEwGafILxRxItbWJng6eEJyKDHRvvHFCl3XzJ4dQjdFcfOlozsn0mmEYCpjKoyzMqA==
 
 "@types/ember__object@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/ember__object/-/ember__object-4.0.0.tgz#18ffa0747ebaceed8ea3dbc9793dd033dc47adf2"
-  integrity sha512-mOd53VoaHTKZiRDnZlY1aouCb6P62OK2IrBLEY4pmnpmQPIFM8Q1COceMw8bh6Xjg8xOnhae5jsi3Ux2Ucnd2A==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ember__object/-/ember__object-4.0.1.tgz#0713bd5ffc6aa41520b2684f5577817649226099"
+  integrity sha512-ra9/ZV6YaQi2UQ0rchDJGveQEOnTCzkgUQzeJLSvvtJc1JPvAfYX55+kdYl79QTqwYxl86YMAlElSvdJNbjTPQ==
   dependencies:
     "@types/ember" "*"
     "@types/ember__object" "*"
@@ -2186,10 +2186,11 @@
   integrity sha512-Yk85J18y1Ys6agoIBLdJWu6ZkWe68oaC9JPyW7BhOINVNKm89PXrR/yxdOJ1/vN1Hj7ZZQKq+4X6fz3sxebavA==
 
 "@types/ember__routing@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/ember__routing/-/ember__routing-4.0.0.tgz#f2d84bbda8f636c07c37de08e63e9d77dd5e45e0"
-  integrity sha512-R0CZWnjGb16vKp7WZj6YhGrGY7wMPVxXlWsi0KsyR+DmVwMJjXJnOA3MHB1CiXajdL6FZyEGEZYHwnx3081mjA==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/ember__routing/-/ember__routing-4.0.4.tgz#6e485e56e86b094f71b229da805fcf02e6b6efa9"
+  integrity sha512-EbcH6vP12uLpsWrCnpmGjU+omIhGVNzHW0leRAAIXhuY60ElAySi3stPttlRF1J42QfO8zBb7vCbFQdqouZZMw==
   dependencies:
+    "@types/ember" "*"
     "@types/ember__controller" "*"
     "@types/ember__object" "*"
     "@types/ember__routing" "*"
@@ -5873,7 +5874,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6067,13 +6068,21 @@ ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-version-checker@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
-  integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
+ember-cli-typescript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.0.0.tgz#52f53843082d0a0128f318809dadabf83a76bbff"
+  integrity sha512-UDKZlG7bInRo7eDsF3jvPz1Dxh1YvRhMw9wyj5rj2K3brw0xEh1IMTqPgWRbPESqjcWuwa8s0FCNuYWDc4PTfg==
   dependencies:
-    resolve "^1.3.3"
-    semver "^5.3.0"
+    ansi-to-html "^0.6.15"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
 
 ember-cli-version-checker@^3.1.3:
   version "3.1.3"
@@ -6198,7 +6207,7 @@ ember-cli@~3.27.0:
     workerpool "^6.0.3"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.2.tgz#839e0c24190b7a2ec8c39b80e030811b1a95b6d3"
   integrity sha512-EKyCGOGBvKkBsk6wKfg3GhjTvTTkcEwzl/cv4VYvZM18cihmjGNpliR4BymWsKRWrv4VJLyq15Vhk3NHkSNBag==
@@ -6207,7 +6216,18 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
 
-ember-destroyable-polyfill@^2.0.2, ember-destroyable-polyfill@^2.0.3:
+ember-compatibility-helpers@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
+  integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    find-up "^5.0.0"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
+ember-destroyable-polyfill@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz#1673ed66609a82268ef270a7d917ebd3647f11e1"
   integrity sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==
@@ -6243,26 +6263,16 @@ ember-load-initializers@^2.1.1:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
 
-ember-modifier-manager-polyfill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
-  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
+ember-modifier@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.1.tgz#7078403b5b84d7b97d0b3298851d33d098a7b82d"
+  integrity sha512-8mMLUX/pclAfrX99RemTsyimVM/8zJ1ZzGOqny2TfUKeFzon3a+mxPUmBhY+TS6W4aNBW32YSeFytEtG01bTdQ==
   dependencies:
-    ember-cli-babel "^7.10.0"
-    ember-cli-version-checker "^2.1.2"
-    ember-compatibility-helpers "^1.2.0"
-
-ember-modifier@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-2.1.1.tgz#aa3a12e2d6cf1622f774f3f1eab4880982a43fa9"
-  integrity sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==
-  dependencies:
-    ember-cli-babel "^7.22.1"
+    ember-cli-babel "^7.26.6"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^3.1.3"
-    ember-destroyable-polyfill "^2.0.2"
-    ember-modifier-manager-polyfill "^1.2.0"
+    ember-cli-typescript "^5.0.0"
+    ember-compatibility-helpers "^1.2.5"
 
 ember-named-blocks-polyfill@^0.2.4:
   version "0.2.4"
@@ -12568,7 +12578,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,10 +1112,10 @@
     ember-cli-typescript "^3.0.0"
     ember-compatibility-helpers "^1.1.2"
 
-"@glimmer/component@^1.0.0", "@glimmer/component@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.2.tgz#679307972d29a849225c13062ab11c779956ff60"
-  integrity sha512-st6YroDjkvUeYWE36NglNG9hXmJOuOI8t44UEp1tufGc4B1L/CTlt1ziQGkaxkhY7/o2r0ZCcWHvf5bpq838YQ==
+"@glimmer/component@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.1.0.tgz#a9ab87896444b01b6af6a885fc2da3cb02ddba42"
+  integrity sha512-oqGUX84p4qu9Kfdv3nxqS9NUuDiJFUFS4jxGqRYrm5i3KgEKss48or21GZo279OX2LrUjDvRT+EMp6Mz5h2Ryw==
   dependencies:
     "@glimmer/di" "^0.1.9"
     "@glimmer/env" "^0.1.7"


### PR DESCRIPTION
This PR ensures Glint is compatible with the recent signature-aware releases of `@glimmer/component`, `ember-modifier`, and `@types/ember__component`. ~It's intended to be the last release in the `0.7.x` line.~

The only actual bugfix is a change to our reexports for `ember-modifier`. Prior to this PR, `tsc` (for whatever reason) was inlining `(...args: ConstructorParameters<typeof Modifier>)` to `(owner: unknown, args: import("ember-modifier").ModifierArgs<unknown>)`, which breaks with `ember-modifier@3`, where `ModifierArgs` doesn't take any type parameters.

Pulling `ModifierConstructor` into its own type prevents this behavior, for reasons I don't 100% understand. Normally that would concern me, but this _should_ be the penultimate release of Glint which includes these reexports, and I've verified emit works as intended.