### PR TITLE
Prevent `tsc` from inlining implementation details from upstream

### DIFF
--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -3,7 +3,7 @@ import { AcceptsBlocks, EmptyObject, Invokable } from '@glint/template/-private/
 type Constructor<T> = new (...params: any) => T;
 type Get<T, K, Otherwise = EmptyObject> = K extends keyof T ? Exclude<T[K], undefined> : Otherwise;
 
-export type AsObjectType<T> = { [K in keyof T]: T[K] };
+export type StaticSide<T> = { [K in Exclude<keyof T, 'prototype'>]: T[K] };
 
 export type ElementOf<C extends ComponentLike> = C extends Constructor<
   Invokable<(...args: any) => AcceptsBlocks<any, infer Element>>

--- a/packages/environment-ember-loose/ember-component/index.ts
+++ b/packages/environment-ember-loose/ember-component/index.ts
@@ -7,7 +7,7 @@ import type {
   EmptyObject,
 } from '@glint/template/-private/integration';
 
-import type { AsObjectType } from '../-private/utilities';
+import type { StaticSide } from '../-private/utilities';
 import type { ComponentSignature } from '../-private';
 
 export type { ComponentSignature };
@@ -25,10 +25,17 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
 
 export type ArgsFor<T extends ComponentSignature> = 'Args' extends keyof T ? T['Args'] : {};
 
-const Component = EmberComponent as AsObjectType<typeof EmberComponent> &
-  (new <T extends ComponentSignature = {}>(
+// Factoring this into a standalone type prevents `tsc` from expanding the
+// `ConstructorParameters` type inline when producing `.d.ts` files, which
+// breaks consumers depending on their version of the upstream types.
+type ComponentConstructor = {
+  new <T extends ComponentSignature = {}>(
     ...args: ConstructorParameters<EmberComponentConstructor>
-  ) => Component<T>);
+  ): Component<T>;
+};
+
+const Component = EmberComponent as unknown as StaticSide<typeof EmberComponent> &
+  ComponentConstructor;
 
 interface Component<T extends ComponentSignature = {}> extends EmberComponent {
   // Allows `extends Component<infer Signature>` clauses to work as expected

--- a/packages/environment-ember-loose/ember-modifier/index.ts
+++ b/packages/environment-ember-loose/ember-modifier/index.ts
@@ -4,7 +4,7 @@ import type {
   BoundModifier,
   EmptyObject,
 } from '@glint/template/-private/integration';
-import type { AsObjectType } from '../-private/utilities';
+import type { StaticSide } from '../-private/utilities';
 
 const EmberModifier = window.require('ember-modifier').default;
 type EmberModifier<T> = import('ember-modifier').default<T>;
@@ -35,12 +35,12 @@ export interface ModifierSignature {
 // breaks consumers depending on whether they're on v2 or v3 of the
 // `ember-modifier` package.
 type ModifierConstructor = {
-  new <T extends ModifierSignature>(
+  new <T extends ModifierSignature = {}>(
     ...args: ConstructorParameters<EmberModifierConstructor>
   ): Modifier<T>;
 };
 
-const Modifier = EmberModifier as AsObjectType<EmberModifierConstructor> & ModifierConstructor;
+const Modifier = EmberModifier as StaticSide<EmberModifierConstructor> & ModifierConstructor;
 
 interface Modifier<T extends ModifierSignature>
   extends EmberModifier<{

--- a/packages/environment-ember-loose/glimmer-component/index.ts
+++ b/packages/environment-ember-loose/glimmer-component/index.ts
@@ -5,7 +5,7 @@ import type {
   AcceptsBlocks,
   EmptyObject,
 } from '@glint/template/-private/integration';
-import { AsObjectType } from '../-private/utilities';
+import { StaticSide } from '../-private/utilities';
 
 import type { ComponentSignature } from '../-private';
 export type { ComponentSignature };
@@ -20,10 +20,17 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
 
-const Component = GlimmerComponent as AsObjectType<GlimmerComponentConstructor> &
-  (new <T extends ComponentSignature = {}>(
+// Factoring this into a standalone type prevents `tsc` from expanding the
+// `ConstructorParameters` type inline when producing `.d.ts` files, which
+// breaks consumers depending on their version of the upstream types.
+type ComponentConstructor = {
+  new <T extends ComponentSignature = {}>(
     ...args: ConstructorParameters<GlimmerComponentConstructor>
-  ) => Component<T>);
+  ): Component<T>;
+};
+
+const Component = GlimmerComponent as unknown as StaticSide<GlimmerComponentConstructor> &
+  ComponentConstructor;
 
 interface Component<T extends ComponentSignature = {}> extends GlimmerComponent<Get<T, 'Args'>> {
   // Allows `extends Component<infer Signature>` clauses to work as expected


### PR DESCRIPTION
This is the same fix as the one for `ember-modifier` in #275 applied to the constructors for `EmberComponent`, `Helper` and `GlimmerComponent`.