### PR TITLE
Fix issue where Component super args were incorrect

### DIFF
--- a/packages/environment-ember-loose/glimmer-component/index.ts
+++ b/packages/environment-ember-loose/glimmer-component/index.ts
@@ -22,7 +22,7 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
 
 const Component = GlimmerComponent as AsObjectType<GlimmerComponentConstructor> &
   (new <T extends ComponentSignature = {}>(
-    ...args: ConstructorParameters<GlimmerComponentConstructor>
+    owner: unknown, args: unknown
   ) => Component<T>);
 
 interface Component<T extends ComponentSignature = {}> extends GlimmerComponent<Get<T, 'Args'>> {


### PR DESCRIPTION
This makes types less safe, but previously, TypeScript would squash
the type param making it incorrect.

Before
```ts
declare type ComponentConstructor = {
    new <T extends ComponentSignature = {}>(...args: ConstructorParameters<GlimmerComponentConstructor>): Component<T>;
};
declare const Component: StaticSide<typeof import("@glimmer/component").default> & ComponentConstructor;
```
After:
```ts
declare type ComponentConstructor = {
    new <T extends ComponentSignature = {}>(owner: unknown, args: unknown): Component<T>;
};
declare const Component: StaticSide<typeof import("@glimmer/component").default> & ComponentConstructor;
```