### PR TITLE
Expose `@glint/template` utility types

### DIFF
--- a/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { EmptyObject } from '@glimmer/component/dist/types/addon/-private/component';
+import type { ComponentLike } from '@glint/template';
 
 {
   class NoArgsComponent extends Component {
@@ -155,4 +156,19 @@ import { EmptyObject } from '@glimmer/component/dist/types/addon/-private/compon
 
   resolve(PositionalArgsComponent)({}, 'a');
   resolve(PositionalArgsComponent)({}, 'a', 1);
+}
+
+// Components are `ComponentLike`
+{
+  interface TestSignature {
+    Args: { key: string };
+    Blocks: {
+      default: [value: string];
+    };
+    Element: HTMLDivElement;
+  }
+
+  class TestComponent extends Component<TestSignature> {}
+
+  expectTypeOf(TestComponent).toMatchTypeOf<ComponentLike<TestSignature>>();
 }

--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@glint/environment-ember-loose/-private/dsl';
 import { EmptyObject } from '@glimmer/component/dist/types/addon/-private/component';
 import { expectTypeOf } from 'expect-type';
+import { ComponentLike } from '@glint/template';
 
 {
   class NoArgsComponent extends Component {}
@@ -107,4 +108,19 @@ import { expectTypeOf } from 'expect-type';
       expectTypeOf(args).toEqualTypeOf<[]>();
     }
   }
+}
+
+// Components are `ComponentLike`
+{
+  interface TestSignature {
+    Args: { key: string };
+    Blocks: {
+      default: [value: string];
+    };
+    Element: HTMLDivElement;
+  }
+
+  class TestComponent extends Component<TestSignature> {}
+
+  expectTypeOf(TestComponent).toMatchTypeOf<ComponentLike<TestSignature>>();
 }

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -2,6 +2,7 @@ import '@glint/environment-ember-loose/native-integration';
 import Helper, { helper, EmptyObject } from '@ember/component/helper';
 import { resolve } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
+import { HelperLike } from '@glint/template';
 
 // Functional helper: fixed signature params
 {
@@ -169,4 +170,21 @@ import { expectTypeOf } from 'expect-type';
   let maybeString = resolve(MaybeStringHelper);
 
   expectTypeOf(maybeString).toEqualTypeOf<(args: EmptyObject) => string | undefined>();
+}
+
+// Helpers are `HelperLike`
+{
+  interface TestSignature {
+    Args: {
+      Named: { count: number };
+      Positional: [value: string];
+    };
+    Return: Array<string>;
+  }
+
+  class MyHelper extends Helper<TestSignature> {}
+  const myHelper = helper<TestSignature>(() => []);
+
+  expectTypeOf(MyHelper).toMatchTypeOf<HelperLike<TestSignature>>();
+  expectTypeOf(myHelper).toMatchTypeOf<HelperLike<TestSignature>>();
 }

--- a/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
@@ -3,6 +3,7 @@ import Modifier, { modifier } from 'ember-modifier';
 import { resolve } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { BoundModifier } from '@glint/template/-private/integration';
+import { ModifierLike } from '@glint/template';
 
 // Class-based modifier
 {
@@ -91,4 +92,21 @@ import { BoundModifier } from '@glint/template/-private/integration';
 
   // @ts-expect-error: invalid named arg
   neat({ hello: 123 }, 'message');
+}
+
+// Modifiers are `ModifierLike`
+{
+  interface TestSignature {
+    Args: {
+      Named: { count: number };
+      Positional: [value: string];
+    };
+    Element: HTMLCanvasElement;
+  }
+
+  class MyModifier extends Modifier<TestSignature> {}
+  const myModifier = modifier<TestSignature>(() => {}, { eager: false });
+
+  expectTypeOf(MyModifier).toMatchTypeOf<ModifierLike<TestSignature>>();
+  expectTypeOf(myModifier).toMatchTypeOf<ModifierLike<TestSignature>>();
 }

--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -1,0 +1,114 @@
+import {
+  AcceptsBlocks,
+  AnyFunction,
+  BoundModifier,
+  EmptyObject,
+  FlattenBlockParams,
+  Invokable,
+} from './integration';
+import { ExpandSignature } from '@glimmer/component/dist/types/addon/-private/component';
+
+/**
+ * A value that is invokable like a component in a template. In an
+ * appropriate Glint environment, subclasses of `EmberComponent` and
+ * `GlimmerComponent` are examples of `ComponentLike` values, as are
+ * the values returned from the `{{component}}` helper.
+ *
+ * The `S` signature paramter here is of the same form as the one
+ * accepted by both the Ember and Glimmer `Component` base classes.
+ */
+export type ComponentLike<S = unknown> = InvokableConstructor<
+  (
+    named: ExpandSignature<S>['Args']['Named'],
+    ...positional: ExpandSignature<S>['Args']['Positional']
+  ) => AcceptsBlocks<
+    FlattenBlockParams<ExpandSignature<S>['Blocks']>,
+    ExpandSignature<S>['Element']
+  >
+>;
+
+/**
+ * A value that is invokable like a helper in a template. Notably,
+ * subclasses of `Helper` and the return value of `helper()` from
+ * `@ember/component/helper` are both `HelperLike` in an appropriate
+ * Glint environment.
+ *
+ * The `S` signature parameter here is of the same form as the one
+ * accepted by `Helper` and `helper`.
+ */
+export type HelperLike<S = unknown> = InvokableConstructor<
+  (...args: InvokableArgs<S>) => Get<S, 'Return', unknown>
+>;
+
+/**
+ * A value that is invokable like a modifier in a template. Notably,
+ * subclasses of `Modifier` and the return value of `modifier()` from
+ * `ember-modifier` are both `ModifierLike` in an appropriate Glint
+ * environment.
+ *
+ * The `S` signature parameter here is of the same form as the ones
+ * accepted by `Modifier` and `modifier`.
+ */
+export type ModifierLike<S = unknown> = InvokableConstructor<
+  (...args: InvokableArgs<S>) => BoundModifier<Constrain<Get<S, 'Element'>, Element>>
+>;
+
+/**
+ * Given a `ComponentLike`, `HelperLike` or `ModifierLike` value
+ * along with a union representing named args that have been
+ * pre-bound, this helper returns the same item back, but with those
+ * named arguments made optional.
+ *
+ * This is typically useful in conjunction with something like the
+ * `{{component}}` helper; for instance, if you wrote this in a
+ * template:
+ *
+ * ```handlebars
+ * {{yield (component MyComponent message="Hello")}}
+ * ```
+ *
+ * Consumers of that yielded value would be able to invoke the
+ * component without having to provide a value for `@message`
+ * themselves. You could represent this in your signature as:
+ *
+ * ```ts
+ * Blocks: {
+ *   default: [WithBoundArgs<typeof MyComponent, 'message'>];
+ * };
+ * ```
+ *
+ * If you had instead just written `default: [typeof MyComponent]`,
+ * consumers would still be obligated to provide a `@message`
+ * arg when invoking the yielded component.
+ */
+export type WithBoundArgs<
+  T extends InvokableConstructor<AnyFunction>,
+  BoundArgs extends NamedArgNames<T>
+> = T extends InvokableConstructor<
+  (named: infer Named, ...positional: infer Positional) => infer Result
+>
+  ? InvokableConstructor<
+      (
+        named: Omit<Named, BoundArgs> & Partial<Pick<Named, BoundArgs & keyof Named>>,
+        ...positional: Positional
+      ) => Result
+    >
+  : never;
+
+type InvokableConstructor<F extends AnyFunction> = abstract new (...args: any) => Invokable<F>;
+type NamedArgNames<T extends InvokableConstructor<AnyFunction>> = T extends InvokableConstructor<
+  (named: infer Named, ...positional: any) => any
+>
+  ? keyof Named
+  : never;
+
+type Get<T, K, Otherwise = unknown> = K extends keyof T ? T[K] : Otherwise;
+type Constrain<T, Constraint, Otherwise = Constraint> = T extends Constraint ? T : Otherwise;
+
+// We use the imported `ExpandSignature` for component signatures, as they have
+// different layers of possible shorthand, but modifiers and helpers only have
+// one structure they can specify their args in, so this utility is sufficient.
+type InvokableArgs<S> = [
+  named: Get<Get<S, 'Args'>, 'Named', EmptyObject>,
+  ...positional: Constrain<Get<Get<S, 'Args'>, 'Positional'>, Array<unknown>, []>
+];

--- a/packages/template/__tests__/component-like.test.ts
+++ b/packages/template/__tests__/component-like.test.ts
@@ -1,0 +1,133 @@
+import { ComponentLike, WithBoundArgs } from '@glint/template';
+import { resolve, emitComponent } from '@glint/template/-private/dsl';
+import { expectTypeOf } from 'expect-type';
+import { AcceptsBlocks } from '../-private/integration';
+
+{
+  const NoArgsComponent = {} as ComponentLike<{}>;
+
+  resolve(NoArgsComponent)({
+    // @ts-expect-error: extra named arg
+    foo: 'bar',
+  });
+
+  resolve(NoArgsComponent)(
+    {},
+    // @ts-expect-error: extra positional arg
+    'oops'
+  );
+
+  {
+    const component = emitComponent(resolve(NoArgsComponent)({}));
+
+    {
+      // @ts-expect-error: never yields, so shouldn't accept blocks
+      component.blockParams.default;
+    }
+  }
+
+  emitComponent(resolve(NoArgsComponent)({}));
+}
+
+{
+  interface YieldingComponentSignature {
+    Args: {
+      values: Array<number>;
+    };
+    Blocks: {
+      default: [number];
+      else: [];
+    };
+  }
+
+  const YieldingComponent = {} as ComponentLike<YieldingComponentSignature>;
+
+  // @ts-expect-error: missing required arg
+  resolve(YieldingComponent)({});
+
+  resolve(YieldingComponent)(
+    { values: [] },
+    // @ts-expect-error: extra positional arg
+    'hi'
+  );
+
+  resolve(YieldingComponent)({
+    // @ts-expect-error: incorrect type for arg
+    values: 'hello',
+  });
+
+  resolve(YieldingComponent)({
+    values: [1, 2, 3],
+    // @ts-expect-error: extra arg
+    oops: true,
+  });
+
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [value] = component.blockParams.default;
+      expectTypeOf(value).toEqualTypeOf<number>();
+    }
+  }
+
+  {
+    const component = emitComponent(resolve(YieldingComponent)({ values: [1, 2, 3] }));
+
+    {
+      const [...args] = component.blockParams.default;
+      expectTypeOf(args).toEqualTypeOf<[number]>();
+    }
+
+    {
+      const [...args] = component.blockParams.else;
+      expectTypeOf(args).toEqualTypeOf<[]>();
+    }
+  }
+}
+
+{
+  interface PositionalArgsComponentSignature {
+    Args: {
+      Named: { key?: string };
+      Positional: [name: string, age?: number];
+    };
+  }
+
+  const PositionalArgsComponent = {} as ComponentLike<PositionalArgsComponentSignature>;
+
+  // @ts-expect-error: missing required positional arg
+  resolve(PositionalArgsComponent)({});
+
+  resolve(PositionalArgsComponent)(
+    {},
+    // @ts-expect-error: incorrect type for positional arg
+    123
+  );
+
+  resolve(PositionalArgsComponent)(
+    {},
+    'a',
+    1,
+    // @ts-expect-error: extra positional arg
+    true
+  );
+
+  resolve(PositionalArgsComponent)({}, 'a');
+  resolve(PositionalArgsComponent)({}, 'a', 1);
+}
+
+// With pre-bound args
+{
+  let MyComponent!: ComponentLike<{
+    Args: { foo: string; bar: number };
+    Element: HTMLCanvasElement;
+    Blocks: { default: [] };
+  }>;
+
+  let MyBoundComponent!: WithBoundArgs<typeof MyComponent, 'foo'>;
+
+  expectTypeOf(resolve(MyBoundComponent)).toEqualTypeOf<
+    (args: { foo?: string; bar: number }) => AcceptsBlocks<{ default: [] }, HTMLCanvasElement>
+  >();
+}

--- a/packages/template/__tests__/helper-like.test.ts
+++ b/packages/template/__tests__/helper-like.test.ts
@@ -1,0 +1,84 @@
+import '@glint/environment-ember-loose/native-integration';
+import { resolve } from '@glint/environment-ember-loose/-private/dsl';
+import { expectTypeOf } from 'expect-type';
+import { HelperLike, WithBoundArgs } from '@glint/template';
+import { EmptyObject } from '../-private/integration';
+
+// Fixed signature params
+{
+  interface InfoSignature {
+    Args: {
+      Named: { age: number };
+      Positional: [name: string];
+    };
+    Return: string;
+  }
+
+  let definition!: HelperLike<InfoSignature>;
+  let info = resolve(definition);
+
+  expectTypeOf(info).toEqualTypeOf<(named: { age: number }, name: string) => string>();
+
+  info(
+    // @ts-expect-error: missing named arg
+    {},
+    'Tom'
+  );
+
+  info(
+    {
+      // @ts-expect-error: extra named arg
+      hello: true,
+      age: 123,
+    },
+    'Tom'
+  );
+
+  // @ts-expect-error: missing positional arg
+  info({ age: 123 });
+
+  // @ts-expect-error: extra positional arg
+  info({ age: 123 }, 'Tom', 'Ster');
+
+  expectTypeOf(info({ age: 123 }, 'Tom')).toEqualTypeOf<string>();
+}
+
+// Generic params
+{
+  interface GenericSignature<T, U> {
+    Args: { Positional: [T, U] };
+    Return: T | U;
+  }
+
+  let definition!: new <T, U>() => InstanceType<HelperLike<GenericSignature<T, U>>>;
+  let or = resolve(definition);
+
+  expectTypeOf(or).toEqualTypeOf<{ <T, U>(args: EmptyObject, t: T, u: U): T | U }>();
+
+  // @ts-expect-error: extra named arg
+  or({ hello: true }, 'a', 'b');
+
+  // @ts-expect-error: missing positional arg
+  or({}, 'a');
+
+  // @ts-expect-error: extra positional arg
+  or({}, 'a', 'b', 'c');
+
+  expectTypeOf(or({}, 'a', 'b')).toEqualTypeOf<string>();
+  expectTypeOf(or({}, 'a', true)).toEqualTypeOf<string | boolean>();
+  expectTypeOf(or({}, false, true)).toEqualTypeOf<boolean>();
+}
+
+// With bound args
+{
+  interface InfoSignature {
+    Args: { Named: { age: number; name: string } };
+    Return: string;
+  }
+
+  let definition!: WithBoundArgs<HelperLike<InfoSignature>, 'name'>;
+
+  expectTypeOf(resolve(definition)).toEqualTypeOf<
+    (args: { age: number; name?: string }) => string
+  >();
+}

--- a/packages/template/__tests__/modifier-like.test.ts
+++ b/packages/template/__tests__/modifier-like.test.ts
@@ -1,0 +1,78 @@
+import '@glint/environment-ember-loose/native-integration';
+import { resolve } from '@glint/environment-ember-loose/-private/dsl';
+import { expectTypeOf } from 'expect-type';
+import { BoundModifier } from '@glint/template/-private/integration';
+import { ModifierLike, WithBoundArgs } from '@glint/template';
+
+// Fixed signature params
+{
+  interface NeatModifierSignature {
+    Args: {
+      Named: { multiplier?: number };
+      Positional: [input: string];
+    };
+    Element: HTMLImageElement;
+  }
+
+  let NeatModifier!: ModifierLike<NeatModifierSignature>;
+  let neat = resolve(NeatModifier);
+
+  expectTypeOf(neat({}, 'hello')).toEqualTypeOf<BoundModifier<HTMLImageElement>>();
+  expectTypeOf(neat({ multiplier: 3 }, 'hello')).toEqualTypeOf<BoundModifier<HTMLImageElement>>();
+
+  // @ts-expect-error: missing required positional arg
+  neat({});
+
+  // @ts-expect-error: extra positional arg
+  neat({}, 'hello', 'goodbye');
+
+  // @ts-expect-error: invalid type for named arg
+  neat({ multiplier: 'hi' }, 'message');
+
+  // @ts-expect-error: invalid named arg
+  neat({ hello: 123 }, 'message');
+}
+
+// Generic params
+{
+  interface OnDestroySignature<T> {
+    Args: {
+      Named: { value: T };
+      Positional: [(value: T) => void];
+    };
+    Element: HTMLCanvasElement;
+  }
+  let definition!: new <T>() => InstanceType<ModifierLike<OnDestroySignature<T>>>;
+  let onDestroy = resolve(definition);
+
+  expectTypeOf(onDestroy({ value: 'hello' }, (value) => value.charAt(0))).toEqualTypeOf<
+    BoundModifier<HTMLCanvasElement>
+  >();
+
+  // @ts-expect-error: missing required positional arg
+  onDestroy({ value: 'hi' });
+
+  onDestroy(
+    { value: 'hi' },
+    'hello',
+    // @ts-expect-error: extra positional arg
+    'goodbye'
+  );
+
+  // @ts-expect-error: mismatched arg types
+  onDestroy({ value: 123 }, (value: string) => value.length);
+}
+
+// With bound args
+{
+  interface NeatModifierSignature {
+    Args: { Named: { multiplier: number; input: string } };
+    Element: HTMLImageElement;
+  }
+
+  let NeatModifier!: WithBoundArgs<ModifierLike<NeatModifierSignature>, 'multiplier'>;
+
+  expectTypeOf(resolve(NeatModifier)).toEqualTypeOf<
+    (args: { multiplier?: number; input: string }) => BoundModifier<HTMLImageElement>
+  >();
+}

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -5,7 +5,7 @@
   "description": "Type definitions to back typechecking for Glimmer templates",
   "license": "MIT",
   "author": "Dan Freeman (https://github.com/dfreeman)",
-  "types": "index.d.ts",
+  "types": "-private/index.d.ts",
   "scripts": {
     "lint": "eslint . --max-warnings 0 && prettier --check .",
     "test": "tsc --project __tests__"

--- a/test-packages/ts-ember-app/app/components/bar/index.ts
+++ b/test-packages/ts-ember-app/app/components/bar/index.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@ember/component';
 
 export interface BarSignature {
   Args: {

--- a/test-packages/ts-ember-app/app/components/ember-component.ts
+++ b/test-packages/ts-ember-app/app/components/ember-component.ts
@@ -1,15 +1,17 @@
-import Component, { ArgsFor } from '@glint/environment-ember-loose/ember-component';
+import Component from '@ember/component';
+
+export interface EmberComponentArgs {
+  required: string;
+  hasDefault?: string;
+  optional?: number;
+}
 
 export interface EmberComponentSignature {
   Element: HTMLDivElement;
-  Args: {
-    required: string;
-    hasDefault?: string;
-    optional?: number;
-  };
+  Args: EmberComponentArgs;
 }
 
-export default interface EmberComponent extends ArgsFor<EmberComponentSignature> {}
+export default interface EmberComponent extends EmberComponentArgs {}
 export default class EmberComponent extends Component<EmberComponentSignature> {
   public hasDefault = 'defaultValue';
 

--- a/test-packages/ts-ember-app/app/components/foo.ts
+++ b/test-packages/ts-ember-app/app/components/foo.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@ember/component';
 
 export default class Foo extends Component {
   name = 'FOO';

--- a/test-packages/ts-ember-app/app/components/qux.ts
+++ b/test-packages/ts-ember-app/app/components/qux.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@ember/component';
 
 export default class Qux extends Component {
   name = 'QUX';

--- a/test-packages/ts-ember-app/app/components/template-only-module.ts
+++ b/test-packages/ts-ember-app/app/components/template-only-module.ts
@@ -1,8 +1,8 @@
-import templateOnlyComponent from '@glint/environment-ember-loose/ember-component/template-only';
+import templateOnlyComponent from '@ember/component/template-only';
 
 interface TemplateOnlyModuleSignature {
   Args: { message: string };
-  Yields: { default: [] };
+  Blocks: { default: [] };
 }
 
 const TemplateOnlyModule = templateOnlyComponent<TemplateOnlyModuleSignature>();

--- a/test-packages/ts-ember-app/app/components/test-cases/subclassing/parent.ts
+++ b/test-packages/ts-ember-app/app/components/test-cases/subclassing/parent.ts
@@ -1,3 +1,3 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@ember/component';
 
 export default class ParentClass extends Component {}

--- a/test-packages/ts-ember-app/app/components/wrapper-component.ts
+++ b/test-packages/ts-ember-app/app/components/wrapper-component.ts
@@ -1,5 +1,5 @@
-import { ComponentLike, ComponentWithBoundArgs } from '@glint/environment-ember-loose';
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import { ComponentLike, WithBoundArgs } from '@glint/template';
+import Component from '@ember/component';
 import EmberComponent from './ember-component';
 
 interface WrapperComponentSignature {
@@ -7,10 +7,10 @@ interface WrapperComponentSignature {
   Args: {
     value: string;
   };
-  Yields: {
+  Blocks: {
     default: [
       {
-        InnerComponent: ComponentWithBoundArgs<typeof EmberComponent, 'required'>;
+        InnerComponent: WithBoundArgs<typeof EmberComponent, 'required'>;
         MaybeComponent?: ComponentLike<{ Args: { key: string } }>;
         stringValue?: string;
       }

--- a/test-packages/ts-ember-app/app/helpers/repeat.ts
+++ b/test-packages/ts-ember-app/app/helpers/repeat.ts
@@ -1,4 +1,4 @@
-import { helper } from '@glint/environment-ember-loose/ember-component/helper';
+import { helper } from '@ember/component/helper';
 
 function repeat(params: [string, number] /*, hash*/) {
   return params[0].repeat(params[1]);

--- a/test-packages/ts-ember-app/app/pods/components/baz/component.ts
+++ b/test-packages/ts-ember-app/app/pods/components/baz/component.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@ember/component';
 
 export interface BazSignature {
   Args: { optional?: string };

--- a/test-packages/ts-ember-app/types/demo-ember-app/index.d.ts
+++ b/test-packages/ts-ember-app/types/demo-ember-app/index.d.ts
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import '@glint/environment-ember-loose';
+import '@glint/environment-ember-loose/native-integration';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/test-packages/ts-ember-app/types/ember-welcome-page/index.d.ts
+++ b/test-packages/ts-ember-app/types/ember-welcome-page/index.d.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/ember-component';
+import Component from '@ember/component';
 
 declare class WelcomePage extends Component {}
 


### PR DESCRIPTION
One of the pending items from #283 is providing projects using native imports and signatures with a way to describe the type of yielded components, as `@glint/environment-ember-loose`'s `ComponentLike` currently does. This is a vital piece for describing the signature of components that do things like:

```hbs
{{yield (hash
  Input=(component "our-special-input" thing=this.defaultThingValue}}
)}}
```

Now that signature formats have been more or less standardized across the board, we can expose standardized `ComponentLike`, `HelperLike` and `ModifierLike` types from `@glint/template` itself rather than homing them in an environment-specific location. Subclasses of `Component`, `Helper` and `Modifier` are respectively assignable to their corresponding `*Like` types, as are the return values from `helper()` and `modifier()`.

Each of these types is compatible as the first argument of a new `WithBoundArgs` helper, which will return an equivalent type except for any named args mentioned in the second argument being made optional. Capturing the above template example in a signature:

```ts
interface TheSignature {
  Blocks: {
    default: [{
      Input: WithBoundArgs<typeof OurSpecialInput, 'thing'>
    }];
  };
}
```

The `@glint/template` package is a types-only package that provides the baseline type declarations that all Glint environments are based on, and as such is something that addons can declare a dependency on without having any (even theoretical) runtime impact on their consumers.