### PR TITLE
Deprecate `environment-ember-loose` reexports

### DIFF
--- a/packages/environment-ember-loose/-private/utilities.ts
+++ b/packages/environment-ember-loose/-private/utilities.ts
@@ -26,6 +26,8 @@ export type YieldsOf<C extends ComponentLike> = C extends Constructor<
 /**
  * The basic shape of a valid component signature. See the
  * README for further details.
+ *
+ * @deprecated Define signatures with no parent interface.
  */
 export type ComponentSignature = {
   Args?: object;
@@ -38,6 +40,8 @@ export type ComponentSignature = {
  * A value that is invokable like a component in a template. Notably,
  * subclasses of `EmberComponent` and `GlimmerComponent` are `ComponentLike`,
  * as are the values returned from the `{{component}}` helper.
+ *
+ * @deprecated Use `ComponentLike` from `@glint/template`.
  */
 export type ComponentLike<T extends ComponentSignature = any> = Constructor<
   Invokable<
@@ -83,6 +87,8 @@ export type ComponentLike<T extends ComponentSignature = any> = Constructor<
  * in a place where you said to expect the `foo` arg to already be
  * bound, that won't be flagged as an error if `strictFunctionTypes`
  * is disabled.
+ *
+ * @deprecated Use `WithBoundArgs` from `@glint/template`.
  */
 export type ComponentWithBoundArgs<
   T extends ComponentLike,

--- a/packages/environment-ember-loose/ember-component/helper.ts
+++ b/packages/environment-ember-loose/ember-component/helper.ts
@@ -16,8 +16,10 @@ type HelperFactory = <Positional extends unknown[] = [], Named = EmptyObject, Re
   fn: (params: Positional, hash: Named) => Return
 ) => new () => Invokable<(named: Named, ...positional: Positional) => Return>;
 
+/** @deprecated Import directly from `@ember/component/helper` instead. */
 export const helper = emberHelper as unknown as HelperFactory;
 
+/** @deprecated Define signatures with no parent interface. */
 export interface HelperSignature {
   NamedArgs?: object;
   PositionalArgs?: Array<unknown>;
@@ -36,6 +38,7 @@ type HelperConstructor = {
 // Overriding `compute` directly is impossible because the base class has such
 // wide parameter types, so we explicitly exclude that from the interface we're
 // extending here so our override can "take" without an error.
+/** @deprecated Import directly from `@ember/component/helper`. */
 const Helper = EmberHelper as unknown as StaticSide<typeof EmberHelper> & HelperConstructor;
 
 type Helper<T extends HelperSignature> = Omit<EmberHelper, 'compute'> & HelperIntegration<T>;

--- a/packages/environment-ember-loose/ember-component/index.ts
+++ b/packages/environment-ember-loose/ember-component/index.ts
@@ -23,6 +23,7 @@ type Get<T, Key, Otherwise = EmptyObject> = Key extends keyof T
   ? Exclude<T[Key], undefined>
   : Otherwise;
 
+/** @deprecated Define your named args in an interface and extend that. */
 export type ArgsFor<T extends ComponentSignature> = 'Args' extends keyof T ? T['Args'] : {};
 
 // Factoring this into a standalone type prevents `tsc` from expanding the
@@ -34,6 +35,7 @@ type ComponentConstructor = {
   ): Component<T>;
 };
 
+/** @deprecated Import directly from `@ember/component`. */
 const Component = EmberComponent as unknown as StaticSide<typeof EmberComponent> &
   ComponentConstructor;
 

--- a/packages/environment-ember-loose/ember-modifier/index.ts
+++ b/packages/environment-ember-loose/ember-modifier/index.ts
@@ -22,8 +22,10 @@ type ModifierFactory = <El extends Element, Positional extends unknown[] = [], N
   fn: (element: El, positional: Positional, named: Named) => unknown
 ) => new () => Invokable<(named: Named, ...positional: Positional) => BoundModifier<El>>;
 
+/** @deprecated Import directly from `ember-modifier`. */
 export const modifier = emberModifier as ModifierFactory;
 
+/** @deprecated Define signatures with no parent interface.  */
 export interface ModifierSignature {
   NamedArgs?: object;
   PositionalArgs?: Array<unknown>;
@@ -40,6 +42,7 @@ type ModifierConstructor = {
   ): Modifier<T>;
 };
 
+/** @deprecated Import directly from `ember-modifier`. */
 const Modifier = EmberModifier as StaticSide<EmberModifierConstructor> & ModifierConstructor;
 
 type Modifier<T extends ModifierSignature> = EmberModifier<{

--- a/packages/environment-ember-loose/glimmer-component/index.ts
+++ b/packages/environment-ember-loose/glimmer-component/index.ts
@@ -27,6 +27,7 @@ type ComponentConstructor = {
   new <T extends ComponentSignature = {}>(owner: unknown, args: unknown): Component<T>;
 };
 
+/** @deprecated Import directly from `@glimmer/component`. */
 const Component = GlimmerComponent as unknown as StaticSide<GlimmerComponentConstructor> &
   ComponentConstructor;
 

--- a/packages/vscode/__fixtures__/ember-app/app/app.ts
+++ b/packages/vscode/__fixtures__/ember-app/app/app.ts
@@ -1,0 +1,2 @@
+import '@glint/environment-ember-loose';
+import '@glint/environment-ember-loose/native-integration';

--- a/packages/vscode/__fixtures__/ember-app/app/components/classic-layout.ts
+++ b/packages/vscode/__fixtures__/ember-app/app/components/classic-layout.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 
 export default class ClassicLayoutComponent extends Component {
   private message = 'hello';

--- a/packages/vscode/__fixtures__/ember-app/app/components/colocated-layout.ts
+++ b/packages/vscode/__fixtures__/ember-app/app/components/colocated-layout.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 
 export default class ColocatedLayoutComponent extends Component {
   private message = 'hello';

--- a/packages/vscode/__fixtures__/ember-app/app/components/pod-layout/component.ts
+++ b/packages/vscode/__fixtures__/ember-app/app/components/pod-layout/component.ts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 
 export default class PodLayoutComponent extends Component {
   private message = 'hello';


### PR DESCRIPTION
This marks all of the exported types and values from `@glint/environment-ember-loose` as deprecated with pointers to alternatives.