### PR TITLE
Use `SilentError` when no config is found

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,7 +21,8 @@
     "cosmiconfig": "^6.0.0",
     "escape-string-regexp": "^4.0.0",
     "minimatch": "^3.0.4",
-    "resolve": "^1.17.0"
+    "resolve": "^1.17.0",
+    "silent-error": "^1.1.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { GlintConfig } from './config';
+import SilentError from 'silent-error';
 
 export { GlintConfig } from './config';
 export {
@@ -20,7 +21,7 @@ export {
 export function loadConfig(from: string): GlintConfig {
   let config = findConfig(from);
   if (!config) {
-    throw new Error(`Unable to find Glint configuration for ${from}`);
+    throw new SilentError(`Unable to find Glint configuration for ${from}`);
   }
 
   return config;

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src", "types"]
 }

--- a/packages/config/types/silent-error.d.ts
+++ b/packages/config/types/silent-error.d.ts
@@ -1,0 +1,4 @@
+declare module 'silent-error' {
+  export default class SilentError extends Error {}
+}
+


### PR DESCRIPTION
Throwing a regular error gave an IMO confusing error message, with the full stack trace etc.

![image](https://user-images.githubusercontent.com/1325249/163015590-d8b70538-57f5-4830-955b-a2625b24daf9.png)
