### PR TITLE
Enable dumping of the intermediate representation source code

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -23,6 +23,10 @@ const { argv } = yargs
     boolean: true,
     description: 'Whether to emit declaration files',
   })
+  .option('debug-intermediate-representation', {
+    boolean: false,
+    description: `When true, writes out a Glint's internal intermediate representation of each file within a GLINT_DEBUG subdirectory of the current working directory. This is intended for debugging Glint itself.`,
+  })
   .wrap(100)
   .strict();
 
@@ -30,6 +34,16 @@ const ts = loadTypeScript();
 const glintConfig = loadConfig(process.cwd());
 const tsconfigPath = argv.project ?? ts.findConfigFile('.', ts.sys.fileExists);
 const optionsToExtend = determineOptionsToExtend(argv);
+
+if (argv['debug-intermediate-representation']) {
+  const fs = require('fs');
+  const path = require('path');
+  (globalThis as any).GLINT_DEBUG_IR = function (filename: string, content: string) {
+    let target = path.join('GLINT_DEBUG', path.relative(glintConfig.rootDir, filename));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  };
+}
 
 if (argv.watch) {
   performWatch(ts, glintConfig, tsconfigPath, optionsToExtend);

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -122,6 +122,8 @@ export function rewriteModule(
   let sparseSpans = completeCorrelatedSpans(partialSpans);
   let { contents, correlatedSpans } = calculateTransformedSource(script, sparseSpans);
 
+  (globalThis as any).GLINT_DEBUG_IR?.(script.filename, contents);
+
   return new TransformedModule(contents, errors, directives, correlatedSpans);
 }
 


### PR DESCRIPTION
This adds a new flag to the `glint` CLI command that causes it to write out the internal intermediate representation of each file, after it has been transformed into the form that TypeScript itself will "see".

## Example usage:

Given an app containing:

```js
//  app/components/example.gts
import Component from '@glimmer/component';
export class A extends Component {
  <template>Hello</template>
}
```

Run `glint --debug-intermediate-representation`, and your project dir will also contain:

```js
// GLINT_DEBUG/app/components/example.gts
import Component from '@glimmer/component';

export class A extends Component {
  static { ({} as typeof import("glint-environment-ember-template-imports/-private/dsl")).template(function(𝚪: import("glint-environment-ember-template-imports/-private/dsl").ResolveContext<A>, χ: typeof import("glint-environment-ember-template-imports/-private/dsl")) {
  𝚪; χ;
}) as unknown }
}
```

## Design Decisions

I am not at all wedded to this particular interface, but I think it's reasonable. A few design decisions to note:

 - The value of cluttering up the public `--help` documentation with a "behind-the-scenes" option like this may be debatable. I think any downside is outweighed by the ease-of-discovery for new contributors. I kept only the long-form name because I think that implies the verbosity / low-level-nature of the feature.

 - I'm communicating this option via `globalThis` instead of adding it to something like `GlintEnvironment`. IMO, I think it's nicer to not complicate the other interfaces with a purely diagnostic feature like this, which justifies this "back-channel" communication.

 - I didn't do the file writing inline in `@glint/transform` because I think it will be easier to port Glint to new environments if a lower-level utility like `@glint/transform` avoids platform-specific features like `fs`. Whereas `@glint/core/src/cli` is already coordinating a lot of environment-specific stuff (like yargs and config file reading).