### PR TITLE
Fix preprocessed template locations

### DIFF
--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -25,6 +25,10 @@ export type GlintExtensionPreprocess<T> = (
 export type GlintEmitMetadata = {
   prepend?: string;
   append?: string;
+  templateLocation?: {
+    start: number;
+    end: number;
+  };
 };
 
 export type GlintExtensionTransform<T> = (


### PR DESCRIPTION
This is a fix for #297.

It allows environment-defined transforms to emit template locations via meta instead of using `node.pos` (which is unreliable when the source has been preprocessed into an intermediate form).