### PR TITLE
Extend volta config in test packages

### DIFF
--- a/test-packages/glint-environment-custom-test/package.json
+++ b/test-packages/glint-environment-custom-test/package.json
@@ -8,5 +8,8 @@
   "scripts": {
     "test": "true",
     "lint": "true"
+  },
+  "volta": {
+    "node": "14.19.1"
   }
 }

--- a/test-packages/glint-environment-custom-test/package.json
+++ b/test-packages/glint-environment-custom-test/package.json
@@ -10,6 +10,6 @@
     "lint": "true"
   },
   "volta": {
-    "node": "14.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/test-packages/js-glimmerx-app/package.json
+++ b/test-packages/js-glimmerx-app/package.json
@@ -111,6 +111,6 @@
   },
   "private": true,
   "volta": {
-    "node": "14.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/test-packages/js-glimmerx-app/package.json
+++ b/test-packages/js-glimmerx-app/package.json
@@ -109,5 +109,8 @@
   "engines": {
     "node": ">= 14.0"
   },
-  "private": true
+  "private": true,
+  "volta": {
+    "node": "14.19.1"
+  }
 }

--- a/test-packages/ts-custom-app/package.json
+++ b/test-packages/ts-custom-app/package.json
@@ -8,6 +8,6 @@
     "test": "glint"
   },
   "volta": {
-    "node": "14.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/test-packages/ts-custom-app/package.json
+++ b/test-packages/ts-custom-app/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "lint": "true",
     "test": "glint"
+  },
+  "volta": {
+    "node": "14.19.1"
   }
 }

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -63,5 +63,8 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "volta": {
+    "node": "14.19.1"
   }
 }

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -65,6 +65,6 @@
     "edition": "octane"
   },
   "volta": {
-    "node": "14.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/test-packages/ts-glimmerx-app/package.json
+++ b/test-packages/ts-glimmerx-app/package.json
@@ -130,6 +130,6 @@
   },
   "private": true,
   "volta": {
-    "node": "14.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/test-packages/ts-glimmerx-app/package.json
+++ b/test-packages/ts-glimmerx-app/package.json
@@ -128,5 +128,8 @@
   "engines": {
     "node": ">= 12.0"
   },
-  "private": true
+  "private": true,
+  "volta": {
+    "node": "14.19.1"
+  }
 }

--- a/test-packages/ts-glimmerx-app/package.json
+++ b/test-packages/ts-glimmerx-app/package.json
@@ -126,7 +126,7 @@
     ]
   },
   "engines": {
-    "node": ">= 12.0"
+    "node": ">= 14.0"
   },
   "private": true,
   "volta": {


### PR DESCRIPTION
This makes working directly in test packages nicer when your default node version is < 14.