### PR TITLE
Add @glint-nocheck directive.

### DIFF
--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -117,6 +117,20 @@ describe('rewriteTemplate', () => {
       ]);
     });
 
+    test('nocheck', () => {
+      let template = stripIndent`
+        {{! @glint-nocheck }}
+        <Foo />
+        {{foo-bar}}
+        {{this.baz}}
+      `;
+
+      let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
+
+      expect(errors).toEqual([]);
+      expect(result?.code).toMatchInlineSnapshot(`""`);
+    });
+
     test('expect-error', () => {
       let template = stripIndent`
         {{! @glint-expect-error: this is fine }}

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -119,7 +119,7 @@ describe('rewriteTemplate', () => {
 
     test('nocheck', () => {
       let template = stripIndent`
-        {{! @glint-nocheck }}
+        {{! @glint-nocheck: don't check this whole template }}
         <Foo />
         {{foo-bar}}
         {{this.baz}}
@@ -128,7 +128,27 @@ describe('rewriteTemplate', () => {
       let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
 
       expect(errors).toEqual([]);
-      expect(result?.code).toMatchInlineSnapshot(`""`);
+      expect(result?.directives).toEqual([
+        {
+          kind: 'ignore',
+          location: {
+            start: 0,
+            end: template.indexOf('template }}') + 'template }}'.length,
+          },
+          areaOfEffect: {
+            start: 0,
+            end: template.length -1,
+          },
+        },
+      ]);
+      expect(templateBody(template)).toMatchInlineSnapshot(`
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])({}));
+          𝛄;
+        }
+        χ.emitValue(χ.resolveOrReturn(χ.Globals[\\"foo-bar\\"])({}));
+        χ.emitValue(χ.resolveOrReturn(𝚪.this.baz)({}));"
+      `);
     });
 
     test('expect-error', () => {

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -41,6 +41,14 @@ export function templateToTypescript(
   return mapTemplateContents(template, (ast, { emit, record, rangeForLine, rangeForNode }) => {
     let scope = new ScopeStack([]);
 
+    const firstNode = ast.body[0];
+    if (firstNode?.type === 'MustacheCommentStatement') {
+      let text = firstNode.value.trim();
+      if (/^@glint-nocheck/i.test(text)) {
+        return;
+      }
+    }
+
     emitTemplateBoilerplate(() => {
       for (let line of preamble) {
         emit.text(line);

--- a/packages/transform/src/template-to-typescript.ts
+++ b/packages/transform/src/template-to-typescript.ts
@@ -66,7 +66,7 @@ export function templateToTypescript(
 
         case 'CommentStatement':
         case 'MustacheCommentStatement':
-          return emitComment(node, template.length);
+          return emitComment(node);
 
         case 'MustacheStatement':
           return emitTopLevelMustacheStatement(node);
@@ -148,10 +148,7 @@ export function templateToTypescript(
       }
     }
 
-    function emitComment(
-      node: AST.MustacheCommentStatement | AST.CommentStatement,
-      templateLength?: number
-    ): void {
+    function emitComment(node: AST.MustacheCommentStatement | AST.CommentStatement): void {
       emit.nothing(node);
 
       let text = node.value.trim();
@@ -164,8 +161,8 @@ export function templateToTypescript(
         record.directive(kind, location, rangeForLine(node.loc.end.line + 1));
       } else if (kind === 'expect-error') {
         record.directive(kind, location, rangeForLine(node.loc.end.line + 1));
-      } else if (kind === 'nocheck' && templateLength) {
-        record.directive('ignore', location, { start: 0, end: templateLength - 1 });
+      } else if (kind === 'nocheck') {
+        record.directive('ignore', location, { start: 0, end: template.length - 1 });
       } else {
         record.error(`Unknown directive @glint-${kind}`, location);
       }

--- a/test-packages/ts-ember-app/app/components/nocheck-me.hbs
+++ b/test-packages/ts-ember-app/app/components/nocheck-me.hbs
@@ -1,0 +1,7 @@
+{{! @glint-nocheck }}
+
+{{this.nothing}}
+
+<Bar />
+
+{{repeat "foo"}}


### PR DESCRIPTION
This adds a `@glint-nocheck` directive, similar to [`@ts-nocheck` in .ts files](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#-ts-nocheck-in-typescript-files), that will cause Glint to not report errors for the whole template (while still providing autocompletion, types, and other diagnostics). It is basically a global `@git-ignore`. While `include` already provides a way to only check specified templates, workflows like [lint-to-the-future](https://github.com/mansona/lint-to-the-future) use file-based ignores. This provides a quick way to opt-out individual templates from type-checking that is easily discoverable by readers of the template.