### PR TITLE
docs: Fix broken link to VS Code extension

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -22,4 +22,4 @@ The CLI and language server currently have a few known limitations:
 
 - The CLI does not yet support composite projects or `tsc`'s `--build` mode.
 - The language server will only operate on projects with a `.glintrc` at their root, not in a subdirectories of the workspace root.
-- In VS Code, you will see diagnostics from both TypeScript and Glint in many files, as well as false 'unused symbol' positives for things only referenced in templates. See [the VS Code extension README](packages/vscode) for details on dealing with this.
+- In VS Code, you will see diagnostics from both TypeScript and Glint in many files, as well as false 'unused symbol' positives for things only referenced in templates. See [the VS Code extension README](../packages/vscode) for details on dealing with this.


### PR DESCRIPTION
Fixes a broken link in the docs by adjusting it's relative path.

The resulting link changes from

https://github.com/typed-ember/glint/blob/main/docs/packages/vscode

to 

https://github.com/typed-ember/glint/tree/main/packages/vscode