### PR TITLE
Handle explicit `Args: {}` and similar

### DIFF
--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -2,7 +2,7 @@ import {
   AcceptsBlocks,
   AnyFunction,
   BoundModifier,
-  EmptyObject,
+  GuardEmpty,
   FlattenBlockParams,
   Invokable,
 } from './integration';
@@ -14,12 +14,12 @@ import { ExpandSignature } from '@glimmer/component/-private/component';
  * `GlimmerComponent` are examples of `ComponentLike` values, as are
  * the values returned from the `{{component}}` helper.
  *
- * The `S` signature paramter here is of the same form as the one
+ * The `S` signature parameter here is of the same form as the one
  * accepted by both the Ember and Glimmer `Component` base classes.
  */
 export type ComponentLike<S = unknown> = InvokableConstructor<
   (
-    named: ExpandSignature<S>['Args']['Named'],
+    named: GuardEmpty<ExpandSignature<S>['Args']['Named']>,
     ...positional: ExpandSignature<S>['Args']['Positional']
   ) => AcceptsBlocks<
     FlattenBlockParams<ExpandSignature<S>['Blocks']>,
@@ -89,7 +89,7 @@ export type WithBoundArgs<
 >
   ? InvokableConstructor<
       (
-        named: Omit<Named, BoundArgs> & Partial<Pick<Named, BoundArgs & keyof Named>>,
+        named: GuardEmpty<Omit<Named, BoundArgs> & Partial<Pick<Named, BoundArgs & keyof Named>>>,
         ...positional: Positional
       ) => Result
     >
@@ -109,6 +109,6 @@ type Constrain<T, Constraint, Otherwise = Constraint> = T extends Constraint ? T
 // different layers of possible shorthand, but modifiers and helpers only have
 // one structure they can specify their args in, so this utility is sufficient.
 type InvokableArgs<S> = [
-  named: Get<Get<S, 'Args'>, 'Named', EmptyObject>,
+  named: GuardEmpty<Get<Get<S, 'Args'>, 'Named'>>,
   ...positional: Constrain<Get<Get<S, 'Args'>, 'Positional'>, Array<unknown>, []>
 ];

--- a/packages/template/-private/integration.d.ts
+++ b/packages/template/-private/integration.d.ts
@@ -25,6 +25,7 @@ export type HasContext<T extends AnyContext = AnyContext> = { [Context]: T };
 // special-cased in the type system not to trigger EPC.
 declare const EmptyObject: unique symbol;
 export type EmptyObject = { [EmptyObject]?: void };
+export type GuardEmpty<T> = T extends any ? (keyof T extends never ? EmptyObject : T) : never;
 
 declare const Element: unique symbol;
 declare const Modifier: unique symbol;

--- a/test-packages/ts-ember-app/tests/integration/types/empty-signature-test.ts
+++ b/test-packages/ts-ember-app/tests/integration/types/empty-signature-test.ts
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { ComponentLike, HelperLike, ModifierLike } from '@glint/template';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Types | empty object signature members', function (hooks) {
+  setupRenderingTest(hooks);
+
+  /* eslint-disable @typescript-eslint/ban-types */
+  interface TestContext {
+    component: ComponentLike<{ Args: {}; Blocks: {} }>;
+    helper: HelperLike<{ Args: { Named: {} }; Return: void }>;
+    modifier: ModifierLike<{ Args: { Named: {} } }>;
+  }
+
+  test('component invocation', async function (assert) {
+    assert.expect(0);
+    await render<TestContext>(hbs`
+      <this.component />
+
+      {{! @glint-expect-error: shouldn't accept blocks }}
+      <this.component></this.component>
+
+      <this.component>
+        {{! @glint-expect-error: shouldn't accept blocks }}
+        <:named></:named>
+      </this.component>
+
+       <this.component
+        {{! @glint-expect-error: shouldn't accept args }}
+        @foo="hi"
+      />
+    `);
+  });
+
+  test('helper invocation', async function (assert) {
+    assert.expect(0);
+    await render<TestContext>(hbs`
+      {{this.helper}}
+
+      {{! @glint-expect-error: shouldn't accept args }}
+      {{this.helper arg='hello'}}
+    `);
+  });
+
+  test('modifier invocation', async function (assert) {
+    assert.expect(0);
+    await render<TestContext>(hbs`
+      <div {{this.modifier}}></div>
+
+      <div
+        {{! @glint-expect-error: shouldn't accept args }}
+        {{this.modifier arg='hello'}}
+      ></div>
+    `);
+  });
+});


### PR DESCRIPTION
Currently, if a developer explicitly writes `Args: {}` in their signature, that bypasses the `EmptyObject` shenanigans we do to ensure that [excess property checking](https://levelup.gitconnected.com/typescript-excess-property-checks-6ffe5584f450) is enabled when invoking a component (or helper, modifier, etc), because those only kick in when the `Args` key isn't specified at all.

This change adds a guard at the 'last mile' of signature expansion in `@glint/template` to explicitly detect `{}` (and other similar key-less types like `object`) and sub in `EmptyObject` instead.

This handles explicit `{}` usage from end users, and it also allows (but doesn't force) us to stop doing the `EmptyObject` dance in `@glimmer/component`, `ember-modifier` and `@types/ember__component` if we choose.