### PR TITLE
For Ember components, keep args in signature, use type alias

### DIFF
--- a/docs/ember/component-signatures.md
+++ b/docs/ember/component-signatures.md
@@ -77,18 +77,18 @@ Since Ember components don't have `this.args`, it takes slightly more boilerplat
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-// We break out the args into their own interface to reference below:
-export interface GreetingArgs {
-  message: string;
-  target?: string;
-}
-
 export interface GreetingSignature {
-  Args: GreetingArgs;
+  Args: {
+    message: string;
+    target?: string;
+  };
   Blocks: {
     default: [greeting: string];
   };
 }
+
+// We define this type alias so that we can extend it below:
+type GreetingArgs = GreetingSignature['Args'];
 
 // This line declares that our component's args will be 'splatted' on to the instance:
 export default interface Greeting extends GreetingArgs {}

--- a/docs/ember/component-signatures.md
+++ b/docs/ember/component-signatures.md
@@ -118,20 +118,20 @@ Ember components also support positional arguments in their signature. Such usag
 ```typescript
 // ...
 
-export interface GreetingArgs {
-  message: string;
-  target?: string;
-}
-
 export interface GreetingSignature {
   Args: {
-    Named: GreetingArgs;
+    Named: {
+      message: string;
+      target?: string;
+    };
     Positional: [extraSpecialPreamble: string];
   };
   Blocks: {
     default: [greeting: string];
   };
 }
+
+type GreetingArgs = GreetingSignature['Args']['Named'];
 
 export default interface Greeting extends GreetingArgs {}
 export default class Greeting extends Component<GreetingSignature> {


### PR DESCRIPTION
This updates the Ember component signature example in the docs to keep the args defined within the signature (like we teach for Glimmer components), and pull them out into a type alias that can be extended (`interface Greeting extends GreetingSignature['Args']` is not allowed, unfortunately). The motivation is that this form facilitates easier migration to Glimmer components because the signature is already in the form we want for Glimmer. Users would simply delete the `GreetingArgs` type alias and the `interface Greeting extends GreetingArgs {}` lines rather than needing to modify the signature by moving the arguments inside. I also think that the consistency between the Glimmer and Ember signatures is a win.