### PR TITLE
Minor docs fixes for Glint types for non ts addons section

### DIFF
--- a/docs/ember/authoring-addons.md
+++ b/docs/ember/authoring-addons.md
@@ -12,7 +12,7 @@ If all apps were already using [first class component templates] (i.e. [strict m
 
 As described in the [Using Addons] guide, the *easy* way for users is to import a file from the addon containing all the registry entries. This is for the most common case in which the app is consuming the addon provided components, helpers and modifiers as they are. The convention here is for the addon - when published on npm - to provide a `glint.d.ts` file, that the app will import as `import 'awesome-addon/glint'`. For a (v1) addon using [`ember-cli-typescript`][ect] this would be a `/addon/glint.ts` file, which needs to contain all the registry entries for all the public components (helpers, modifiers) the addon exposes to the app (in the addon's `/app` tree):
 
-{% code title="addon/glint.ts" %}
+{% code title="/addon/glint.ts" %}
 
 ```typescript
 import type AwesomeButton from 'awesome-addon/components/awesome-button';
@@ -33,15 +33,15 @@ While this easy way, which only requires the app to import this single file, is 
 
 This is given by letting the app manage the registry entries on its own, thereby being able to pick what to import from the addon directly and what to replace with its own custom types.
 
-Note: in apps, we generally define the registry entries right in the actual file itself so that it is nicely co-located with the signature and implementation. If an app imported such a module from an addon, though, TypeScript would see the registry declaration there and apply it, which is exactly what we want to prevent. For addons it is therefore recommended that all the registry entries are only added to the `addon/glint.ts` file as described above, and *not* to the file containing the actual class!
+Note: in apps, we generally define the registry entries right in the actual file itself so that it is nicely co-located with the signature and implementation. If an app imported such a module from an addon, though, TypeScript would see the registry declaration there and apply it, which is exactly what we want to prevent. For addons it is therefore recommended that all the registry entries are only added to the `/addon/glint.ts` file as described above, and *not* to the file containing the actual class!
 
 A real world example of this setup can be seen in [`ember-responsive-image`][eri]
 
 ## Adding Glint types to addons not written in TypeScript
 
-Even if an addon author has choosen not to adopt TypeScript, the addon can still ship Glint types! The setup, however, will be slightly different. First, without [`ember-cli-typescript`][ect], types in `addon/glint.ts` won't be emitted to `glint.d.ts` on publish, so you'll need to do what you would have done in `addon/glint.d.ts` in `glint.d.ts` instead. Also, since the components, helpers, and modifiers are not written in TypeScript, we can't add type signatures to them directly. Instead we'll need to create declaration files for them. And these files will need to use the importable path directly from the root of the addon (not under `addon/`). Here's an example:
+Even if an addon author has choosen not to adopt TypeScript, the addon can still ship Glint types! The setup, however, will be slightly different. First, without [`ember-cli-typescript`][ect], types in `/addon/glint.ts` won't be emitted to `/glint.d.ts` on publish, so you'll need to do what you would have done in `/addon/glint.d.ts` in `/glint.d.ts` instead. Also, since the components, helpers, and modifiers are not written in TypeScript, we can't add type signatures to them directly. Instead we'll need to create declaration files for them. And these files will need to use the importable path directly from the root of the addon (not under `/addon/`). Here's an example:
 
-{% code title="components/awesome-button.d.ts" %}
+{% code title="/components/awesome-button.d.ts" %}
 
 ```typescript
 import Component from '@glimmer/component';
@@ -58,7 +58,7 @@ export default class AwesomeButton extends Component<AwesomeButtonSignature> {}
 
 {% endcode %}
 
-{% code title="helpers/awesome-sauce.d.ts" %}
+{% code title="/helpers/awesome-sauce.d.ts" %}
 
 ```typescript
 import Helper from '@ember/component/helper';
@@ -75,7 +75,7 @@ export default class AwesomeSauce extends Helper<AwesomeSauceSignature> {}
 
 {% endcode %}
 
-{% code title="glint.d.ts" %}
+{% code title="/glint.d.ts" %}
 
 ```typescript
 import type AwesomeButton from './components/awesome-button';

--- a/docs/ember/authoring-addons.md
+++ b/docs/ember/authoring-addons.md
@@ -39,7 +39,7 @@ A real world example of this setup can be seen in [`ember-responsive-image`][eri
 
 ## Adding Glint types to addons not written in TypeScript
 
-Even if an addon author has choosen not to adopt TypeScript, the addon can still ship Glint types! The setup, however, will be slightly different. First, without [`ember-cli-typescript`][ect], types in `/addon/glint.ts` won't be emitted to `/glint.d.ts` on publish, so you'll need to do what you would have done in `/addon/glint.d.ts` in `/glint.d.ts` instead. Also, since the components, helpers, and modifiers are not written in TypeScript, we can't add type signatures to them directly. Instead we'll need to create declaration files for them. And these files will need to use the importable path directly from the root of the addon (not under `/addon/`). Here's an example:
+Even if an addon author has choosen not to adopt TypeScript, the addon can still ship Glint types! The setup, however, will be slightly different. First, without [`ember-cli-typescript`][ect], types in `/addon/glint.ts` won't be emitted to `/glint.d.ts` on publish, so you'll need to do what you would have done in `/addon/glint.ts` in `/glint.d.ts` instead. Also, since the components, helpers, and modifiers are not written in TypeScript, we can't add type signatures to them directly. Instead we'll need to create declaration files for them. And these files will need to use the importable path directly from the root of the addon (not under `/addon/`). Here's an example:
 
 {% code title="/components/awesome-button.d.ts" %}
 


### PR DESCRIPTION
- Add preceding `/` to all file paths for clarity/consistency
- Change reference to `/addon/glint.d.ts` to `/addon/glint.ts` for consistency