### PR TITLE
DOCS: Clarify Getting Started and Ember Installation pages

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -24,3 +24,4 @@
 - [Migrating](migrating.md)
 - [Diagnosing Common Error Messages](diagnosing-common-error-messages.md)
 - [Known Limitations](known-limitations.md)
+- [Glint Language Server](glint-language-server.md)

--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -34,3 +34,7 @@ Note that specifying `include` globs is optional, but may be a useful way to inc
 To minimize spurious errors when typechecking with vanilla `tsc` or your editor's TypeScript integration, you should add `import '@glint/environment-ember-loose';` somewhere in your project's source or type declarations. You may also choose to disable TypeScript's "unused symbol" warnings in your editor, since `tsserver` won't understand that templates actually are using them.
 
 {% endhint %}
+
+## Ember CLI TypeScript
+
+If you are using Glint with TypeScript and Ember, visit the [Ember CLI TypeScript documentation](https://docs.ember-cli-typescript.com/) for more information.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,19 +1,13 @@
 ## Setup
 
-You'll first need to add `@glint/core` and an appropriate Glint environment to your project's `devDependencies`.
-Check the section in the sidebar to the left for details about the specifics of working with Glint in a GlimmerX or Ember.js project.
+First, add `@glint/core` and an appropriate Glint environment to your project's `devDependencies`.
 
-Next, you'll add a `.glintrc.yml` file to the root of your project (typically alongside your `tsconfig.json` file). This file tells Glint what environment you're working in and, optionally, which files it should include in its typechecking:
+Then, add a `.glintrc.yml` file to the root of your project (typically alongside your `tsconfig.json` file). This file tells Glint what environment you're working in and, optionally, which files it should include in its typechecking.
 
-{% code title=".glintrc.yml" %}
+For setup instructions specific to your project type, check out the links below:
 
-```yaml
-environment: a-glint-environment
-include:
-  - 'app/**'
-```
-
-{% endcode %}
+- [GlimmerX Installation](glimmerx/installation.md)
+- [Ember.js Installation](ember/installation.md)
 
 Finally, you may choose to install an editor extension to display Glint's diagnostics inline in your templates and provide richer editor support, such as the [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,17 +9,18 @@ For setup instructions specific to your project type, check out the links below:
 - [GlimmerX Installation](glimmerx/installation.md)
 - [Ember.js Installation](ember/installation.md)
 
-Finally, you may choose to install an editor extension to display Glint's diagnostics inline in your templates and provide richer editor support, such as the [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode).
-
 ## Using Glint
 
 The `@glint/core` package includes two executables: `glint` and `glint-language-server`.
+
+### Glint CLI
 
 The `glint` CLI can be used to typecheck your project in a similar manner to `tsc`, but with understanding of how values flow through templates.
 
 ![A `tsc`-style template type error in the terminal](https://user-images.githubusercontent.com/108688/111076577-1d61db00-84ed-11eb-876a-e5b504758d11.png)
 
 You can use the `glint` executable in CI to ensure you maintain type safety in your templates.
+
 For example, in GitHub Actions you might change this:
 
 ```yaml
@@ -36,8 +37,11 @@ To this:
 
 You can also use the `glint` command locally with the `--watch` flag to monitor your project as you work!
 
-Similarly, `glint-language-server` can be used by editor integrations to expose that same information inline as you type.
+### Glint Editor Extensions
+
+You can install an editor extension to display Glint's diagnostics inline in your templates and provide richer editor support, powered by `glint-language-server`:
+
+- Install the [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode).
+- Learn more about the [Glint Language Server](glint-language-server.md).
 
 ![A type error being shown inline for a template file in VS Code](https://user-images.githubusercontent.com/108688/111076679-995c2300-84ed-11eb-934a-3a29f21be89a.png)
-
-The language server can also enable your editor to provide other richer help, such as type information on hover, automated refactoring, and more. See [the VS Code extension README](https://github.com/typed-ember/glint/tree/main/packages/vscode) for further examples.

--- a/docs/glint-language-server.md
+++ b/docs/glint-language-server.md
@@ -1,0 +1,5 @@
+The `glint-language-server` can be used by editor integrations to user Glint's typechecking features as you type:
+
+![A type error being shown inline for a template file in VS Code](https://user-images.githubusercontent.com/108688/111076679-995c2300-84ed-11eb-934a-3a29f21be89a.png)
+
+The language server enables your editor to provide richer help, such as typechecking, type information on hover, automated refactoring, and more. See [the VS Code extension README](https://github.com/typed-ember/glint/tree/main/packages/vscode) for further examples.


### PR DESCRIPTION
Clarifications to the Getting Started and Ember Installation pages per my comments on https://github.com/typed-ember/glint/pull/307. Specifically:

- Link directly to specific setup instructions in lieu of the somewhat confusing generic `.glintrc.yml` example.
- Link to ember-cli-typescript from Ember installation page since that package is so frequently used with this one. This is helpful if the user is not aware of the e-cli-ts package and got to the Glint docs by Googling "Ember TypeScript."
- Moves Glint Language Server docs to separate file to simplify the Getting Started page. The average user is not going to use the language server when they are just getting started.
- Some reformatting to make the page easier to skim.