### PR TITLE
Make Ember template-only components ComponentLike

### DIFF
--- a/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
@@ -41,10 +41,13 @@ interface TemplateOnlyComponentInstance<S> extends InstanceType<ComponentLike<S>
   [Context]: ComponentContext<void, S>;
 }
 
+// As with other abstract constructor types, this allows us to provide a class
+// and therefore have InstanceType work as needed, while forbidding construction
+// by end users.
+type TemplateOnlyConstructor<S> = abstract new () => TemplateOnlyComponentInstance<S>;
+
 declare module '@ember/component/template-only' {
-  export interface TemplateOnlyComponent<S> {
-    new (...args: [never]): TemplateOnlyComponentInstance<S>;
-  }
+  export interface TemplateOnlyComponent<S> extends TemplateOnlyConstructor<S> {}
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -9,6 +9,7 @@ import { AcceptsBlocks } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
 import { ComponentKeyword } from '../../-private/intrinsics/component';
 import { EmptyObject } from '@glimmer/component/-private/component';
+import { ComponentLike, WithBoundArgs } from '@glint/template';
 
 {
   const NoArgsComponent = templateOnlyComponent();
@@ -124,4 +125,23 @@ import { EmptyObject } from '@glimmer/component/-private/component';
   expectTypeOf(resolve(CurriedWithA)).toEqualTypeOf<
     (args: { a?: string; b: number }) => AcceptsBlocks<EmptyObject>
   >();
+}
+
+// Template-only components are `ComponentLike`
+{
+  interface TestSignature {
+    Args: {
+      item: string;
+    };
+    Blocks: {
+      default: [greeting: string];
+    };
+    Element: HTMLParagraphElement;
+  }
+
+  const BasicTOC = templateOnlyComponent<TestSignature>();
+  expectTypeOf(BasicTOC).toMatchTypeOf<ComponentLike<TestSignature>>();
+
+  // and therefore works correctly with `WithBoundArgs`
+  expectTypeOf<WithBoundArgs<typeof BasicTOC, 'item'>>().not.toBeNever();
 }


### PR DESCRIPTION
- Currently, template-only components do not work with `WithBoundArgs` because they are not `ComponentLike`. Introduce a failing test to demonstrate the problem (and prevent future regressions).
- Passing `args: never` instead of having an abstract constructor involved tripped up the assignability relation for `ComponentLike` with `TemplateOnlyComponent`: `new (arg: never) => Type` is not assignable to `new (...args: any) => Type` ([example][1]). Instead, introduce an abstract constructor type which the `TemplateOnlyComponent` interface can *extend*, using interface merging with the existing base definition in Ember itself (currently on DefinitelyTyped) to provide the desired semantics and constraints:
    - The type acts like a class for our purposes, meaning we can use it to get instance type info.
    - The type is *not* user-constructible (users cannot call `new` on it, since the constructor is `abstract`).

Thanks to @dfreeman for ID'ing the correct shape of the fix here!

[1]: https://tsplay.dev/WoGX8W