### PR TITLE
docs: change return value of page-title helper

### DIFF
--- a/docs/ember/using-addons.md
+++ b/docs/ember/using-addons.md
@@ -18,7 +18,7 @@ declare module '@glint/environment-ember-loose/registry' {
     WelcomePage: ComponentLike;
     'page-title': HelperLike<{
       Args: { Positional: [title: string] };
-      Return: void;
+      Return: '';
     }>;
   }
 }


### PR DESCRIPTION
The code for the `page-title` helper includes:

```js
  compute(params, _hash) {
    let hash = {
      ..._hash,
      id: this.tokenId,
      title: params.join(''),
    };

    this.tokens.push(hash);
    this.tokens.scheduleTitleUpdate();
    return '';
  }
```

https://github.com/ember-cli/ember-page-title/blob/9f3a3b979a8bbca9e41f5c274993a964dc0fa461/addon/src/helpers/page-title.js#L24

The return value of the helper is an empty string, and not `void`, so
I've updated the signature typing in the glint documentation.