### PR TITLE
Account for leading trivia in source files for LSP diagnostic locations

### DIFF
--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -213,6 +213,7 @@ describe('Language Server: Diagnostics', () => {
 
   test('reports diagnostics for an inline template type error', () => {
     let code = stripIndent`
+      // Here's a leading comment to make sure we handle trivia right
       import Component, { hbs } from '@glint/environment-glimmerx/component';
 
       type ApplicationArgs = {
@@ -241,11 +242,11 @@ describe('Language Server: Diagnostics', () => {
           "range": Object {
             "end": Object {
               "character": 21,
-              "line": 7,
+              "line": 8,
             },
             "start": Object {
               "character": 10,
-              "line": 7,
+              "line": 8,
             },
           },
           "severity": 2,
@@ -259,11 +260,11 @@ describe('Language Server: Diagnostics', () => {
           "range": Object {
             "end": Object {
               "character": 43,
-              "line": 11,
+              "line": 12,
             },
             "start": Object {
               "character": 31,
-              "line": 11,
+              "line": 12,
             },
           },
           "severity": 1,

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -134,8 +134,8 @@ export default class GlintLanguageServer {
           source: `glint${diagnostic.code ? `:ts(${diagnostic.code})` : ''}`,
           tags: tagsForDiagnostic(diagnostic),
           range: {
-            start: offsetToPosition(file.getText(), start),
-            end: offsetToPosition(file.getText(), start + length),
+            start: offsetToPosition(file.text, start),
+            end: offsetToPosition(file.text, start + length),
           },
         };
       });


### PR DESCRIPTION
We had an issue (#263) _only_ for diagnostics and _only_ for the language server where leading trivia (comments and whitespace) at the start of a file would cause offsets to be incorrect.