### PR TITLE
Don't flood the language server work queue when many changes come in

### DIFF
--- a/packages/core/src/common/scheduling.ts
+++ b/packages/core/src/common/scheduling.ts
@@ -5,6 +5,6 @@ export function debounce(threshold: number, f: () => void): () => void {
       clearTimeout(pending);
     }
 
-    setTimeout(f, threshold);
+    pending = setTimeout(f, threshold);
   };
 }


### PR DESCRIPTION
I think this area of the language server is going to get reworked a bit more broadly as we rethink the relationship between Glint and TS config locations and look toward better support for Glint projects set in arbitrary places in a workspace. For now, though, this fixes a silly (but terrible) but where we aren't actually canceling pending work like we mean to be when a change comes in.

Fixes #265