### PR TITLE
[bugfix] Cleanup for dependency issues and CLI/LSP consistency

### DIFF
--- a/packages/core/src/cli/options.ts
+++ b/packages/core/src/cli/options.ts
@@ -9,6 +9,7 @@ export function determineOptionsToExtend(argv: {
     options.emitDeclarationOnly = Boolean(argv.declaration);
   } else {
     options.noEmit = true;
+    options.declaration = false;
   }
 
   return options;

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -61,6 +61,7 @@ export default class GlintLanguageServer {
       getCurrentDirectory: ts.sys.getCurrentDirectory,
       directoryExists: ts.sys.directoryExists,
       getDirectories: ts.sys.getDirectories,
+      realpath: ts.sys.realpath,
     };
 
     this.service = ts.createLanguageService(serviceHost);

--- a/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
@@ -2,7 +2,7 @@ import { AcceptsBlocks, DirectInvokable, EmptyObject } from '@glint/template/-pr
 
 export type EachInKeyword = DirectInvokable<{
   <T>(args: EmptyObject, object: T): AcceptsBlocks<{
-    default: [key: EachInKey<T>, value: NonNullable<T>[EachInKey<T>]];
+    default: [key: EachInKey<T>, value: Exclude<T, null | undefined>[EachInKey<T>]];
     else?: [];
   }>;
 }>;
@@ -10,4 +10,4 @@ export type EachInKeyword = DirectInvokable<{
 // `{{each-in}}` internally uses `Object.keys`, so only string keys are included
 // TS, on the other hand, gives a wider result for `keyof` than many users expect
 // for record types: https://github.com/microsoft/TypeScript/issues/29249
-type EachInKey<T> = keyof NonNullable<T> & string;
+type EachInKey<T> = keyof Exclude<T, null | undefined> & string;

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -62,7 +62,7 @@ import { EmptyObject as GlintEmptyObject } from '@glint/template/-private/integr
   or({}, 'a', 'b', 'c');
 
   expectTypeOf(or({}, 'a', 'b')).toEqualTypeOf<string>();
-  expectTypeOf(or({}, 'a', true)).toEqualTypeOf<string | boolean>();
+  expectTypeOf(or({}, 'a' as string, true as boolean)).toEqualTypeOf<string | boolean>();
   expectTypeOf(or({}, false, true)).toEqualTypeOf<boolean>();
 }
 

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -31,6 +31,14 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-modifier": "^3.2.7"
   },
+  "peerDependenciesMeta": {
+    "ember-cli-htmlbars": {
+      "optional": true
+    },
+    "ember-modifier": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@glimmer/component": "^1.1.2",
     "@types/ember__component": "~4.0.8",

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -21,6 +21,9 @@
     "README.md",
     "-private/**/*.{js,d.ts}"
   ],
+  "dependencies": {
+    "@glint/template": "^0.8.2"
+  },
   "peerDependencies": {
     "@glint/environment-ember-loose": "^0.8.2",
     "ember-template-imports": "^3.0.0"

--- a/packages/environment-glimmerx/__tests__/helper.test.ts
+++ b/packages/environment-glimmerx/__tests__/helper.test.ts
@@ -43,7 +43,7 @@ import { expectTypeOf } from 'expect-type';
   or({}, 'a', 'b', 'c');
 
   expectTypeOf(or({}, 'a', 'b')).toEqualTypeOf<string>();
-  expectTypeOf(or({}, 'a', true)).toEqualTypeOf<string | boolean>();
+  expectTypeOf(or({}, 'a' as string, true as boolean)).toEqualTypeOf<string | boolean>();
   expectTypeOf(or({}, false, true)).toEqualTypeOf<boolean>();
 }
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,65 +1,71 @@
 {
-  "name": "glint-vscode",
-  "displayName": "Glint",
-  "description": "Glint language server integration for VS Code",
-  "version": "0.8.2",
-  "publisher": "typed-ember",
-  "preview": true,
-  "private": true,
-  "author": "James C. Davis (https://github.com/jamescdavis)",
-  "license": "MIT",
-  "main": "lib/extension.js",
-  "homepage": "https://github.com/typed-ember/glint/packages/vscode",
-  "repository": {
-    "url": "https://github.com/typed-ember/glint"
-  },
-  "keywords": [
-    "ember",
-    "glimmer",
-    "handlebars",
-    "typescript"
-  ],
-  "categories": [
-    "Programming Languages",
-    "Linters"
-  ],
-  "files": [
-    "README.md",
-    "lib"
-  ],
-  "scripts": {
-    "lint": "eslint . --max-warnings 0 && prettier --check src",
-    "test": "node __tests__/support/launch-from-cli.js",
-    "build": "tsc --build",
-    "vscode:prepublish": "yarn build"
-  },
-  "engines": {
-    "vscode": "^1.52.0"
-  },
-  "activationEvents": [
-    "workspaceContains:.glintrc*"
-  ],
-  "icon": "assets/glint.png",
-  "galleryBanner": {
-    "color": "#1E293B",
-    "theme": "dark"
-  },
-  "workspaces": {
-    "nohoist": [
-      "**/*"
-    ]
-  },
-  "dependencies": {
-    "resolve": "^1.20.0",
-    "vscode-languageclient": "^7.0.0"
-  },
-  "devDependencies": {
-    "@glint/core": "^0.8.2",
-    "@types/jest": "^26.0.13",
-    "@types/vscode": "^1.52.0",
-    "intercept-stdout": "^0.1.2",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.3.0",
-    "vscode-test": "^1.5.1"
-  }
+	"name": "glint-vscode",
+	"displayName": "Glint",
+	"description": "Glint language server integration for VS Code",
+	"version": "0.8.2",
+	"publisher": "typed-ember",
+	"preview": true,
+	"private": true,
+	"author": "James C. Davis (https://github.com/jamescdavis)",
+	"license": "MIT",
+	"main": "lib/extension.js",
+	"homepage": "https://github.com/typed-ember/glint/packages/vscode",
+	"repository": {
+		"url": "https://github.com/typed-ember/glint"
+	},
+	"keywords": [
+		"ember",
+		"glimmer",
+		"handlebars",
+		"typescript"
+	],
+	"categories": [
+		"Programming Languages",
+		"Linters"
+	],
+	"files": [
+		"README.md",
+		"lib"
+	],
+	"scripts": {
+		"lint": "eslint . --max-warnings 0 && prettier --check src",
+		"test": "node __tests__/support/launch-from-cli.js",
+		"build": "tsc --build",
+		"vscode:prepublish": "yarn build"
+	},
+	"engines": {
+		"vscode": "^1.52.0"
+	},
+	"activationEvents": [
+		"workspaceContains:.glintrc*"
+	],
+	"icon": "assets/glint.png",
+	"galleryBanner": {
+		"color": "#1E293B",
+		"theme": "dark"
+	},
+	"workspaces": {
+		"nohoist": [
+			"**/*"
+		]
+	},
+	"dependencies": {
+		"resolve": "^1.20.0",
+		"vscode-languageclient": "^7.0.0"
+	},
+	"devDependencies": {
+		"@glint/core": "^0.8.2",
+		"@types/jest": "^26.0.13",
+		"@types/vscode": "^1.52.0",
+		"intercept-stdout": "^0.1.2",
+		"jest": "^26.4.2",
+		"ts-jest": "^26.3.0",
+		"vscode-test": "^1.5.1"
+	},
+	"__metadata": {
+		"id": "f1370239-cb1d-475c-b9da-20961224a998",
+		"publisherDisplayName": "typed-ember",
+		"publisherId": "b79e9b30-918d-42b5-9460-27287aca13c4",
+		"isPreReleaseVersion": false
+	}
 }


### PR DESCRIPTION
This PR fixes up a couple of issues that have popped up recently:
 - The `ember-template-imports` environment is missing a declared dependency on `@glint/template`
 - The CLI emits `declaration`-related diagnostics even when `--declaration` isn't passed if `declaration: true` is set in your `tsconfig.json`
 - The language server doesn't resolve links the same way the `glint` CLI and `tsserver` both do, which can lead to different behavior in projects with `pnpm`'s linking shenanigans