### PR TITLE
Language server and Code extension improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release-it": "^14.4.1",
     "release-it-lerna-changelog": "^3.1.0",
     "release-it-yarn-workspaces": "^2.0.0",
-    "typescript": "^4.6.3"
+    "typescript": "^4.7.0"
   },
   "version": "0.8.3"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,8 @@
     "@glint/transform": "^0.8.3",
     "resolve": "^1.17.0",
     "uuid": "^8.3.2",
-    "vscode-languageserver": "^7.0.0",
-    "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-languageserver": "^8.0.1",
+    "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-uri": "^3.0.2",
     "yargs": "^15.3.1"
   },

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -9,7 +9,6 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { GlintCompletionItem } from './glint-language-server';
 import { LanguageServerPool } from './pool';
-import { uriToFilePath } from './util';
 
 export const capabilities: ServerCapabilities = {
   textDocumentSync: TextDocumentSyncKind.Full,
@@ -110,12 +109,8 @@ export function bindLanguageServerPool({ connection, pool, openDocuments }: Bind
   });
 
   connection.onDidChangeWatchedFiles(({ changes }) => {
-    let changePaths = changes.map((change) => ({ change, path: uriToFilePath(change.uri) }));
-
-    pool.forEachServer(({ server, rootDir, scheduleDiagnostics }) => {
-      for (let { change, path } of changePaths) {
-        if (!path.startsWith(rootDir)) continue;
-
+    pool.forEachServer(({ server, scheduleDiagnostics }) => {
+      for (let change of changes) {
         if (change.type === FileChangeType.Created) {
           server.watchedFileWasAdded(change.uri);
         } else if (change.type === FileChangeType.Deleted) {

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -9,6 +9,7 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { GlintCompletionItem } from './glint-language-server';
 import { LanguageServerPool } from './pool';
+import { GetIRRequest } from './messages';
 
 export const capabilities: ServerCapabilities = {
   textDocumentSync: TextDocumentSyncKind.Full,
@@ -106,6 +107,10 @@ export function bindLanguageServerPool({ connection, pool, openDocuments }: Bind
       symbols.push(...server.findSymbols(query));
     });
     return symbols;
+  });
+
+  connection.onRequest(GetIRRequest.type, ({ uri }) => {
+    return pool.withServerForURI(uri, ({ server }) => server.getTransformedContents(uri));
   });
 
   connection.onDidChangeWatchedFiles(({ changes }) => {

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -329,6 +329,14 @@ export default class GlintLanguageServer {
     return this.calculateOriginalLocations(references);
   }
 
+  public getTransformedContents(uri: string): string | null {
+    let filePath = uriToFilePath(uri);
+    let source = this.findDiagnosticsSource(filePath);
+    if (source !== filePath) return null;
+
+    return this.transformManager.readTransformedFile(filePath) ?? null;
+  }
+
   private calculateOriginalLocations(spans: ReadonlyArray<ts.DocumentSpan>): Array<Location> {
     return spans
       .map((span) => this.textSpanToLocation(span.fileName, span.textSpan))

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -101,7 +101,10 @@ export default class GlintLanguageServer {
   }
 
   public watchedFileWasAdded(uri: string): void {
-    this.rootFileNames.add(this.glintConfig.getSynthesizedScriptPathForTS(uriToFilePath(uri)));
+    let filePath = uriToFilePath(uri);
+    if (filePath.startsWith(this.glintConfig.rootDir)) {
+      this.rootFileNames.add(this.glintConfig.getSynthesizedScriptPathForTS(filePath));
+    }
   }
 
   public watchedFileDidChange(uri: string): void {

--- a/packages/core/src/language-server/messages.ts
+++ b/packages/core/src/language-server/messages.ts
@@ -1,0 +1,26 @@
+import { ProtocolRequestType } from 'vscode-languageserver';
+
+export type Request<Name extends string, T> = {
+  name: Name;
+  type: T;
+};
+
+export const GetIRRequest = makeRequestType(
+  'glint/getIR',
+  ProtocolRequestType<GetIRParams, string | null, void, void, void>
+);
+
+export interface GetIRParams {
+  uri: string;
+}
+
+// This utility allows us to encode type information to enforce that we're using
+// a valid request name along with its associated param/response types without
+// actually requring the runtime code here to be imported elsewhere.
+// See `requestKey` in the Code extension.
+function makeRequestType<Name extends string, T>(
+  name: Name,
+  RequestType: new (name: Name) => T
+): Request<Name, T> {
+  return { name, type: new RequestType(name) };
+}

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -24,6 +24,18 @@ describe('Smoke test: Ember', () => {
     }
   });
 
+  describe('debugging commands', () => {
+    test('showing IR', async () => {
+      let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
+      let editor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
+
+      await commands.executeCommand('glint.show-debug-ir');
+      await waitUntil(() => editor.document.getText().includes('𝚪'));
+
+      expect(editor.document.getText()).toMatch('𝚪.this.message');
+    });
+  });
+
   describe('diagnostics for errors', () => {
     test('component template', async () => {
       let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -40,6 +40,25 @@
     "workspaceContains:**/tsconfig.json",
     "workspaceContains:**/jsconfig.json"
   ],
+  "contributes": {
+    "configuration": [
+      {
+        "title": "Glint",
+        "properties": {
+          "glint.trace.server": {
+            "description": "Traces communication between VS Code and the Glint language server.",
+            "type": "string",
+            "default": "off",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ]
+          }
+        }
+      }
+    ]
+  },
   "icon": "assets/glint.png",
   "galleryBanner": {
     "color": "#1E293B",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -45,12 +45,22 @@
       {
         "title": "Glint: Restart Glint Server",
         "command": "glint.restart-language-server"
+      },
+      {
+        "title": "Glint: Show IR for Debugging",
+        "command": "glint.show-debug-ir",
+        "enablement": "config.glint.debug == true"
       }
     ],
     "configuration": [
       {
         "title": "Glint",
         "properties": {
+          "glint.debug": {
+            "description": "Enable debugging commands for Glint.",
+            "type": "boolean",
+            "default": false
+          },
           "glint.trace.server": {
             "description": "Traces communication between VS Code and the Glint language server.",
             "type": "string",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -41,6 +41,12 @@
     "workspaceContains:**/jsconfig.json"
   ],
   "contributes": {
+    "commands": [
+      {
+        "title": "Glint: Restart Glint Server",
+        "command": "glint.restart-language-server"
+      }
+    ],
     "configuration": [
       {
         "title": "Glint",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,72 +1,72 @@
 {
- "name": "glint-vscode",
- "displayName": "Glint",
- "description": "Glint language server integration for VS Code",
- "version": "0.8.3",
- "publisher": "typed-ember",
- "preview": true,
- "private": true,
- "author": "James C. Davis (https://github.com/jamescdavis)",
- "license": "MIT",
- "main": "lib/extension.js",
- "homepage": "https://github.com/typed-ember/glint/packages/vscode",
- "repository": {
-  "url": "https://github.com/typed-ember/glint"
- },
- "keywords": [
-  "ember",
-  "glimmer",
-  "handlebars",
-  "typescript"
- ],
- "categories": [
-  "Programming Languages",
-  "Linters"
- ],
- "files": [
-  "README.md",
-  "lib"
- ],
- "scripts": {
-  "lint": "eslint . --max-warnings 0 && prettier --check src",
-  "test": "node __tests__/support/launch-from-cli.js",
-  "build": "tsc --build",
-  "vscode:prepublish": "yarn build"
- },
- "engines": {
-  "vscode": "^1.52.0"
- },
- "activationEvents": [
-  "workspaceContains:**/tsconfig.json",
-  "workspaceContains:**/jsconfig.json"
- ],
- "icon": "assets/glint.png",
- "galleryBanner": {
-  "color": "#1E293B",
-  "theme": "dark"
- },
- "workspaces": {
-  "nohoist": [
-   "**/*"
-  ]
- },
- "dependencies": {
-  "resolve": "^1.20.0",
-  "vscode-languageclient": "^7.0.0"
- },
- "devDependencies": {
-  "@glint/core": "^0.8.3",
-  "@types/jest": "^26.0.13",
-  "@types/vscode": "^1.52.0",
-  "intercept-stdout": "^0.1.2",
-  "jest": "^26.4.2",
-  "ts-jest": "^26.3.0",
-  "vscode-test": "^1.5.1"
- },
- "__metadata": {
-  "id": "f1370239-cb1d-475c-b9da-20961224a998",
-  "publisherDisplayName": "typed-ember",
-  "publisherId": "b79e9b30-918d-42b5-9460-27287aca13c4",
-  "isPreReleaseVersion": false
- }
+  "name": "glint-vscode",
+  "displayName": "Glint",
+  "description": "Glint language server integration for VS Code",
+  "version": "0.8.3",
+  "publisher": "typed-ember",
+  "preview": true,
+  "private": true,
+  "author": "James C. Davis (https://github.com/jamescdavis)",
+  "license": "MIT",
+  "main": "lib/extension.js",
+  "homepage": "https://github.com/typed-ember/glint/packages/vscode",
+  "repository": {
+    "url": "https://github.com/typed-ember/glint"
+  },
+  "keywords": [
+    "ember",
+    "glimmer",
+    "handlebars",
+    "typescript"
+  ],
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
+  "files": [
+    "README.md",
+    "lib"
+  ],
+  "scripts": {
+    "lint": "eslint . --max-warnings 0 && prettier --check src",
+    "test": "node __tests__/support/launch-from-cli.js",
+    "build": "tsc --build",
+    "vscode:prepublish": "yarn build"
+  },
+  "engines": {
+    "vscode": "^1.52.0"
+  },
+  "activationEvents": [
+    "workspaceContains:**/tsconfig.json",
+    "workspaceContains:**/jsconfig.json"
+  ],
+  "icon": "assets/glint.png",
+  "galleryBanner": {
+    "color": "#1E293B",
+    "theme": "dark"
+  },
+  "workspaces": {
+    "nohoist": [
+      "**/*"
+    ]
+  },
+  "dependencies": {
+    "resolve": "^1.20.0",
+    "vscode-languageclient": "^8.0.1"
+  },
+  "devDependencies": {
+    "@glint/core": "^0.8.3",
+    "@types/jest": "^26.0.13",
+    "@types/vscode": "^1.68.1",
+    "intercept-stdout": "^0.1.2",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.3.0",
+    "vscode-test": "^1.5.1"
+  },
+  "__metadata": {
+    "id": "f1370239-cb1d-475c-b9da-20961224a998",
+    "publisherDisplayName": "typed-ember",
+    "publisherId": "b79e9b30-918d-42b5-9460-27287aca13c4",
+    "isPreReleaseVersion": false
+  }
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -18,6 +18,9 @@ export function activate(context: ExtensionContext): void {
   let watcher = workspace.createFileSystemWatcher(filePattern);
 
   context.subscriptions.push(watcher);
+  context.subscriptions.push(
+    commands.registerCommand('glint.restart-language-server', restartClients)
+  );
 
   workspace.workspaceFolders?.forEach((folder) => addWorkspaceFolder(folder, watcher));
   workspace.onDidChangeWorkspaceFolders(({ added, removed }) => {
@@ -30,6 +33,10 @@ export async function deactivate(): Promise<void> {
   await Promise.all([...clients.values()].map((client) => client.stop()));
 }
 
+async function restartClients(): Promise<void> {
+  outputChannel.appendLine(`Restarting Glint language server...`);
+  await Promise.all([...clients.values()].map((client) => client.restart()));
+}
 
 async function addWorkspaceFolder(
   workspaceFolder: WorkspaceFolder,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,72 +1,79 @@
-import { ExtensionContext, workspace, window, WorkspaceFolder } from 'vscode';
 import {
-  Disposable,
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-} from 'vscode-languageclient/node';
+  ExtensionContext,
+  workspace,
+  window,
+  WorkspaceFolder,
+  FileSystemWatcher,
+  commands,
+} from 'vscode';
+import { LanguageClient, ServerOptions } from 'vscode-languageclient/node';
 import { sync as resolve } from 'resolve';
 
-module.exports = {
-  activate(context: ExtensionContext) {
-    workspace.workspaceFolders?.forEach((folder) => addWorkspaceFolder(folder, context));
-    workspace.onDidChangeWorkspaceFolders(({ added, removed }) => {
-      added.forEach((folder) => addWorkspaceFolder(folder, context));
-      removed.forEach((folder) => removeWorkspaceFolder(folder, context));
-    });
-  },
-};
-
 const outputChannel = window.createOutputChannel('Glint Language Server');
-const clients = new Map<string, Disposable>();
+const clients = new Map<string, LanguageClient>();
+const extensions = ['.js', '.ts', '.gjs', '.gts', '.hbs'];
+const filePattern = `**/*{${extensions.join(',')}}`;
 
-function addWorkspaceFolder(workspaceFolder: WorkspaceFolder, context: ExtensionContext): void {
+export function activate(context: ExtensionContext): void {
+  let watcher = workspace.createFileSystemWatcher(filePattern);
+
+  context.subscriptions.push(watcher);
+
+  workspace.workspaceFolders?.forEach((folder) => addWorkspaceFolder(folder, watcher));
+  workspace.onDidChangeWorkspaceFolders(({ added, removed }) => {
+    added.forEach((folder) => addWorkspaceFolder(folder, watcher));
+    removed.forEach((folder) => removeWorkspaceFolder(folder));
+  });
+}
+
+export async function deactivate(): Promise<void> {
+  await Promise.all([...clients.values()].map((client) => client.stop()));
+}
+
+
+async function addWorkspaceFolder(
+  workspaceFolder: WorkspaceFolder,
+  watcher: FileSystemWatcher
+): Promise<void> {
   let folderPath = workspaceFolder.uri.fsPath;
   if (clients.has(folderPath)) return;
 
-  let serverArgs = [];
+  let serverPath = findLanguageServer(folderPath);
+  if (!serverPath) return;
+
+  let serverOptions: ServerOptions = { module: serverPath };
+  let client = new LanguageClient('glint', 'Glint', serverOptions, {
+    workspaceFolder,
+    outputChannel,
+    documentSelector: [{ scheme: 'file', pattern: `${folderPath}/${filePattern}` }],
+    synchronize: { fileEvents: watcher },
+  });
+
+  clients.set(folderPath, client);
+
+  await client.start();
+}
+
+async function removeWorkspaceFolder(workspaceFolder: WorkspaceFolder): Promise<void> {
+  let folderPath = workspaceFolder.uri.fsPath;
+  let client = clients.get(folderPath);
+  if (client) {
+    clients.delete(folderPath);
+    await client.stop();
+  }
+}
+
+function findLanguageServer(basedir: string): string | null {
   try {
-    serverArgs.unshift(resolve('@glint/core/bin/glint-language-server', { basedir: folderPath }));
+    return resolve('@glint/core/bin/glint-language-server', { basedir });
   } catch {
     // Many workspaces with `tsconfig` files won't be Glint projects, so it's totally fine for us to
     // just bail out if we don't see `@glint/core`. If someone IS expecting Glint to run for this
     // project, though, we leave a message in our channel explaining why we didn't launch.
     outputChannel.appendLine(
-      `Unable to resolve @glint/core from ${folderPath} — not launching Glint for this directory.`
+      `Unable to resolve @glint/core from ${basedir} — not launching Glint for this directory.`
     );
-    return;
-  }
 
-  let serverOptions: ServerOptions = {
-    run: { command: 'node', args: serverArgs },
-    debug: { command: 'node', args: ['--nolazy', `--inspect`, ...serverArgs] },
-  };
-
-  let extensions = ['.js', '.ts', '.gjs', '.gts', '.hbs'];
-  let filePattern = `${folderPath}/**/*{${extensions.join(',')}}`;
-
-  let clientOptions: LanguageClientOptions = {
-    workspaceFolder,
-    outputChannel,
-    documentSelector: [{ scheme: 'file', pattern: filePattern }],
-    synchronize: {
-      fileEvents: workspace.createFileSystemWatcher(filePattern),
-    },
-  };
-
-  const client = new LanguageClient('glint', 'Glint', serverOptions, clientOptions);
-  const disposable = client.start();
-
-  context.subscriptions.push(disposable);
-  clients.set(folderPath, disposable);
-}
-
-function removeWorkspaceFolder(workspaceFolder: WorkspaceFolder, context: ExtensionContext): void {
-  let folderPath = workspaceFolder.uri.fsPath;
-  let client = clients.get(folderPath);
-  if (client) {
-    clients.delete(folderPath);
-    context.subscriptions.splice(context.subscriptions.indexOf(client), 1);
-    client.dispose();
+    return null;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14660,10 +14660,10 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^4.7.0:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,10 +2616,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
-"@types/vscode@^1.52.0":
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.53.0.tgz#47b53717af6562f2ad05171bc9c8500824a3905c"
-  integrity sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==
+"@types/vscode@^1.68.1":
+  version "1.68.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.68.1.tgz#a9e5b33f825f715cae80593cb6d5d6d4cabbe998"
+  integrity sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==
 
 "@types/webpack-sources@*":
   version "1.4.0"
@@ -14999,44 +14999,44 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vscode-jsonrpc@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
-  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
+vscode-jsonrpc@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
+  integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
 
-vscode-languageclient@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
-  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
+vscode-languageclient@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz#bf5535c4463a78daeaca0bcb4f5868aec86bb301"
+  integrity sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==
   dependencies:
     minimatch "^3.0.4"
-    semver "^7.3.4"
-    vscode-languageserver-protocol "3.16.0"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.1"
 
-vscode-languageserver-protocol@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
-  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
+vscode-languageserver-protocol@3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz#e801762c304f740208b6c804a0cf21f2c87509ed"
+  integrity sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==
   dependencies:
-    vscode-jsonrpc "6.0.0"
-    vscode-languageserver-types "3.16.0"
+    vscode-jsonrpc "8.0.1"
+    vscode-languageserver-types "3.17.1"
 
-vscode-languageserver-textdocument@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
-  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
+vscode-languageserver-textdocument@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.5.tgz#838769940ece626176ec5d5a2aa2d0aa69f5095c"
+  integrity sha512-1ah7zyQjKBudnMiHbZmxz5bYNM9KKZYz+5VQLj+yr8l+9w3g+WAhCkUkWbhMEdC5u0ub4Ndiye/fDyS8ghIKQg==
 
-vscode-languageserver-types@3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
-  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
+vscode-languageserver-types@3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
+  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
-vscode-languageserver@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz#49b068c87cfcca93a356969d20f5d9bdd501c6b0"
-  integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
+vscode-languageserver@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz#56bd7a01f5c88af075a77f1d220edcb30fc4bdc7"
+  integrity sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==
   dependencies:
-    vscode-languageserver-protocol "3.16.0"
+    vscode-languageserver-protocol "3.17.1"
 
 vscode-test@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
## Overview

This PR contains a handful of quality-of-life improvements for the language server and Code extension.

I've declared two new configuration options for the extension:
  - `glint.trace.server`: The `vscode-languageserver` library already automatically honored this option to determine the level of logging it does for LSP messages, but now it shows up in the UI instead of requiring users to manually enter it in their preferences JSON file.
  - `glint.debug`: Enables additional debugging commands in the editor (see below)

I've also added two new commands:
  - `Glint: Restart Glint Server`: Manually restarts any active language server process(es), which is much quicker than restarting the entire Code extension host (and consistent with how TS itself and others work)
  - `Glint: Show IR for Debugging`: Only available when `glint.debug` is set. This command replaces the contents of the active editor with Glint's IR view of it, making it very easy to see exactly what's being emitted and how it's typechecking. I don't intend to document this anywhere, but I expect it to be a lot more useful for quick debugging than the CLI's `--debug-intermediate-representation` flag that dumps _everything_ into a directory.

Finally, I've tweaked a few automatic behaviors:
  - We now notify all active language server instances when a workspace file changes, which should fix #353 for the common case working in a monorepo.
  - We automatically restart any active language server processes in the workspace when a `tsconfig`-looking file changes on disk.

I also upgraded TS to 4.7 (I really wanted an [instantiation expression](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#instantiation-expressions) somewhere in this) and the `vscode-languageclient` and `vscode-languageserver` libraries to their respective latest versions.

## Notes

Regarding the fix for #353: a more general-purpose solution to ensure we always reflect changes on disk _anywhere_ looks like it would be significantly more involved. TypeScript's `createLanguageService` does no file watching on its own, instead relying on the editor to alert it when things change. That's mostly fine, but Code's watch implementation likes to ignore things in `node_modules` and outside the workspace. The most common case of working across packages within a monorepo is handled now, though, and the "restart glint" command makes it less painful when changes do get dropped, but we may still consider alternative approaches in the future if folks are still having trouble with this.

Potential options include manually setting up a watcher ourselves in the language server (usually a recipe for disaster, but possible), or investigating TypeScript's `ProjectService`, which is what `tsserver` uses under the covers to orchestrate these things, but doesn't appear to be documented and may not be extensible in the places we'd need.