### PR TITLE
Support the default helper manager RFC in `environment-ember-loose`

### DIFF
--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -38,6 +38,29 @@ To minimize spurious errors when typechecking with vanilla `tsc` or your editor'
 
 {% endhint %}
 
+## Functions as Helpers
+
+By default, `@glint/environment-ember-loose` includes support for the [default helper manager RFC](https://github.com/emberjs/rfcs/pull/756).
+
+If your project uses an older version of Ember, you can have Glint treat attempted use of functions as helpers as a type error by setting `allowPlainFunctionInvocation: false` in your environment configuration.
+
+{% code title="tsconfig.json" %}
+
+```javascript
+{
+  "compilerOptions": { /* ... */ },
+  "glint": {
+    "environment": {
+      "ember-loose": {
+        "allowPlainFunctionInvocation": false
+      }
+    }
+  }
+}
+```
+
+{% endcode %}
+
 ## Ember CLI TypeScript
 
 If you are using Glint with TypeScript and Ember, visit the [Ember CLI TypeScript documentation](https://docs.ember-cli-typescript.com/) for more information.

--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -11,7 +11,7 @@ describe('Environments', () => {
     test('locating a single tag', () => {
       let env = new GlintEnvironment(['test-env'], {
         tags: {
-          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
+          'my-cool-environment': { hbs: { typesModule: 'whatever' } },
         },
       });
 
@@ -23,9 +23,9 @@ describe('Environments', () => {
     test('locating one of several tags', () => {
       let env = new GlintEnvironment(['test-env'], {
         tags: {
-          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
-          'another-env': { tagMe: { typesSource: 'over-here' } },
-          'and-this-one': { hbs: { typesSource: '✨' } },
+          'my-cool-environment': { hbs: { typesModule: 'whatever' } },
+          'another-env': { tagMe: { typesModule: 'over-here' } },
+          'and-this-one': { hbs: { typesModule: '✨' } },
         },
       });
 
@@ -37,7 +37,7 @@ describe('Environments', () => {
     test('checking a module with no tags in use', () => {
       let env = new GlintEnvironment(['test-env'], {
         tags: {
-          'my-cool-environment': { hbs: { typesSource: 'whatever' } },
+          'my-cool-environment': { hbs: { typesModule: 'whatever' } },
         },
       });
 
@@ -50,7 +50,7 @@ describe('Environments', () => {
       let tags = {
         '@glimmerx/component': {
           hbs: {
-            typesSource: '@glint/environment-glimmerx/-private/dsl',
+            typesModule: '@glint/environment-glimmerx/-private/dsl',
           },
         },
       };
@@ -73,7 +73,7 @@ describe('Environments', () => {
     test('reflecting specified configuration', () => {
       let env = new GlintEnvironment(['test-env'], {
         template: {
-          typesPath: '@glint/test-env/types',
+          typesModule: '@glint/test-env/types',
           getPossibleTemplatePaths: (script) => [
             { path: script.replace('.ts', '.hbs'), deferTo: ['another/script.ts'] },
           ],
@@ -223,7 +223,7 @@ describe('Environments', () => {
       test('loading compatible environments', () => {
         let envA = createEnvironment('() => ({ tags: { "foo-bar": { hbs: {} } } })');
         let envB = createEnvironment(
-          '() => ({ tags: { "foo-bar": { tpl: {} }, "baz": { hbs: {} } }, template: { typesPath: "foo" } })'
+          '() => ({ tags: { "foo-bar": { tpl: {} }, "baz": { hbs: {} } }, template: { typesModule: "foo" } })'
         );
 
         let env = GlintEnvironment.load([envA, envB], { rootDir: testDir });
@@ -236,8 +236,8 @@ describe('Environments', () => {
       });
 
       test('loading conflicting standalone template config', () => {
-        let envA = createEnvironment('() => ({ template: { typesPath: "foo" } })');
-        let envB = createEnvironment('() => ({ template: { typesPath: "bar" } })');
+        let envA = createEnvironment('() => ({ template: { typesModule: "foo" } })');
+        let envB = createEnvironment('() => ({ template: { typesModule: "bar" } })');
 
         expect(() => GlintEnvironment.load([envA, envB], { rootDir: testDir })).toThrow(
           'Multiple configured Glint environments attempted to define behavior for standalone template files'

--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -53,7 +53,7 @@ export type GlintExtensionsConfig = {
 };
 
 export type GlintTagConfig = {
-  typesSource: string;
+  typesModule: string;
   globals?: Array<string>;
 };
 
@@ -73,7 +73,7 @@ export type PathCandidateWithDeferral = {
 };
 
 export type GlintTemplateConfig = {
-  typesPath: string;
+  typesModule: string;
   getPossibleTemplatePaths(scriptPath: string): Array<PathCandidate>;
   getPossibleScriptPaths(templatePath: string): Array<PathCandidate>;
 };
@@ -151,7 +151,7 @@ export class GlintEnvironment {
    * environment supports such templates.
    */
   public getTypesForStandaloneTemplate(): string | undefined {
-    return this.standaloneTemplateConfig?.typesPath;
+    return this.standaloneTemplateConfig?.typesModule;
   }
 
   /**

--- a/packages/environment-ember-loose/-private/dsl/index.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/index.d.ts
@@ -1,4 +1,37 @@
-import './integration-declarations';
+export * from './without-function-resolution';
 
-export * from '@glint/template/-private/dsl';
-export { Globals } from './globals';
+import { ResolveOrReturn } from '@glint/template/-private/dsl';
+import {
+  DirectInvokable,
+  EmptyObject,
+  Invokable,
+  Invoke,
+  InvokeDirect,
+} from '@glint/template/-private/integration';
+
+type OptNamed<N extends Record<string, unknown> | undefined> = N extends undefined
+  ? NonNullable<N> | EmptyObject
+  : N;
+
+// Items that can be directly invoked by value
+export declare function resolve<T extends DirectInvokable>(item: T): T[typeof InvokeDirect];
+// Items whose instance type can be invoked
+export declare function resolve<Args extends unknown[], Instance extends Invokable>(
+  item: abstract new (...args: Args) => Instance
+): (...args: Parameters<Instance[typeof Invoke]>) => ReturnType<Instance[typeof Invoke]>;
+// Functions that narrow the type of their first arg
+export declare function resolve<Value, Args extends unknown[], T extends Value>(
+  item: (value: Value, ...args: Args) => value is T
+): (named: EmptyObject, value: Value, ...args: Args) => value is T;
+// Functions that have a final parameter that looks like named args
+export declare function resolve<
+  P extends unknown[],
+  N extends Record<string, unknown> | undefined,
+  T
+>(item: (...args: [...positional: P, named: N]) => T): (named: OptNamed<N>, ...positional: P) => T;
+// All other functions
+export declare function resolve<P extends unknown[], T>(
+  item: (...positional: P) => T
+): (named: EmptyObject, ...positional: P) => T;
+
+export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;

--- a/packages/environment-ember-loose/-private/dsl/without-function-resolution.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/without-function-resolution.d.ts
@@ -1,0 +1,4 @@
+import './integration-declarations';
+
+export * from '@glint/template/-private/dsl';
+export { Globals } from './globals';

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -16,12 +16,12 @@ export default function emberLooseEnvironment(): GlintEnvironmentConfig {
     tags: {
       'ember-cli-htmlbars': {
         hbs: {
-          typesSource: '@glint/environment-ember-loose/-private/dsl',
+          typesModule: '@glint/environment-ember-loose/-private/dsl',
         },
       },
     },
     template: {
-      typesPath: '@glint/environment-ember-loose/-private/dsl',
+      typesModule: '@glint/environment-ember-loose/-private/dsl',
 
       getPossibleScriptPaths(templatePath) {
         // Colocated script/template pair

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -11,17 +11,22 @@ const REGEXES = {
   TS_SCRIPT_EXT: /\.ts$/,
 };
 
-export default function emberLooseEnvironment(): GlintEnvironmentConfig {
+export default function emberLooseEnvironment(
+  options: Record<string, unknown>
+): GlintEnvironmentConfig {
+  let typesModule = '@glint/environment-ember-loose/-private/dsl';
+  if (options['allowPlainFunctionInvocation'] === false) {
+    typesModule += '/without-function-resolution';
+  }
+
   return {
     tags: {
       'ember-cli-htmlbars': {
-        hbs: {
-          typesModule: '@glint/environment-ember-loose/-private/dsl',
-        },
+        hbs: { typesModule },
       },
     },
     template: {
-      typesModule: '@glint/environment-ember-loose/-private/dsl',
+      typesModule,
 
       getPossibleScriptPaths(templatePath) {
         // Colocated script/template pair

--- a/packages/environment-ember-loose/README.md
+++ b/packages/environment-ember-loose/README.md
@@ -2,7 +2,4 @@
 
 This package contains the information necessary for glint to typecheck a standard (non-[strict-mode](http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html)) Ember.js project.
 
-Note that when used in an [`ember-cli`] project, you will need to have [`ember-auto-import`] installed in order for the reexports from this package to be available to your project.
-
-[`ember-cli`]: https://cli.emberjs.com/release/
-[`ember-auto-import`]: https://github.com/ef4/ember-auto-import
+See [the Glint documentation](https://typed-ember.gitbook.io/glint/using-glint/ember/installation) for more detailed instructions on working with Ember.js projects in Glint.

--- a/packages/environment-ember-loose/__tests__/environment.test.ts
+++ b/packages/environment-ember-loose/__tests__/environment.test.ts
@@ -97,4 +97,34 @@ describe('Environments: Ember Loose', () => {
       '/routes/hello.js',
     ]);
   });
+
+  test('honors `allowPlainFunctionInvocation` configuration', () => {
+    let envWithNoConfig = GlintEnvironment.load('ember-loose');
+    let envWithPlainFunctions = GlintEnvironment.load({
+      'ember-loose': { allowPlainFunctionInvocation: true },
+    });
+    let envWithoutPlainFunctions = GlintEnvironment.load({
+      'ember-loose': { allowPlainFunctionInvocation: false },
+    });
+
+    expect(envWithNoConfig.getConfiguredTemplateTags()).toEqual({
+      'ember-cli-htmlbars': {
+        hbs: { typesModule: '@glint/environment-ember-loose/-private/dsl' },
+      },
+    });
+
+    expect(envWithPlainFunctions.getConfiguredTemplateTags()).toEqual({
+      'ember-cli-htmlbars': {
+        hbs: { typesModule: '@glint/environment-ember-loose/-private/dsl' },
+      },
+    });
+
+    expect(envWithoutPlainFunctions.getConfiguredTemplateTags()).toEqual({
+      'ember-cli-htmlbars': {
+        hbs: {
+          typesModule: '@glint/environment-ember-loose/-private/dsl/without-function-resolution',
+        },
+      },
+    });
+  });
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -188,3 +188,112 @@ import { EmptyObject as GlintEmptyObject } from '@glint/template/-private/integr
   expectTypeOf(MyHelper).toMatchTypeOf<HelperLike<TestSignature>>();
   expectTypeOf(myHelper).toMatchTypeOf<HelperLike<TestSignature>>();
 }
+
+// Bare-function helpers
+{
+  let positionalOnlyConcrete = resolve((a: number, b: number) => a + b);
+  expectTypeOf(positionalOnlyConcrete).toEqualTypeOf<
+    (named: GlintEmptyObject, a: number, b: number) => number
+  >();
+  expectTypeOf(positionalOnlyConcrete({}, 1, 2)).toBeNumber();
+
+  let positionalOnlyGeneric = resolve(<A, B>(a: A, b: B): [A, B] => [a, b]);
+  expectTypeOf(positionalOnlyGeneric).toEqualTypeOf<
+    <A, B>(named: GlintEmptyObject, a: A, b: B) => [A, B]
+  >();
+  expectTypeOf(positionalOnlyGeneric({}, 'hi', true)).toEqualTypeOf<[string, boolean]>();
+  expectTypeOf(positionalOnlyGeneric({}, 123, Symbol())).toEqualTypeOf<[number, symbol]>();
+
+  let mixedConcrete = resolve(
+    (a: number, b: number, named: { fallback: number }) => named.fallback
+  );
+  expectTypeOf(mixedConcrete).toEqualTypeOf<
+    (named: { fallback: number }, a: number, b: number) => number
+  >();
+  expectTypeOf(mixedConcrete({ fallback: 123 }, 1, 2)).toBeNumber();
+
+  let mixedGenericNamed = resolve(
+    <T>(a: number, b: number, named: { fallback: T }) => a + b || named.fallback
+  );
+  expectTypeOf(mixedGenericNamed).toEqualTypeOf<
+    <T>(named: { fallback: T }, a: number, b: number) => T | number
+  >();
+  expectTypeOf(mixedGenericNamed({ fallback: 'hi' }, 1, 2)).toEqualTypeOf<number | string>();
+  expectTypeOf(mixedGenericNamed({ fallback: 3 }, 1, 2)).toBeNumber();
+
+  let mixedGenericPositional = resolve(
+    <T>(a: T, b: T, named: { fallback: string }): string | T => a || b || named.fallback
+  );
+  expectTypeOf(mixedGenericPositional).toEqualTypeOf<
+    <T>(named: { fallback: string }, a: T, b: T) => T | string
+  >();
+  expectTypeOf(mixedGenericPositional({ fallback: 'hi' }, 'a', 'b')).toBeString();
+  expectTypeOf(mixedGenericPositional({ fallback: 'hi' }, 1, 2)).toEqualTypeOf<string | number>();
+  // @ts-expect-error: inconsistent T
+  mixedGenericPositional({ fallback: 'hi' }, 'a', 123);
+
+  let mixedGeneric = resolve(<A, B, C>(a: A, b: B, named: { c: C }): [A, B, C] => [a, b, named.c]);
+  expectTypeOf(mixedGeneric).toEqualTypeOf<<A, B, C>(named: { c: C }, a: A, b: B) => [A, B, C]>();
+  expectTypeOf(mixedGeneric({ c: 'hi' }, 123, false)).toEqualTypeOf<[number, boolean, string]>();
+
+  let namedOnlyConcrete = resolve((named: { age: number; name: string }) => named.name);
+  expectTypeOf(namedOnlyConcrete).toEqualTypeOf<(named: { age: number; name: string }) => string>();
+  expectTypeOf(namedOnlyConcrete({ age: 100, name: 'Alex' })).toBeString();
+
+  let namedOnlyGeneric = resolve(<T, U>(named: { t: T; u: U }): [T, U] => [named.t, named.u]);
+  expectTypeOf(namedOnlyGeneric).toEqualTypeOf<<T, U>(named: { t: T; u: U }) => [T, U]>();
+  expectTypeOf(namedOnlyGeneric({ t: 'hi', u: 123 })).toEqualTypeOf<[string, number]>();
+
+  let optionalNamed = resolve(<T, U>(a: T, named?: { cool: U }): [T, U] => [a, named?.cool as U]);
+  expectTypeOf(optionalNamed).toEqualTypeOf<
+    <T, U>(named: GlintEmptyObject | { cool: T }, a: U) => [T, U]
+  >();
+  expectTypeOf(optionalNamed({}, 123)).toEqualTypeOf<[number, unknown]>();
+  expectTypeOf(optionalNamed({ cool: true }, 123)).toEqualTypeOf<[number, boolean]>();
+
+  let optionalBoth = resolve(<T, U, V>(a: T, b?: U, named?: { foo: V }): [T, U, V] => [
+    a,
+    b as U,
+    named?.foo as V,
+  ]);
+  expectTypeOf(optionalBoth).toEqualTypeOf<
+    <T, U, V>(named: GlintEmptyObject | { foo: V }, a: T, b?: U) => [T, U, V]
+  >();
+  expectTypeOf(optionalBoth({}, 'hi')).toEqualTypeOf<[string, unknown, unknown]>();
+  expectTypeOf(optionalBoth({}, 'hi', 123)).toEqualTypeOf<[string, number, unknown]>();
+  expectTypeOf(optionalBoth({ foo: true }, 'hi')).toEqualTypeOf<[string, unknown, boolean]>();
+  expectTypeOf(optionalBoth({ foo: true }, 'hi', 123)).toEqualTypeOf<[string, number, boolean]>();
+
+  interface NamedInterface {
+    name: string;
+  }
+  let namedArgsInterface = resolve((pos: string, options: NamedInterface) => {
+    console.log(pos, options);
+  });
+  expectTypeOf(namedArgsInterface).toEqualTypeOf<
+    (named: GlintEmptyObject, pos: string, options: NamedInterface) => void
+  >();
+
+  type NamedType = { name: string };
+  let namedArgsType = resolve((pos: string, named: NamedType) => {
+    console.log(pos, named);
+  });
+  expectTypeOf(namedArgsType).toEqualTypeOf<(named: NamedType, pos: string) => void>();
+
+  let narrowsFirstArg = resolve(
+    <K extends string>(arg: unknown, key: K): arg is Record<K, number> => !!key
+  );
+  expectTypeOf(narrowsFirstArg).toEqualTypeOf<
+    <K extends string>(named: GlintEmptyObject, arg: unknown, key: K) => arg is Record<K, number>
+  >();
+
+  let narrowsFirstArgTestValue!: unknown;
+  if (narrowsFirstArg({}, narrowsFirstArgTestValue, 'key')) {
+    expectTypeOf(narrowsFirstArgTestValue.key).toBeNumber();
+  }
+
+  let allOptional = resolve((a?: string, b?: { foo: string }) => `${a}${b?.foo}`);
+  expectTypeOf(allOptional).toEqualTypeOf<
+    (named: GlintEmptyObject | { foo: string }, a?: string) => string
+  >();
+}

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -1,5 +1,6 @@
 import Helper, { helper, EmptyObject } from '@ember/component/helper';
 import { resolve } from '@glint/environment-ember-loose/-private/dsl';
+import { resolve as resolveWithoutFunctionResolution } from '@glint/environment-ember-loose/-private/dsl/without-function-resolution';
 import { expectTypeOf } from 'expect-type';
 import { HelperLike } from '@glint/template';
 import { EmptyObject as GlintEmptyObject } from '@glint/template/-private/integration';
@@ -191,6 +192,9 @@ import { EmptyObject as GlintEmptyObject } from '@glint/template/-private/integr
 
 // Bare-function helpers
 {
+  // @ts-expect-error: the env with no support for function resolution should reject this
+  resolveWithoutFunctionResolution(() => 'hi');
+
   let positionalOnlyConcrete = resolve((a: number, b: number) => a + b);
   expectTypeOf(positionalOnlyConcrete).toEqualTypeOf<
     (named: GlintEmptyObject, a: number, b: number) => number

--- a/packages/environment-ember-template-imports/-private/environment/index.ts
+++ b/packages/environment-ember-template-imports/-private/environment/index.ts
@@ -7,7 +7,7 @@ export default function emberTemplateImportsEnvironment(): GlintEnvironmentConfi
     tags: {
       'ember-template-imports': {
         hbs: {
-          typesSource: '@glint/environment-ember-template-imports/-private/dsl',
+          typesModule: '@glint/environment-ember-template-imports/-private/dsl',
           globals: [
             'action',
             'component',

--- a/packages/environment-glimmerx/-private/environment/index.ts
+++ b/packages/environment-glimmerx/-private/environment/index.ts
@@ -8,7 +8,7 @@ export default function glimmerxEnvironment(
     : [];
 
   let tagConfig: GlintTagConfig = {
-    typesSource: '@glint/environment-glimmerx/-private/dsl',
+    typesModule: '@glint/environment-glimmerx/-private/dsl',
     globals: [
       'component',
       'debugger',

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -118,9 +118,9 @@ describe('rewriteModule', () => {
       let testEnvironment = new GlintEnvironment(['test'], {
         tags: {
           '@glint/test-env': {
-            hbsCaptureAll: { typesSource: '@glint/test-env', globals: [] },
-            hbsCaptureSome: { typesSource: '@glint/test-env', globals: ['global'] },
-            hbsCaptureNone: { typesSource: '@glint/test-env' },
+            hbsCaptureAll: { typesModule: '@glint/test-env', globals: [] },
+            hbsCaptureSome: { typesModule: '@glint/test-env', globals: ['global'] },
+            hbsCaptureNone: { typesModule: '@glint/test-env' },
           },
         },
       });

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -9,11 +9,11 @@ describe('rewriteTemplate', () => {
   // the body, to keep snapshots brief and focused.
   function templateBody(
     template: string,
-    options: Omit<TemplateToTypescriptOptions, 'typesPath'> = {}
+    options: Omit<TemplateToTypescriptOptions, 'typesModule'> = {}
   ): string {
     let { result, errors } = templateToTypescript(template, {
       ...options,
-      typesPath: '@glint/template',
+      typesModule: '@glint/template',
     });
     if (errors.length) {
       throw new Error('Unexpected error(s): ' + errors.map((e) => e.message).join(', '));
@@ -28,7 +28,7 @@ describe('rewriteTemplate', () => {
 
   describe('template boilerplate', () => {
     test('without any specified type parameters or context type', () => {
-      expect(templateToTypescript('', { typesPath: '@glint/template' }).result?.code)
+      expect(templateToTypescript('', { typesModule: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
         "({} as typeof import(\\"@glint/template\\")).template(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
           𝚪; χ;
@@ -41,7 +41,7 @@ describe('rewriteTemplate', () => {
       let contextType = 'MyComponent<T>';
 
       expect(
-        templateToTypescript('', { contextType, typeParams, typesPath: '@glint/template' }).result
+        templateToTypescript('', { contextType, typeParams, typesModule: '@glint/template' }).result
           ?.code
       ).toMatchInlineSnapshot(`
         "({} as typeof import(\\"@glint/template\\")).template(function<T extends string>(𝚪: import(\\"@glint/template\\").ResolveContext<MyComponent<T>>, χ: typeof import(\\"@glint/template\\")) {
@@ -53,7 +53,7 @@ describe('rewriteTemplate', () => {
     test('given preamble code', () => {
       let preamble = ['console.log("hello!");', 'throw new Error();'];
 
-      expect(templateToTypescript('', { preamble, typesPath: '@glint/template' }).result?.code)
+      expect(templateToTypescript('', { preamble, typesModule: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
         "({} as typeof import(\\"@glint/template\\")).template(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
           console.log(\\"hello!\\");
@@ -73,7 +73,7 @@ describe('rewriteTemplate', () => {
         </Foo>
       `;
 
-      let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
+      let { result, errors } = templateToTypescript(template, { typesModule: '@glint/template' });
 
       expect(errors).toEqual([]);
       expect(result?.directives).toEqual([
@@ -102,7 +102,7 @@ describe('rewriteTemplate', () => {
         </Foo>
       `;
 
-      let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
+      let { result, errors } = templateToTypescript(template, { typesModule: '@glint/template' });
 
       expect(errors).toEqual([]);
       expect(result?.directives).toEqual([
@@ -128,7 +128,7 @@ describe('rewriteTemplate', () => {
         {{this.baz}}
       `;
 
-      let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
+      let { result, errors } = templateToTypescript(template, { typesModule: '@glint/template' });
 
       expect(errors).toEqual([]);
       expect(result?.directives).toEqual([
@@ -162,7 +162,7 @@ describe('rewriteTemplate', () => {
         </Foo>
       `;
 
-      let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
+      let { result, errors } = templateToTypescript(template, { typesModule: '@glint/template' });
 
       expect(errors).toEqual([]);
       expect(result?.directives).toEqual([
@@ -188,7 +188,7 @@ describe('rewriteTemplate', () => {
         </Foo>
       `;
 
-      let { result, errors } = templateToTypescript(template, { typesPath: '@glint/template' });
+      let { result, errors } = templateToTypescript(template, { typesModule: '@glint/template' });
 
       expect(result?.directives).toEqual([]);
       expect(errors).toEqual([
@@ -1038,7 +1038,7 @@ describe('rewriteTemplate', () => {
   describe('error conditions', () => {
     test('Handlebars syntax error', () => {
       let { errors } = templateToTypescript('<Foo @attr={{"123}} />', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1056,7 +1056,7 @@ describe('rewriteTemplate', () => {
 
     test('HTML syntax error', () => {
       let { errors } = templateToTypescript('<Foo </Foo>', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1070,7 +1070,7 @@ describe('rewriteTemplate', () => {
 
     test('{{yield}} in expression position', () => {
       let { errors } = templateToTypescript('<Foo @attr={{yield}} />', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1083,7 +1083,7 @@ describe('rewriteTemplate', () => {
 
     test('{{yield}} to a dynamic named block', () => {
       let { errors } = templateToTypescript('{{yield to=@blockName}}', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1096,7 +1096,7 @@ describe('rewriteTemplate', () => {
 
     test('{{hash}} with positional parameters', () => {
       let { errors } = templateToTypescript('<Foo @attr={{hash 123 foo="bar"}} />', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1109,7 +1109,7 @@ describe('rewriteTemplate', () => {
 
     test('{{array}} with named parameters', () => {
       let { errors } = templateToTypescript('<Foo @attr={{array 123 foo="bar"}} />', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1122,7 +1122,7 @@ describe('rewriteTemplate', () => {
 
     test('inline {{if}} with no consequent', () => {
       let { errors } = templateToTypescript('<Foo @attr={{if true}} />', {
-        typesPath: '@glint/template',
+        typesModule: '@glint/template',
       });
 
       expect(errors).toEqual([
@@ -1140,7 +1140,7 @@ describe('rewriteTemplate', () => {
             hello!
           {{/if}}
         `,
-        { typesPath: '@glint/template' }
+        { typesModule: '@glint/template' }
       );
 
       expect(errors).toEqual([
@@ -1165,7 +1165,7 @@ describe('rewriteTemplate', () => {
           </Component>
           Footer content
         `,
-        { typesPath: '@glint/template' }
+        { typesModule: '@glint/template' }
       );
 
       expect(errors).toEqual([
@@ -1189,7 +1189,7 @@ describe('rewriteTemplate', () => {
             {{foo-bar}}
           </Component>
         `,
-        { typesPath: '@glint/template' }
+        { typesModule: '@glint/template' }
       );
 
       expect(errors).toEqual([

--- a/packages/transform/src/template/inlining/companion-file.ts
+++ b/packages/transform/src/template/inlining/companion-file.ts
@@ -18,8 +18,8 @@ export function calculateCompanionTemplateSpans(
   let errors: Array<TransformError> = [];
   let directives: Array<Directive> = [];
   let partialSpans: Array<PartialCorrelatedSpan> = [];
-  let typesPath = environment.getTypesForStandaloneTemplate();
-  if (!typesPath) {
+  let typesModule = environment.getTypesForStandaloneTemplate();
+  if (!typesModule) {
     errors.push({
       source: template,
       location: { start: 0, end: template.contents.length },
@@ -45,7 +45,7 @@ export function calculateCompanionTemplateSpans(
     }
 
     let rewriteResult = templateToTypescript(template.contents, {
-      typesPath,
+      typesModule,
       contextType,
       typeParams,
       useJsDoc,
@@ -69,7 +69,7 @@ export function calculateCompanionTemplateSpans(
     }
 
     let rewriteResult = templateToTypescript(template.contents, {
-      typesPath,
+      typesModule,
       contextType,
       useJsDoc,
     });

--- a/packages/transform/src/template/inlining/tagged-strings.ts
+++ b/packages/transform/src/template/inlining/tagged-strings.ts
@@ -29,7 +29,7 @@ export function calculateTaggedTemplateSpans(
       'No interpolated values in template strings'
     );
 
-    let { typesSource, globals } = info.tagConfig;
+    let { typesModule, globals } = info.tagConfig;
     let tagName = tag.text;
     let contents = node.template.rawText ?? node.template.text;
 
@@ -52,7 +52,7 @@ export function calculateTaggedTemplateSpans(
 
     let { inClass, className, typeParams, contextType } = getContainingTypeInfo(ts, node);
     let transformedTemplate = templateToTypescript(template, {
-      typesPath: typesSource,
+      typesModule: typesModule,
       meta,
       preamble,
       globals,

--- a/packages/transform/src/template/template-to-typescript.ts
+++ b/packages/transform/src/template/template-to-typescript.ts
@@ -12,7 +12,7 @@ type InlineKeyword = typeof INLINE_KEYWORDS[number];
 type BlockKeyword = typeof BLOCK_KEYWORDS[number];
 
 export type TemplateToTypescriptOptions = {
-  typesPath: string;
+  typesModule: string;
   meta?: GlintEmitMetadata | undefined;
   globals?: Array<string> | undefined;
   contextType?: string;
@@ -29,7 +29,7 @@ export type TemplateToTypescriptOptions = {
 export function templateToTypescript(
   template: string,
   {
-    typesPath,
+    typesModule,
     globals,
     meta,
     typeParams = '',
@@ -91,9 +91,9 @@ export function templateToTypescript(
         if (contextType) {
           emit.text('/** @type {unknown} */ (');
         }
-        emit.text(`(/** @type {typeof import("${typesPath}")} */ ({})).template(function(`);
+        emit.text(`(/** @type {typeof import("${typesModule}")} */ ({})).template(function(`);
       } else {
-        emit.text(`({} as typeof import("${typesPath}")).template(function`);
+        emit.text(`({} as typeof import("${typesModule}")).template(function`);
         emit.synthetic(typeParams);
       }
       if (!useJsDoc) {
@@ -102,11 +102,11 @@ export function templateToTypescript(
 
       if (contextType) {
         if (useJsDoc) {
-          emit.text(`/** @type {import("${typesPath}").ResolveContext<`);
+          emit.text(`/** @type {import("${typesModule}").ResolveContext<`);
           emit.synthetic(contextType);
           emit.text('>} */ ');
         } else {
-          emit.text(`: import("${typesPath}").ResolveContext<`);
+          emit.text(`: import("${typesModule}").ResolveContext<`);
           emit.synthetic(contextType);
           emit.text('>');
         }
@@ -114,9 +114,9 @@ export function templateToTypescript(
 
       if (useJsDoc) {
         emit.text('𝚪');
-        emit.text(`, /** @type {typeof import("${typesPath}")} */ χ) {`);
+        emit.text(`, /** @type {typeof import("${typesModule}")} */ χ) {`);
       } else {
-        emit.text(`, χ: typeof import("${typesPath}")) {`);
+        emit.text(`, χ: typeof import("${typesModule}")) {`);
       }
 
       emit.newline();

--- a/test-packages/ts-ember-app/app/components/ember-component.hbs
+++ b/test-packages/ts-ember-app/app/components/ember-component.hbs
@@ -7,3 +7,13 @@
   {{@optional}}
   {{@hasDefault}}
 </div>
+
+{{#if this.showFunctionHelpers}}
+  {{! @glint-expect-error: missing arg }}
+  {{this.isLongString}}
+
+  {{! @glint-expect-error: wrong arg type }}
+  {{this.isLongString 123}}
+
+  {{this.isLongString 'hi'}}
+{{/if}}

--- a/test-packages/ts-ember-app/app/components/ember-component.ts
+++ b/test-packages/ts-ember-app/app/components/ember-component.ts
@@ -15,6 +15,11 @@ export interface EmberComponentSignature {
 export default interface EmberComponent extends EmberComponentArgs {}
 export default class EmberComponent extends Component<EmberComponentSignature> {
   public hasDefault = 'defaultValue';
+  public showFunctionHelpers = false;
+
+  public isLongString(value: string): boolean {
+    return value.length > 5;
+  }
 
   public checkTypes(): unknown {
     const required: string = this.required;


### PR DESCRIPTION
This PR adds support for the default helper manager RFC to projects using `@glint/environment-ember-loose`. This support is enabled by default, but since the implementation only just landed and it may be some time before projects (particularly addons) are comfortable adopting it, we also allow opting out via a flag in the environment config.

Fixes #363 