### PR TITLE
core/cli: implement `glint --build --force`

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -33,14 +33,14 @@ const argv = yargs
     // As with TS itself, we *must* emit declarations when in build mode
     conflicts: 'declaration',
   })
-  // TODO: implement these!
-  /*
   .option('clean', {
     implies: 'build',
     boolean: true,
     description: 'Delete the outputs of all projects.',
     conflicts: 'watch',
   })
+  // TODO: implement these!
+  /*
   .option('force', {
     implies: 'build',
     description: 'Act as if all projects are out of date. Same as the TS `--force` flag.',
@@ -81,7 +81,7 @@ if (argv.build) {
   // Type signature here so we get a useful error as close to the source of the
   // error as possible, rather than at the *use* sites below.
   let buildOptions: TS.BuildOptions = {
-    // clean: argv.clean,
+    clean: argv.clean,
     // force: argv.force,
     // dry: argv.dry,
     // incremental: argv.incremental,

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -39,13 +39,13 @@ const argv = yargs
     description: 'Delete the outputs of all projects.',
     conflicts: 'watch',
   })
-  // TODO: implement these!
-  /*
   .option('force', {
     implies: 'build',
     description: 'Act as if all projects are out of date. Same as the TS `--force` flag.',
     type: 'boolean',
   })
+  // TODO: implement these!
+  /*
   .option('dry', {
     implies: 'build',
     description: `Show what would be built (or deleted, if specified with '--clean'). Same as the TS \`--dry\` flag.`,
@@ -82,7 +82,7 @@ if (argv.build) {
   // error as possible, rather than at the *use* sites below.
   let buildOptions: TS.BuildOptions = {
     clean: argv.clean,
-    // force: argv.force,
+    force: argv.force,
     // dry: argv.dry,
     // incremental: argv.incremental,
   };


### PR DESCRIPTION
Building on top of the work in https://github.com/typed-ember/glint/pull/377, add correct handling for the `--force` flag. This simply passes it through directly to TypeScript itself.

(Draft because it builds on #381)