### PR TITLE
core/cli: implement `glint --build --dry`

### DIFF
--- a/packages/config/__tests__/environment.test.ts
+++ b/packages/config/__tests__/environment.test.ts
@@ -147,7 +147,7 @@ describe('Environments', () => {
     });
 
     afterEach(() => {
-      fs.rmdirSync(testDir, { recursive: true });
+      fs.rmSync(testDir, { recursive: true, force: true });
     });
 
     test('loading an environment via @glint/environment-* shorthand', () => {

--- a/packages/config/__tests__/load-config.test.ts
+++ b/packages/config/__tests__/load-config.test.ts
@@ -8,7 +8,7 @@ describe('loadConfig', () => {
   const testDir = `${os.tmpdir()}/glint-config-test-load-config-${process.pid}`;
 
   beforeEach(() => {
-    fs.rmdirSync(testDir, { recursive: true });
+    fs.rmSync(testDir, { recursive: true, force: true });
     fs.mkdirSync(testDir);
     fs.writeFileSync(
       `${testDir}/local-env.js`,
@@ -17,7 +17,7 @@ describe('loadConfig', () => {
   });
 
   afterEach(() => {
-    fs.rmdirSync(testDir, { recursive: true });
+    fs.rmSync(testDir, { recursive: true, force: true });
   });
 
   test('throws an error if no config is found', () => {

--- a/packages/config/__tests__/loader.test.ts
+++ b/packages/config/__tests__/loader.test.ts
@@ -8,7 +8,7 @@ describe('loadConfig', () => {
   const testDir = `${os.tmpdir()}/glint-config-test-loader-${process.pid}`;
 
   beforeEach(() => {
-    fs.rmdirSync(testDir, { recursive: true });
+    fs.rmSync(testDir, { recursive: true, force: true });
     fs.mkdirSync(testDir);
     fs.writeFileSync(
       `${testDir}/local-env.js`,
@@ -17,7 +17,7 @@ describe('loadConfig', () => {
   });
 
   afterEach(() => {
-    fs.rmdirSync(testDir, { recursive: true });
+    fs.rmSync(testDir, { recursive: true, force: true });
   });
 
   test('returns null if no config file is found', () => {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/minimatch": "^3.0.3",
     "@types/resolve": "^1.17.1",
-    "vitest": "^0.18.1"
+    "vitest": "^0.22.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/__tests__/cli/build.test.ts
+++ b/packages/core/__tests__/cli/build.test.ts
@@ -1331,7 +1331,6 @@ describe('CLI: --build --dry', () => {
       });
 
       test('when there are no changes', async () => {
-        await project.build();
         let buildResult = await project.build({ flags: ['--dry'] });
         expect(buildResult.exitCode).toBe(0);
         expect(stripAnsi(buildResult.stdout)).toMatch(
@@ -1341,8 +1340,6 @@ describe('CLI: --build --dry', () => {
       });
 
       test('when there are changes', async () => {
-        await project.build();
-
         let code = stripIndent`
           import '@glint/environment-ember-template-imports';
           import Component from '@glimmer/component';

--- a/packages/core/__tests__/utils/project.ts
+++ b/packages/core/__tests__/utils/project.ts
@@ -173,7 +173,7 @@ export default class Project {
 
   public async destroy(): Promise<void> {
     this.server?.dispose();
-    fs.rmdirSync(this.rootDir, { recursive: true });
+    fs.rmSync(this.rootDir, { recursive: true, force: true });
   }
 
   public check(options: Options & { flags?: string[] } = {}): ExecaChildProcess {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^18.7.6",
     "execa": "^4.0.1",
     "strip-ansi": "^6.0.0",
-    "vitest": "^0.18.1"
+    "vitest": "^0.22.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@types/resolve": "^1.17.1",
     "@types/uuid": "^8.3.4",
     "@types/yargs": "^17.0.10",
+    "@types/node": "^18.7.6",
     "execa": "^4.0.1",
     "strip-ansi": "^6.0.0",
     "vitest": "^0.18.1"

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -44,13 +44,13 @@ const argv = yargs
     description: 'Act as if all projects are out of date. Same as the TS `--force` flag.',
     type: 'boolean',
   })
-  // TODO: implement these!
-  /*
   .option('dry', {
     implies: 'build',
     description: `Show what would be built (or deleted, if specified with '--clean'). Same as the TS \`--dry\` flag.`,
     type: 'boolean',
   })
+  // TODO: implement these!
+  /*
   .option('incremental', {
     description:
       'Save .tsbuildinfo files to allow for incremental compilation of projects. Same as the TS `--incremental` flag.',
@@ -83,7 +83,7 @@ if (argv.build) {
   let buildOptions: TS.BuildOptions = {
     clean: argv.clean,
     force: argv.force,
-    // dry: argv.dry,
+    dry: argv.dry,
     // incremental: argv.incremental,
   };
 

--- a/packages/core/src/cli/perform-build.ts
+++ b/packages/core/src/cli/perform-build.ts
@@ -37,9 +37,5 @@ function createCompilerHost(ts: TypeScript, sysPool: TransformManagerPool): Buil
     (diagnostic) => console.error(formatDiagnostic(diagnostic))
   );
 
-  host.fileExists = sysPool.fileExists;
-  host.readFile = sysPool.readTransformedFile;
-  host.readDirectory = sysPool.readDirectory;
-
   return host;
 }

--- a/packages/core/src/cli/perform-build.ts
+++ b/packages/core/src/cli/perform-build.ts
@@ -24,14 +24,17 @@ export function performBuild(ts: TypeScript, projects: string[], buildOptions: B
 
 type BuilderHost = TS.SolutionBuilderHost<TS.EmitAndSemanticDiagnosticsBuilderProgram>;
 
-function createCompilerHost(ts: TypeScript, sysPool: TransformManagerPool): BuilderHost {
+function createCompilerHost(
+  ts: TypeScript,
+  transformManagerPool: TransformManagerPool
+): BuilderHost {
   let formatDiagnostic = buildDiagnosticFormatter(ts);
 
   let host = ts.createSolutionBuilderHost(
-    sysForCompilerHost(ts, sysPool),
+    sysForCompilerHost(ts, transformManagerPool),
     (...args) => {
       let program = ts.createEmitAndSemanticDiagnosticsBuilderProgram(...args);
-      patchProgram(program, sysPool);
+      patchProgram(program, transformManagerPool);
       return program;
     },
     (diagnostic) => console.error(formatDiagnostic(diagnostic))

--- a/packages/core/src/cli/utils/sys-for-compiler-host.ts
+++ b/packages/core/src/cli/utils/sys-for-compiler-host.ts
@@ -13,5 +13,6 @@ export function sysForCompilerHost(
     fileExists: transformManagerOrPool.fileExists,
     watchFile: transformManagerOrPool.watchTransformedFile,
     readFile: transformManagerOrPool.readTransformedFile,
+    getModifiedTime: transformManagerOrPool.getModifiedTime,
   };
 }

--- a/packages/core/src/cli/utils/sys-for-compiler-host.ts
+++ b/packages/core/src/cli/utils/sys-for-compiler-host.ts
@@ -4,14 +4,14 @@ import TransformManagerPool from './transform-manager-pool';
 
 export function sysForCompilerHost(
   ts: typeof TS,
-  transformManagerOrSysPool: TransformManager | TransformManagerPool
+  transformManagerOrPool: TransformManager | TransformManagerPool
 ): TS.System {
   return {
     ...ts.sys,
-    readDirectory: transformManagerOrSysPool.readDirectory,
-    watchDirectory: transformManagerOrSysPool.watchDirectory,
-    fileExists: transformManagerOrSysPool.fileExists,
-    watchFile: transformManagerOrSysPool.watchTransformedFile,
-    readFile: transformManagerOrSysPool.readTransformedFile,
+    readDirectory: transformManagerOrPool.readDirectory,
+    watchDirectory: transformManagerOrPool.watchDirectory,
+    fileExists: transformManagerOrPool.fileExists,
+    watchFile: transformManagerOrPool.watchTransformedFile,
+    readFile: transformManagerOrPool.readTransformedFile,
   };
 }

--- a/packages/core/src/cli/utils/transform-manager-pool.ts
+++ b/packages/core/src/cli/utils/transform-manager-pool.ts
@@ -84,4 +84,11 @@ export default class TransformManagerPool {
       this.managerFor(filename)?.readTransformedFile ?? this.#rootSys.readFile;
     return readTransformedFile(filename, encoding);
   };
+
+  public getModifiedTime = (filename: string): Date | undefined => {
+    assert(this.#rootSys.getModifiedTime);
+    let getModifiedTime =
+      this.managerFor(filename)?.getModifiedTime ?? this.#rootSys.getModifiedTime;
+    return getModifiedTime(filename);
+  };
 }

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -44,7 +44,7 @@
     "@types/ember__component": "~4.0.8",
     "ember-modifier": "^3.2.7",
     "expect-type": "0.11.0",
-    "vitest": "^0.18.1"
+    "vitest": "^0.22.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -33,7 +33,7 @@
     "@types/ember__helper": "^4.0.0",
     "@types/ember__modifier": "^4.0.0",
     "ember-template-imports": "^3.0.0",
-    "vitest": "^0.18.1"
+    "vitest": "^0.22.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "typescript": "^4.7.4",
-    "vitest": "^0.18.0",
+    "vitest": "^0.22.0",
     "json5": "^2.2.1"
   },
   "publishConfig": {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -25,7 +25,7 @@
     "@types/common-tags": "^1.8.0",
     "@types/debug": "^4.1.5",
     "common-tags": "^1.8.0",
-    "vitest": "^0.18.1"
+    "vitest": "^0.22.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,6 +2553,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
   integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
+"@types/node@^18.7.6":
+  version "18.7.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.6.tgz#31743bc5772b6ac223845e18c3fc26f042713c83"
+  integrity sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==
+
 "@types/node@^9.6.0":
   version "9.6.61"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.61.tgz#29f124eddd41c4c74281bd0b455d689109fc2a2d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,18 +1806,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jest/types@^26.3.0":
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
-  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^26.6.2":
+"@jest/types@^26.3.0", "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
   integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
@@ -2145,15 +2134,10 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*", "@types/chai@^4.2.9":
-  version "4.2.14"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
-  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
-
-"@types/chai@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
-  integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
+"@types/chai@*", "@types/chai@^4.2.9", "@types/chai@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -2514,15 +2498,10 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
-
-"@types/json-schema@^7.0.4", "@types/json-schema@^7.0.7":
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
-  integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
 "@types/keyv@*":
   version "3.1.1"
@@ -2548,12 +2527,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=10.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
-
-"@types/node@^18.7.6":
+"@types/node@*", "@types/node@>= 8", "@types/node@>=10.0.0", "@types/node@^18.7.6":
   version "18.7.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.6.tgz#31743bc5772b6ac223845e18c3fc26f042713c83"
   integrity sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==
@@ -8348,12 +8322,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@^2.1.2, fsevents@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
-  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
-
-fsevents@~2.3.2:
+fsevents@^2.1.2, fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -9245,15 +9214,7 @@ import-cwd@3.0.0:
   dependencies:
     import-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
-  integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -10289,24 +10250,12 @@ jest-snapshot@^26.4.2:
     pretty-format "^26.4.2"
     semver "^7.3.2"
 
-jest-util@26.x:
+jest-util@26.x, jest-util@^26.3.0:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
   integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
   dependencies:
     "@jest/types" "^26.6.2"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^2.0.0"
-    micromatch "^4.0.2"
-
-jest-util@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.3.0.tgz#a8974b191df30e2bf523ebbfdbaeb8efca535b3e"
-  integrity sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
-  dependencies:
-    "@jest/types" "^26.3.0"
     "@types/node" "*"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
@@ -10755,7 +10704,7 @@ loader.js@^4.7.0:
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.7.0.tgz#a1a52902001c83631efde9688b8ab3799325ef1f"
   integrity sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==
 
-local-pkg@^0.4.1, local-pkg@^0.4.2:
+local-pkg@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
   integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
@@ -13788,7 +13737,7 @@ semver@7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.x:
+semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -13799,13 +13748,6 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
 
 send@0.18.0:
   version "0.18.0"
@@ -14409,7 +14351,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14434,15 +14376,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
 
 string.prototype.matchall@^4.0.5, string.prototype.matchall@^4.0.6:
   version "4.0.7"
@@ -14914,20 +14847,10 @@ tiny-lr@^2.0.0:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
-tinypool@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.2.tgz#9b1da3a4f0c8c44c04e8af8783d9f27f1795bda2"
-  integrity sha512-tp4n5OARNL3v8ntdJUyo5NsDfwvUtu8isB43USjrsQxQrADDKY6UGBkmFaw/2vNmEt8S/uSm2U5FhkiK1eAFGw==
-
 tinypool@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.4.tgz#4d2598c4689d1a2ce267ddf3360a9c6b3925a20c"
   integrity sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==
-
-tinyspy@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.3.tgz#8b57f8aec7fe1bf583a3a49cb9ab30c742f69237"
-  integrity sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==
 
 tinyspy@^1.0.0:
   version "1.0.0"
@@ -15565,27 +15488,12 @@ verror@1.10.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.18.0.tgz#a9b59213ee6917e9da0797a2e1d7cb52b8f1b644"
-  integrity sha512-ryAtlh5Gvg3+aLNuOQ8YOHxgQCCu46jx40X5MBL0K0/ejB9i5zsr8fV8LTGXbXex80UMHlzceI9F+ouGaiR+mQ==
+vitest@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.22.0.tgz#175622a04af77c48967da3b798d53420ad463670"
+  integrity sha512-BSIro/QOHLaQY08FHwT6THWhqLQ+VPU+N4Rdo4pcP+16XB6oLmNNAXGcSh/MOLUhfUy+mqCwx7AyKmU7Ms5R+g==
   dependencies:
-    "@types/chai" "^4.3.1"
-    "@types/chai-subset" "^1.3.3"
-    "@types/node" "*"
-    chai "^4.3.6"
-    debug "^4.3.4"
-    local-pkg "^0.4.1"
-    tinypool "^0.2.1"
-    tinyspy "^0.3.3"
-    vite "^2.9.12 || ^3.0.0-0"
-
-vitest@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.18.1.tgz#33c5003fc8c4b296801897ae1a3f142f57015574"
-  integrity sha512-4F/1K/Vn4AvJwe7i2YblR02PT5vMKcw9KN4unDq2KD0YcSxX0B/6D6Qu9PJaXwVuxXMFTQ5ovd4+CQaW3bwofA==
-  dependencies:
-    "@types/chai" "^4.3.1"
+    "@types/chai" "^4.3.3"
     "@types/chai-subset" "^1.3.3"
     "@types/node" "*"
     chai "^4.3.6"


### PR DESCRIPTION
This should also include the bits required to support `--incremental` builds, since if TS *knows* that a build needs to be re-run and can report it in `--dry`, it can also *do* the build with `--incremental`.