### PR TITLE
Handle TS nightly changes to declaration emit

### DIFF
--- a/packages/core/__tests__/cli/declaration.test.ts
+++ b/packages/core/__tests__/cli/declaration.test.ts
@@ -16,9 +16,9 @@ describe('CLI: emitting declarations', () => {
     let code = stripIndent`
       import Component, { hbs } from '@glint/environment-glimmerx/component';
 
-      export type ApplicationArgs = {
+      export interface ApplicationArgs {
         version: string;
-      };
+      }
 
       export default class Application extends Component<{ Args: ApplicationArgs }> {
         private startupTime = new Date().toISOString();
@@ -38,9 +38,9 @@ describe('CLI: emitting declarations', () => {
 
     expect(project.read('index.d.ts')).toMatchInlineSnapshot(`
       "import Component from '@glint/environment-glimmerx/component';
-      export declare type ApplicationArgs = {
+      export interface ApplicationArgs {
           version: string;
-      };
+      }
       export default class Application extends Component<{
           Args: ApplicationArgs;
       }> {

--- a/packages/core/__tests__/utils/project.ts
+++ b/packages/core/__tests__/utils/project.ts
@@ -92,7 +92,7 @@ export default class Project {
       },
     };
 
-    fs.rmdirSync(project.rootDir, { recursive: true });
+    fs.rmSync(project.rootDir, { recursive: true, force: true });
     fs.mkdirSync(project.rootDir, { recursive: true });
 
     fs.writeFileSync(path.join(project.rootDir, 'package.json'), '{}');


### PR DESCRIPTION
The latest TS 4.9 nightly build stopped including `declare` in emitted `type` declarations. We don't actually care about this, but it happened to break one of our snapshots.