### PR TITLE
core/cli: add `glint --incremental` support

### DIFF
--- a/packages/core/__tests__/cli/incremental.test.ts
+++ b/packages/core/__tests__/cli/incremental.test.ts
@@ -1,0 +1,124 @@
+import { existsSync, statSync } from 'fs';
+
+import { stripIndent } from 'common-tags';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import Project from '../utils/project';
+
+const BUILD_INFO = 'tsconfig.tsbuildinfo';
+const INPUT_SCRIPT = 'index.ts';
+
+describe('CLI: --incremental', () => {
+  test('when no build has occurred', async () => {
+    let project = await Project.create();
+
+    let code = stripIndent`
+      import '@glint/environment-ember-template-imports';
+      import Component from '@glimmer/component';
+      import { hbs } from 'ember-template-imports';
+
+      type ApplicationArgs = {
+        version: string;
+      };
+
+      export default class Application extends Component<{ Args: ApplicationArgs }> {
+        private startupTime = new Date().toISOString();
+
+        public static template = hbs\`
+          Welcome to app v{{@version}}.
+          The current time is {{this.startupTime}}.
+        \`;
+      }
+    `;
+
+    project.write(INPUT_SCRIPT, code);
+
+    let checkResult = await project.build({ flags: ['--incremental'] });
+
+    expect(checkResult.exitCode).toBe(0);
+    expect(checkResult.stdout).toEqual('');
+    expect(checkResult.stderr).toEqual('');
+    expect(existsSync(project.filePath(BUILD_INFO))).toBe(true);
+  });
+
+  describe('when a build has occurred', () => {
+    let project!: Project;
+    beforeEach(async () => {
+      project = await Project.create();
+
+      let code = stripIndent`
+        import '@glint/environment-ember-template-imports';
+        import Component from '@glimmer/component';
+        import { hbs } from 'ember-template-imports';
+  
+        type ApplicationArgs = {
+          version: string;
+        };
+  
+        export default class Application extends Component<{ Args: ApplicationArgs }> {
+          private startupTime = new Date().toISOString();
+  
+          public static template = hbs\`
+            Welcome to app v{{@version}}.
+            The current time is {{this.startupTime}}.
+          \`;
+        }
+      `;
+
+      project.write(INPUT_SCRIPT, code);
+
+      await project.build({ flags: ['--incremental'] });
+    });
+
+    test('and there are no changes', async () => {
+      let firstStat = statSync(project.filePath(BUILD_INFO));
+
+      let checkResult = await project.build({ flags: ['--incremental'] });
+
+      // This should succeed again...
+      expect(checkResult.exitCode).toBe(0);
+      expect(checkResult.stdout).toEqual('');
+      expect(checkResult.stderr).toEqual('');
+
+      // ...without needing to update the build info.
+      let secondStat = statSync(project.filePath(BUILD_INFO));
+      expect(firstStat.mtime).toEqual(secondStat.mtime);
+    });
+
+    test('and there are changes', async () => {
+      let firstStat = statSync(project.filePath(BUILD_INFO));
+
+      let code = stripIndent`
+        import '@glint/environment-ember-template-imports';
+        import Component from '@glimmer/component';
+        import { hbs } from 'ember-template-imports';
+  
+        type ApplicationArgs = {
+          appVersion: string;
+        };
+  
+        export default class Application extends Component<{ Args: ApplicationArgs }> {
+          private startupTime = new Date().toISOString();
+  
+          public static template = hbs\`
+            Welcome to app v{{@appVersion}}.
+            The current time is {{this.startupTime}}.
+          \`;
+        }
+      `;
+
+      project.write(INPUT_SCRIPT, code);
+
+      let checkResult = await project.build({ flags: ['--incremental'] });
+
+      // This should succeed again...
+      expect(checkResult.exitCode).toBe(0);
+      expect(checkResult.stdout).toEqual('');
+      expect(checkResult.stderr).toEqual('');
+
+      // ...but the build info should be updated.
+      let secondStat = statSync(project.filePath(BUILD_INFO));
+      expect(firstStat.mtimeMs).toBeLessThan(secondStat.mtimeMs);
+    });
+  });
+});

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -49,14 +49,11 @@ const argv = yargs
     description: `Show what would be built (or deleted, if specified with '--clean'). Same as the TS \`--dry\` flag.`,
     type: 'boolean',
   })
-  // TODO: implement these!
-  /*
   .option('incremental', {
     description:
       'Save .tsbuildinfo files to allow for incremental compilation of projects. Same as the TS `--incremental` flag.',
     type: 'boolean',
   })
-  */
   .option('debug-intermediate-representation', {
     boolean: false,
     description: `When true, writes out a Glint's internal intermediate representation of each file within a GLINT_DEBUG subdirectory of the current working directory. This is intended for debugging Glint itself.`,
@@ -84,7 +81,7 @@ if (argv.build) {
     clean: argv.clean,
     force: argv.force,
     dry: argv.dry,
-    // incremental: argv.incremental,
+    incremental: argv.incremental,
   };
 
   // Get the closest TS to us, since we have to assume that we may be in the

--- a/packages/core/src/cli/options.ts
+++ b/packages/core/src/cli/options.ts
@@ -1,7 +1,10 @@
+import { type CompilerOptions } from 'typescript';
+
 export function determineOptionsToExtend(argv: {
   declaration?: boolean | undefined;
+  incremental?: boolean | undefined;
 }): import('typescript').CompilerOptions {
-  let options: import('typescript').CompilerOptions = {};
+  let options: CompilerOptions = { incremental: argv.incremental };
 
   if ('declaration' in argv) {
     options.noEmit = !argv.declaration;


### PR DESCRIPTION
Include the flag in the CLI and incorporate it for both `--build` and regular builds.

The test here is intentionally minimal: we exercise a much broader set of features via the `--build` and especially `--build --dry` tests, which exercise these capabilities explicitly. Here, we just check that `--incremental` does the right thing when *not* in a `--build` context.