### PR TITLE
Mention minimum Ember version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TypeScript-powered tooling for Glimmer templates.
 
 ## Overview
 
-[Glint] is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
+[Glint] is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] (Version 3.24+) and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
 
 ⚠️ Note: **Glint is still under active development!** Please bear with us and expect breaking changes and rough edges as we work toward a stable release. Also note that Glint is currently only compatible with TypeScript projects, but our aim is ultimately to support JavaScript as well, as TypeScript's tooling can provide best-in-class support for both TS and JS projects.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TypeScript-powered tooling for Glimmer templates.
 
 ## Overview
 
-[Glint] is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] (Version 3.24+) and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
+[Glint] is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] v3.24+ and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
 
 ⚠️ Note: **Glint is still under active development!** Please bear with us and expect breaking changes and rough edges as we work toward a stable release. Also note that Glint is currently only compatible with TypeScript projects, but our aim is ultimately to support JavaScript as well, as TypeScript's tooling can provide best-in-class support for both TS and JS projects.
 

--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -1,4 +1,4 @@
-To use Glint with [Ember](https://github.com/emberjs/ember.js) (Version 3.24 or higher), you'll add the `@glint/core` and `@glint/environment-ember-loose` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
+To use Glint with [Ember](https://github.com/emberjs/ember.js) v3.24 or higher, you'll add the `@glint/core` and `@glint/environment-ember-loose` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
 
 {% tabs %}
 {% tab title="Yarn" %}

--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -1,4 +1,4 @@
-To use Glint with [Ember](https://github.com/emberjs/ember.js), you'll add the `@glint/core` and `@glint/environment-ember-loose` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
+To use Glint with [Ember](https://github.com/emberjs/ember.js) (Version 3.24 or higher), you'll add the `@glint/core` and `@glint/environment-ember-loose` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
 
 {% tabs %}
 {% tab title="Yarn" %}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,4 @@
-Glint is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] (Version 3.24+) and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
+Glint is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] v3.24+ and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
 
 ## Glint CLI
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,4 @@
-Glint is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
+Glint is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js] (Version 3.24+) and [GlimmerX] projects. Similar to [Vetur] for Vue projects or [Svelte Language Tools], Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI.
 
 ## Glint CLI
 


### PR DESCRIPTION
I believe it's Ember 4, but if it's not I can change it, just so long as it's mentioned somewhere.

_edit: Ember 3.24+ seems more correct, and i verified this with my own testing_