### PR TITLE
Break `template()` in two

### DIFF
--- a/packages/core/__tests__/cli/declaration.test.ts
+++ b/packages/core/__tests__/cli/declaration.test.ts
@@ -45,7 +45,7 @@ describe('CLI: emitting declarations', () => {
           Args: ApplicationArgs;
       }> {
           private startupTime;
-          static template: unknown;
+          static template: abstract new () => unknown;
       }
       "
     `);

--- a/packages/core/__tests__/cli/declaration.test.ts
+++ b/packages/core/__tests__/cli/declaration.test.ts
@@ -117,7 +117,6 @@ describe('CLI: emitting declarations', () => {
       }
       export default class ClassComponent extends Component<ClassComponentSignature> {
           private startupTime;
-          protected static '~template:ClassComponent': unknown;
       }
       "
     `);

--- a/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
@@ -1,8 +1,7 @@
 import Component from '@ember/component';
 import {
-  template,
+  templateForBackingValue,
   resolve,
-  ResolveContext,
   yieldToBlock,
   emitComponent,
 } from '@glint/environment-ember-loose/-private/dsl';
@@ -12,9 +11,11 @@ import type { ComponentLike } from '@glint/template';
 
 {
   class NoArgsComponent extends Component {
-    static template = template(function* (𝚪: ResolveContext<NoArgsComponent>) {
-      𝚪;
-    });
+    static {
+      templateForBackingValue(this, function (𝚪) {
+        𝚪;
+      });
+    }
   }
 
   resolve(NoArgsComponent)({
@@ -44,11 +45,13 @@ import type { ComponentLike } from '@glint/template';
   class StatefulComponent extends Component {
     private foo = 'hello';
 
-    static template = template(function* (𝚪: ResolveContext<StatefulComponent>) {
-      expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
-      expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
-      expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
-    });
+    static {
+      templateForBackingValue(this, function* (𝚪) {
+        expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
+        expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
+        expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
+      });
+    }
   }
 
   emitComponent(resolve(StatefulComponent)({}));
@@ -69,18 +72,27 @@ import type { ComponentLike } from '@glint/template';
 
   interface YieldingComponent<T> extends YieldingComponentArgs<T> {}
   class YieldingComponent<T> extends Component<YieldingComponentSignature<T>> {
-    static template = template(function* <T>(𝚪: ResolveContext<YieldingComponent<T>>) {
-      expectTypeOf(𝚪.this).toEqualTypeOf<YieldingComponent<T>>();
-      expectTypeOf(𝚪.args).toEqualTypeOf<{ values: T[] }>();
+    static {
+      templateForBackingValue(this, function* (𝚪) {
+        // We can't directly assert on the type of e.g. `@values` here, as we don't
+        // have a name for it in scope. However, the yields below confirm that the
+        // only thing we can legally yield to the default block is an element of the
+        // `@values` arg, since the only information we have about that type is that
+        // the array element and the yielded value are the same.
+        yieldToBlock(
+          𝚪,
+          'default',
+          // @ts-expect-error: only a `T` is a valid yield
+          123
+        );
 
-      expectTypeOf(𝚪.this.values).toEqualTypeOf<Array<T>>();
-
-      if (𝚪.args.values.length) {
-        yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
-      } else {
-        yieldToBlock(𝚪, 'else');
-      }
-    });
+        if (𝚪.args.values.length) {
+          yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
+        } else {
+          yieldToBlock(𝚪, 'else');
+        }
+      });
+    }
   }
 
   // @ts-expect-error: missing required arg

--- a/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
@@ -75,8 +75,8 @@ import type { ComponentLike } from '@glint/template';
     static {
       templateForBackingValue(this, function* (𝚪) {
         // We can't directly assert on the type of e.g. `@values` here, as we don't
-        // have a name for it in scope. However, the yields below confirm that the
-        // only thing we can legally yield to the default block is an element of the
+        // have a name for it in scope: the type `T` is present on the class instance,
+        // but not in a `static` block. However, the yields below confirm that the
         // `@values` arg, since the only information we have about that type is that
         // the array element and the yielded value are the same.
         yieldToBlock(

--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -67,8 +67,8 @@ import { ComponentLike } from '@glint/template';
     static {
       templateForBackingValue(this, function* (𝚪) {
         // We can't directly assert on the type of e.g. `@values` here, as we don't
-        // have a name for it in scope. However, the yields below confirm that the
-        // only thing we can legally yield to the default block is an element of the
+        // have a name for it in scope: the type `T` is present on the class instance,
+        // but not in a `static` block. However, the yields below confirm that the
         // `@values` arg, since the only information we have about that type is that
         // the array element and the yielded value are the same.
         yieldToBlock(

--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -1,8 +1,7 @@
 import Component from '@glimmer/component';
 import {
-  template,
+  templateForBackingValue,
   resolve,
-  ResolveContext,
   yieldToBlock,
   emitComponent,
 } from '@glint/environment-ember-loose/-private/dsl';
@@ -40,12 +39,14 @@ import { ComponentLike } from '@glint/template';
   class StatefulComponent extends Component {
     private foo = 'hello';
 
-    static template = template(function* (𝚪: ResolveContext<StatefulComponent>) {
-      expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
-      expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
-      expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
-      expectTypeOf(𝚪.this.args).toEqualTypeOf<Readonly<EmptyObject>>();
-    });
+    static {
+      templateForBackingValue(this, function* (𝚪) {
+        expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
+        expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
+        expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
+        expectTypeOf(𝚪.this.args).toEqualTypeOf<Readonly<EmptyObject>>();
+      });
+    }
   }
 
   emitComponent(resolve(StatefulComponent)({}));
@@ -63,17 +64,27 @@ import { ComponentLike } from '@glint/template';
   }
 
   class YieldingComponent<T> extends Component<YieldingComponentSignature<T>> {
-    static template = template(function* <T>(𝚪: ResolveContext<YieldingComponent<T>>) {
-      expectTypeOf(𝚪.this).toEqualTypeOf<YieldingComponent<T>>();
-      expectTypeOf(𝚪.args).toEqualTypeOf<{ values: T[] }>();
-      expectTypeOf(𝚪.this.args).toEqualTypeOf<Readonly<{ values: T[] }>>();
+    static {
+      templateForBackingValue(this, function* (𝚪) {
+        // We can't directly assert on the type of e.g. `@values` here, as we don't
+        // have a name for it in scope. However, the yields below confirm that the
+        // only thing we can legally yield to the default block is an element of the
+        // `@values` arg, since the only information we have about that type is that
+        // the array element and the yielded value are the same.
+        yieldToBlock(
+          𝚪,
+          'default',
+          // @ts-expect-error: only a `T` is a valid yield
+          123
+        );
 
-      if (𝚪.args.values.length) {
-        yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
-      } else {
-        yieldToBlock(𝚪, 'else');
-      }
-    });
+        if (𝚪.args.values.length) {
+          yieldToBlock(𝚪, 'default', 𝚪.args.values[0]);
+        } else {
+          yieldToBlock(𝚪, 'else');
+        }
+      });
+    }
   }
 
   // @ts-expect-error: missing required arg

--- a/packages/environment-ember-loose/__tests__/type-tests/route-and-controller.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/route-and-controller.test.ts
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
 import { expectTypeOf } from 'expect-type';
 import { EmptyObject } from '@glint/template/-private/integration';
-import { ResolveContext } from '../../-private/dsl';
+import { templateForBackingValue } from '../../-private/dsl';
 
 class TestRoute extends Route {
   override async model(): Promise<{ message: string }> {
@@ -10,12 +10,12 @@ class TestRoute extends Route {
   }
 }
 
-declare const routeContext: ResolveContext<TestRoute>;
-
-expectTypeOf(routeContext.args).toEqualTypeOf<{ model: { message: string } }>();
-expectTypeOf(routeContext.element).toBeNull();
-expectTypeOf(routeContext.this).toEqualTypeOf<Controller & { model: { message: string } }>();
-expectTypeOf(routeContext.blocks).toEqualTypeOf<EmptyObject>();
+templateForBackingValue(TestRoute, function (routeContext) {
+  expectTypeOf(routeContext.args).toEqualTypeOf<{ model: { message: string } }>();
+  expectTypeOf(routeContext.element).toBeNull();
+  expectTypeOf(routeContext.this).toEqualTypeOf<Controller & { model: { message: string } }>();
+  expectTypeOf(routeContext.blocks).toEqualTypeOf<EmptyObject>();
+});
 
 class TestController extends Controller {
   declare date: Date;
@@ -25,9 +25,9 @@ class TestController extends Controller {
   };
 }
 
-declare const controllerContext: ResolveContext<TestController>;
-
-expectTypeOf(controllerContext.args).toEqualTypeOf<{ model: { name: string; age: number } }>();
-expectTypeOf(controllerContext.element).toBeNull();
-expectTypeOf(controllerContext.this).toEqualTypeOf<TestController>();
-expectTypeOf(controllerContext.blocks).toEqualTypeOf<EmptyObject>();
+templateForBackingValue(TestController, function (controllerContext) {
+  expectTypeOf(controllerContext.args).toEqualTypeOf<{ model: { name: string; age: number } }>();
+  expectTypeOf(controllerContext.element).toBeNull();
+  expectTypeOf(controllerContext.this).toEqualTypeOf<TestController>();
+  expectTypeOf(controllerContext.blocks).toEqualTypeOf<EmptyObject>();
+});

--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -1,8 +1,7 @@
 import templateOnlyComponent from '@ember/component/template-only';
 import {
-  template,
+  templateForBackingValue,
   resolve,
-  ResolveContext,
   emitComponent,
 } from '@glint/environment-ember-loose/-private/dsl';
 import { AcceptsBlocks } from '@glint/template/-private/integration';
@@ -36,7 +35,7 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
 
   emitComponent(resolve(NoArgsComponent)({}));
 
-  template(function (𝚪: ResolveContext<typeof NoArgsComponent>) {
+  templateForBackingValue(NoArgsComponent, function (𝚪) {
     expectTypeOf(𝚪.this).toBeNull();
     expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
     expectTypeOf(𝚪.element).toBeNull();
@@ -94,7 +93,7 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
     }
   }
 
-  template(function (𝚪: ResolveContext<typeof YieldingComponent>) {
+  templateForBackingValue(YieldingComponent, function (𝚪) {
     expectTypeOf(𝚪.this).toBeNull();
     expectTypeOf(𝚪.args).toEqualTypeOf<YieldingComponentSignature['Args']>();
     expectTypeOf(𝚪.element).toEqualTypeOf<YieldingComponentSignature['Element']>();

--- a/packages/environment-ember-template-imports/-private/dsl/index.d.ts
+++ b/packages/environment-ember-template-imports/-private/dsl/index.d.ts
@@ -80,14 +80,14 @@ export declare function resolve<P extends unknown[], T>(
 
 export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;
 
-// We customize the top-level `template` wrapper function for this environment to
+// We customize the top-level `templateExpression` wrapper function for this environment to
 // return a type that's assignable to `TemplateOnlyComponent` from '@ember/component/template-only'.
 // Longer term we should rationalize this to a type that doesn't carry extra baggage
 // and likely comes from a more sensible path.
 
 import { TemplateOnlyComponent } from '@ember/component/template-only';
 
-export declare function template<
+export declare function templateExpression<
   Signature extends AnyFunction = (args: EmptyObject) => AcceptsBlocks<EmptyObject>,
   Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
 >(

--- a/packages/environment-glimmerx/-private/dsl/index.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/index.d.ts
@@ -55,20 +55,16 @@ export declare function resolve<Args extends unknown[], T>(
 
 export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;
 
-// We customize the top-level `template` wrapper function for this environment to
+// We customize the top-level `templateExpression` wrapper function for this environment to
 // return a type that's assignable to `TemplateComponent` from '@glimmerx/component'.
 // Longer term we should rationalize this to a type that doesn't carry extra baggage
 // and likely comes from a more sensible path.
 
 import { TemplateComponent } from '@glimmerx/component';
 
-export declare function template<
+export declare function templateExpression<
   Signature extends AnyFunction = (args: EmptyObject) => AcceptsBlocks<EmptyObject>,
   Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
 >(
   f: (𝚪: Context, χ: never) => void
 ): TemplateComponent<never> & (new () => Invokable<Signature> & HasContext<Context>);
-export declare function template<
-  Signature extends AnyFunction = (args: EmptyObject) => AcceptsBlocks<EmptyObject>,
-  Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
->(f: (𝚪: Context, χ: never) => void): new () => Invokable<Signature> & HasContext<Context>;

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -67,8 +67,8 @@ import { AcceptsBlocks, EmptyObject } from '@glint/template/-private/integration
   class YieldingComponent<T> extends Component<YieldingComponentSignature<T>> {
     static template = templateForBackingValue(this, function (𝚪) {
       // We can't directly assert on the type of e.g. `@values` here, as we don't
-      // have a name for it in scope. However, the yields below confirm that the
-      // only thing we can legally yield to the default block is an element of the
+      // have a name for it in scope: the type `T` is present on the class instance,
+      // but not in a `static` block. However, the yields below confirm that the
       // `@values` arg, since the only information we have about that type is that
       // the array element and the yielded value are the same.
       yieldToBlock(

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -83,18 +83,16 @@ export declare function templateExpression<
  * The given callback accepts a template context value as well as an instance of the
  * environment's DSL export.
  *
- * Note that the constructor-based signature returns an (arbitrary) abstract constructor
- * type in order to trigger TypeScript's higher-order function type inference and propagate
- * any type parameters on the class (see https://github.com/microsoft/TypeScript/pull/30215)
+ * Note that this signature is structured carefully to trigger TypeScript's higher-order function
+ * type inference so that any type parameters on the given backing value (if it's a class) will
+ * be preserved and reflected in the template body. Both the `Args` type and the constructor return
+ * value are necessary for this, despite the fact that we don't actually do anything with those
+ * types (see https://github.com/microsoft/TypeScript/pull/30215).
  */
 export declare function templateForBackingValue<Args extends unknown[], Context extends AnyContext>(
   backingValue: abstract new (...args: Args) => HasContext<Context>,
   body: (𝚪: Context, χ: never) => void
 ): abstract new () => unknown;
-export declare function templateForBackingValue<Context extends AnyContext>(
-  backingValue: HasContext<Context>,
-  body: (𝚪: Context, χ: never) => void
-): void;
 
 /*
  * Used in template bodies to encode a `{{yield}}` statement.

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -64,15 +64,37 @@ export declare function emitComponent<T extends AcceptsBlocks<any, any>>(
   blockParams: T extends AcceptsBlocks<infer Yields, any> ? Required<Yields> : any;
 };
 
-/**
- * Acts as a top-level wrapper for translated template bodies. The given
- * callback accepts a template context value as well as an instance of the
+/*
+ * Wraps a template body that appears as a standalone expression and is therefore not
+ * associated with any backing value.
+ *
+ * The given callback accepts a template context value as well as an instance of the
  * environment's DSL export.
  */
-export declare function template<
+export declare function templateExpression<
   Signature extends AnyFunction = (args: EmptyObject) => AcceptsBlocks<EmptyObject>,
   Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
 >(f: (𝚪: Context, χ: never) => void): new () => Invokable<Signature> & HasContext<Context>;
+
+/*
+ * Wraps a template body that's backed by a known value (typically a class), either
+ * via a `.hbs` association to a default export or via embedding e.g. with `<template>`.
+ *
+ * The given callback accepts a template context value as well as an instance of the
+ * environment's DSL export.
+ *
+ * Note that the constructor-based signature returns an (arbitrary) abstract constructor
+ * type in order to trigger TypeScript's higher-order function type inference and propagate
+ * any type parameters on the class (see https://github.com/microsoft/TypeScript/pull/30215)
+ */
+export declare function templateForBackingValue<Args extends unknown[], Context extends AnyContext>(
+  backingValue: abstract new (...args: Args) => HasContext<Context>,
+  body: (𝚪: Context, χ: never) => void
+): abstract new () => unknown;
+export declare function templateForBackingValue<Context extends AnyContext>(
+  backingValue: HasContext<Context>,
+  body: (𝚪: Context, χ: never) => void
+): void;
 
 /*
  * Used in template bodies to encode a `{{yield}}` statement.

--- a/packages/template/-private/dsl/types.d.ts
+++ b/packages/template/-private/dsl/types.d.ts
@@ -1,4 +1,4 @@
-import { EmptyObject, HasContext } from '@glint/template/-private/integration';
+import { EmptyObject } from '@glint/template/-private/integration';
 
 type Constructor<T> = abstract new (...args: never[]) => T;
 
@@ -19,13 +19,3 @@ export type ElementForTagName<Name extends string> = Name extends keyof HTMLElem
   : Name extends keyof SVGElementTagNameMap
   ? SVGElementTagNameMap[Name]
   : Element;
-
-/**
- * Given the constructor or instance type of a component backing class, produces the appropriate
- * `TemplateContext` type for its template.
- */
-export type ResolveContext<T> = T extends HasContext<infer Context>
-  ? Context
-  : T extends Constructor<HasContext<infer Context>>
-  ? Context
-  : unknown;

--- a/packages/template/__tests__/attributes.test.ts
+++ b/packages/template/__tests__/attributes.test.ts
@@ -1,8 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 import {
-  template,
+  templateForBackingValue,
   resolve,
-  ResolveContext,
   applyModifier,
   applySplattributes,
   applyAttributes,
@@ -33,17 +32,19 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
    * <img ...attributes {{imageModifier}}>
    * ```
    */
-  public static template = template(function (𝚪: ResolveContext<MyComponent>) {
-    expectTypeOf(𝚪.element).toEqualTypeOf<HTMLImageElement>();
+  static {
+    templateForBackingValue(this, function (𝚪) {
+      expectTypeOf(𝚪.element).toEqualTypeOf<HTMLImageElement>();
 
-    {
-      const ctx = emitElement('img');
-      expectTypeOf(ctx.element).toEqualTypeOf<HTMLImageElement>();
+      {
+        const ctx = emitElement('img');
+        expectTypeOf(ctx.element).toEqualTypeOf<HTMLImageElement>();
 
-      applyModifier(ctx.element, resolve(imageModifier)({}));
-      applySplattributes(𝚪.element, ctx.element);
-    }
-  });
+        applyModifier(ctx.element, resolve(imageModifier)({}));
+        applySplattributes(𝚪.element, ctx.element);
+      }
+    });
+  }
 }
 
 // `emitElement` type resolution

--- a/packages/template/__tests__/emit-component.test.ts
+++ b/packages/template/__tests__/emit-component.test.ts
@@ -5,9 +5,8 @@ import {
   emitElement,
   emitContent,
   resolve,
-  ResolveContext,
   resolveOrReturn,
-  template,
+  templateForBackingValue,
   yieldToBlock,
 } from '../-private/dsl';
 import TestComponent, { globals } from './test-component';
@@ -39,37 +38,39 @@ class MyComponent<T> extends TestComponent<MyComponentSignature<T>> {
    * {{/let}}
    * ```
    */
-  public static template = template(function <T>(𝚪: ResolveContext<MyComponent<T>>) {
-    const component = emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready));
-    const [isReady] = component.blockParams.default;
+  static {
+    templateForBackingValue(this, function (𝚪) {
+      const component = emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready));
+      const [isReady] = component.blockParams.default;
 
-    {
-      const 𝛄 = emitElement('div');
-      expectTypeOf(𝛄).toEqualTypeOf<{ element: HTMLDivElement }>();
-      applyModifier(𝛄.element, resolve(globals.on)({}, 'click', 𝚪.this.wrapperClicked));
-    }
+      {
+        const 𝛄 = emitElement('div');
+        expectTypeOf(𝛄).toEqualTypeOf<{ element: HTMLDivElement }>();
+        applyModifier(𝛄.element, resolve(globals.on)({}, 'click', 𝚪.this.wrapperClicked));
+      }
 
-    yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
+      yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
 
-    yieldToBlock(
-      𝚪,
-      // @ts-expect-error: bad block
-      'bad',
-      isReady,
-      𝚪.args.value
-    );
+      yieldToBlock(
+        𝚪,
+        // @ts-expect-error: bad block
+        'bad',
+        isReady,
+        𝚪.args.value
+      );
 
-    // @ts-expect-error: missing params
-    yieldToBlock(𝚪, 'body');
+      // @ts-expect-error: missing params
+      yieldToBlock(𝚪, 'body');
 
-    yieldToBlock(
-      𝚪,
-      'body',
-      isReady,
-      // @ts-expect-error: wrong param type
-      Symbol()
-    );
-  });
+      yieldToBlock(
+        𝚪,
+        'body',
+        isReady,
+        // @ts-expect-error: wrong param type
+        Symbol()
+      );
+    });
+  }
 }
 
 /**

--- a/packages/template/__tests__/resolution.test.ts
+++ b/packages/template/__tests__/resolution.test.ts
@@ -3,9 +3,8 @@ import { AcceptsBlocks, DirectInvokable, TemplateContext } from '../-private/int
 import {
   emitComponent,
   resolve,
-  ResolveContext,
   resolveOrReturn,
-  template,
+  templateForBackingValue,
   yieldToBlock,
 } from '../-private/dsl';
 import TestComponent, { globals } from './test-component';
@@ -32,16 +31,18 @@ declare function value<T>(): T;
      * {{/let}}
      * ```
      */
-    public static template = template(function <T>(𝚪: ResolveContext<MyComponent<T>>) {
-      {
-        const component = emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready));
-
+    static {
+      templateForBackingValue(this, function (𝚪) {
         {
-          const [isReady] = component.blockParams.default;
-          yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
+          const component = emitComponent(resolve(globals.let)({}, 𝚪.this.state.ready));
+
+          {
+            const [isReady] = component.blockParams.default;
+            yieldToBlock(𝚪, 'body', isReady, 𝚪.args.value);
+          }
         }
-      }
-    });
+      });
+    }
   }
 
   type ExpectedSignature = <T>(args: MyArgs<T>) => AcceptsBlocks<{
@@ -54,8 +55,13 @@ declare function value<T>(): T;
   expectTypeOf(resolve(MyComponent)).toEqualTypeOf<ExpectedSignature>();
 
   // Template context is inferred correctly
-  expectTypeOf<ResolveContext<MyComponent<number>>>().toEqualTypeOf<ExpectedContext<number>>();
-  expectTypeOf<ResolveContext<MyComponent<string>>>().toEqualTypeOf<ExpectedContext<string>>();
+  templateForBackingValue(MyComponent<number>, function (context) {
+    expectTypeOf(context).toEqualTypeOf<ExpectedContext<number>>();
+  });
+
+  templateForBackingValue(MyComponent<string>, function (context) {
+    expectTypeOf(context).toEqualTypeOf<ExpectedContext<string>>();
+  });
 }
 
 // A raw Invokable value

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -38,112 +38,108 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        |  ts(165:804):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(131:708):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
-        | | Mapping: Identifier
-        | |  hbs(0:0):
-        | |  ts(325:336):  MyComponent
-        | |
         | | Mapping: BlockStatement
         | |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        | |  ts(406:781):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
+        | |  ts(310:685):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
         | |
         | | | Mapping: PathExpression
         | | |  hbs(3:7):     each
-        | | |  ts(451:468):  χ.Globals[\\"each\\"]
+        | | |  ts(355:372):  χ.Globals[\\"each\\"]
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(3:7):     each
-        | | | |  ts(462:466):  each
+        | | | |  ts(366:370):  each
         | | | |
         | | |
         | | | Mapping: SubExpression
         | | |  hbs(8:43):    (array \\"world\\" \\"planet\\" \\"universe\\")
-        | | |  ts(474:505):  [\\"world\\", \\"planet\\", \\"universe\\"]
+        | | |  ts(378:409):  [\\"world\\", \\"planet\\", \\"universe\\"]
         | | |
         | | | | Mapping: StringLiteral
         | | | |  hbs(15:22):   \\"world\\"
-        | | | |  ts(475:482):  \\"world\\"
+        | | | |  ts(379:386):  \\"world\\"
         | | | |
         | | | | Mapping: StringLiteral
         | | | |  hbs(23:31):   \\"planet\\"
-        | | | |  ts(484:492):  \\"planet\\"
+        | | | |  ts(388:396):  \\"planet\\"
         | | | |
         | | | | Mapping: StringLiteral
         | | | |  hbs(32:42):   \\"universe\\"
-        | | | |  ts(494:504):  \\"universe\\"
+        | | | |  ts(398:408):  \\"universe\\"
         | | | |
         | | |
         | | | Mapping: Identifier
         | | |  hbs(48:54):   target
-        | | |  ts(528:534):  target
+        | | |  ts(432:438):  target
         | | |
         | | | Mapping: Identifier
         | | |  hbs(55:60):   index
-        | | |  ts(536:541):  index
+        | | |  ts(440:445):  index
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(67:82):   {{add index 1}}
-        | | |  ts(572:634):  χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
+        | | |  ts(476:538):  χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(69:72):   add
-        | | | |  ts(602:618):  χ.Globals[\\"add\\"]
+        | | | |  ts(506:522):  χ.Globals[\\"add\\"]
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(69:72):   add
-        | | | | |  ts(613:616):  add
+        | | | | |  ts(517:520):  add
         | | | | |
         | | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(73:78):   index
-        | | | |  ts(624:629):  index
+        | | | |  ts(528:533):  index
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(73:78):   index
-        | | | | |  ts(624:629):  index
+        | | | | |  ts(528:533):  index
         | | | | |
         | | | |
         | | | | Mapping: NumberLiteral
         | | | |  hbs(79:80):   1
-        | | | |  ts(631:632):  1
+        | | | |  ts(535:536):  1
         | | | |
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(84:100):  {{this.message}}
-        | | |  ts(636:695):  χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}))
+        | | |  ts(540:599):  χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(86:98):   this.message
-        | | | |  ts(674:689):  𝚪.this.message
+        | | | |  ts(578:593):  𝚪.this.message
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(86:90):   this
-        | | | | |  ts(677:681):  this
+        | | | | |  ts(581:585):  this
         | | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(91:98):   message
-        | | | | |  ts(682:689):  message
+        | | | | |  ts(586:593):  message
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(102:112): {{target}}
-        | | |  ts(697:747):  χ.emitContent(χ.resolveOrReturn(target)({}))
+        | | |  ts(601:651):  χ.emitContent(χ.resolveOrReturn(target)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(104:110): target
-        | | | |  ts(735:741):  target
+        | | | |  ts(639:645):  target
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(104:110): target
-        | | | | |  ts(735:741):  target
+        | | | | |  ts(639:645):  target
         | | | | |
         | | | |
         | | |
         | | | Mapping: Identifier
         | | |  hbs(117:121): each
-        | | |  ts(770:774):  each
+        | | |  ts(674:678):  each
         | | |
         | |
         |"
@@ -184,43 +180,39 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(151:201): hbs\`\\\\n    <HelperComponent @foo={{this.bar}} />\\\\n  \`
-        |  ts(151:510):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(151:451):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
-        | | Mapping: Identifier
-        | |  hbs(151:151):
-        | |  ts(305:316):  MyComponent
-        | |
         | | Mapping: ElementNode
         | |  hbs(160:197): <HelperComponent @foo={{this.bar}} />
-        | |  ts(390:488):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
+        | |  ts(331:429):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
         | |
         | | | Mapping: Identifier
         | | |  hbs(161:176): HelperComponent
-        | | |  ts(435:450):  HelperComponent
+        | | |  ts(376:391):  HelperComponent
         | | |
         | | | Mapping: AttrNode
         | | |  hbs(177:194): @foo={{this.bar}}
-        | | |  ts(454:470):  foo: 𝚪.this.bar
+        | | |  ts(395:411):  foo: 𝚪.this.bar
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(178:181): foo
-        | | | |  ts(454:457):  foo
+        | | | |  ts(395:398):  foo
         | | | |
         | | | | Mapping: MustacheStatement
         | | | |  hbs(182:194): {{this.bar}}
-        | | | |  ts(459:470):  𝚪.this.bar
+        | | | |  ts(400:411):  𝚪.this.bar
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(184:192): this.bar
-        | | | | |  ts(459:470):  𝚪.this.bar
+        | | | | |  ts(400:411):  𝚪.this.bar
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(184:188): this
-        | | | | | |  ts(462:466):  this
+        | | | | | |  ts(403:407):  this
         | | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(189:192): bar
-        | | | | | |  ts(467:470):  bar
+        | | | | | |  ts(408:411):  bar
         | | | | | |
         | | | | |
         | | | |
@@ -230,49 +222,45 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(295:419): hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>\\\\n  \`
-        |  ts(604:1072): ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(545:950):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
-        | | Mapping: Identifier
-        | |  hbs(295:295):
-        | |  ts(758:773):  HelperComponent
-        | |
         | | Mapping: ElementNode
         | |  hbs(304:415): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
-        | |  ts(847:1050): {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
+        | |  ts(725:928):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | |
         | | | Mapping: AttrNode
         | | |  hbs(307:320): ...attributes
-        | | |  ts(886:935):  χ.applySplattributes(𝚪.element, 𝛄.element);
+        | | |  ts(764:813):  χ.applySplattributes(𝚪.element, 𝛄.element);
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(335:343): {{@foo}}
-        | | |  ts(936:989):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | |  ts(814:867):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(337:341): @foo
-        | | | |  ts(972:983):  𝚪.args.foo
+        | | | |  ts(850:861):  𝚪.args.foo
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(338:341): foo
-        | | | | |  ts(980:983):  foo
+        | | | | |  ts(858:861):  foo
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheCommentStatement
         | | |  hbs(352:391): {{! @glint-expect-error: no @bar arg }}
-        | | |  ts(991:991):
+        | | |  ts(869:869):
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(398:406): {{@bar}}
-        | | |  ts(991:1044): χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
+        | | |  ts(869:922):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(400:404): @bar
-        | | | |  ts(1027:1038):𝚪.args.bar
+        | | | |  ts(905:916):  𝚪.args.bar
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(401:404): bar
-        | | | | |  ts(1035:1038):bar
+        | | | | |  ts(913:916):  bar
         | | | | |
         | | | |
         | | |
@@ -315,43 +303,39 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(156:208): hbs\`\\\\r\\\\n    <HelperComponent @foo={{this.bar}} />\\\\r\\\\n  \`
-        |  ts(156:515):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(156:456):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
-        | | Mapping: Identifier
-        | |  hbs(156:156):
-        | |  ts(310:321):  MyComponent
-        | |
         | | Mapping: ElementNode
         | |  hbs(166:203): <HelperComponent @foo={{this.bar}} />
-        | |  ts(395:493):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
+        | |  ts(336:434):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
         | |
         | | | Mapping: Identifier
         | | |  hbs(167:182): HelperComponent
-        | | |  ts(440:455):  HelperComponent
+        | | |  ts(381:396):  HelperComponent
         | | |
         | | | Mapping: AttrNode
         | | |  hbs(183:200): @foo={{this.bar}}
-        | | |  ts(459:475):  foo: 𝚪.this.bar
+        | | |  ts(400:416):  foo: 𝚪.this.bar
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(184:187): foo
-        | | | |  ts(459:462):  foo
+        | | | |  ts(400:403):  foo
         | | | |
         | | | | Mapping: MustacheStatement
         | | | |  hbs(188:200): {{this.bar}}
-        | | | |  ts(464:475):  𝚪.this.bar
+        | | | |  ts(405:416):  𝚪.this.bar
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(190:198): this.bar
-        | | | | |  ts(464:475):  𝚪.this.bar
+        | | | | |  ts(405:416):  𝚪.this.bar
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(190:194): this
-        | | | | | |  ts(467:471):  this
+        | | | | | |  ts(408:412):  this
         | | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(195:198): bar
-        | | | | | |  ts(472:475):  bar
+        | | | | | |  ts(413:416):  bar
         | | | | | |
         | | | | |
         | | | |
@@ -361,49 +345,45 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(306:437): hbs\`\\\\r\\\\n    <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>\\\\r\\\\n  \`
-        |  ts(613:1081): ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<HelperComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(554:959):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
         |
-        | | Mapping: Identifier
-        | |  hbs(306:306):
-        | |  ts(767:782):  HelperComponent
-        | |
         | | Mapping: ElementNode
         | |  hbs(316:432): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
-        | |  ts(856:1059): {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
+        | |  ts(734:937):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | |
         | | | Mapping: AttrNode
         | | |  hbs(319:332): ...attributes
-        | | |  ts(895:944):  χ.applySplattributes(𝚪.element, 𝛄.element);
+        | | |  ts(773:822):  χ.applySplattributes(𝚪.element, 𝛄.element);
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(348:356): {{@foo}}
-        | | |  ts(945:998):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | |  ts(823:876):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(350:354): @foo
-        | | | |  ts(981:992):  𝚪.args.foo
+        | | | |  ts(859:870):  𝚪.args.foo
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(351:354): foo
-        | | | | |  ts(989:992):  foo
+        | | | | |  ts(867:870):  foo
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheCommentStatement
         | | |  hbs(367:406): {{! @glint-expect-error: no @bar arg }}
-        | | |  ts(1000:1000):
+        | | |  ts(878:878):
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(414:422): {{@bar}}
-        | | |  ts(1000:1053):χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
+        | | |  ts(878:931):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(416:420): @bar
-        | | | |  ts(1036:1047):𝚪.args.bar
+        | | | |  ts(914:925):  𝚪.args.bar
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(417:420): bar
-        | | | | |  ts(1044:1047):bar
+        | | | | |  ts(922:925):  bar
         | | | | |
         | | | |
         | | |

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -38,7 +38,7 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        |  ts(131:708):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(131:697):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: BlockStatement
         | |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
@@ -180,7 +180,7 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(151:201): hbs\`\\\\n    <HelperComponent @foo={{this.bar}} />\\\\n  \`
-        |  ts(151:451):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(151:440):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: ElementNode
         | |  hbs(160:197): <HelperComponent @foo={{this.bar}} />
@@ -222,45 +222,45 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(295:419): hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>\\\\n  \`
-        |  ts(545:950):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(534:928):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: ElementNode
         | |  hbs(304:415): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
-        | |  ts(725:928):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
+        | |  ts(714:917):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | |
         | | | Mapping: AttrNode
         | | |  hbs(307:320): ...attributes
-        | | |  ts(764:813):  χ.applySplattributes(𝚪.element, 𝛄.element);
+        | | |  ts(753:802):  χ.applySplattributes(𝚪.element, 𝛄.element);
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(335:343): {{@foo}}
-        | | |  ts(814:867):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | |  ts(803:856):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(337:341): @foo
-        | | | |  ts(850:861):  𝚪.args.foo
+        | | | |  ts(839:850):  𝚪.args.foo
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(338:341): foo
-        | | | | |  ts(858:861):  foo
+        | | | | |  ts(847:850):  foo
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheCommentStatement
         | | |  hbs(352:391): {{! @glint-expect-error: no @bar arg }}
-        | | |  ts(869:869):
+        | | |  ts(858:858):
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(398:406): {{@bar}}
-        | | |  ts(869:922):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
+        | | |  ts(858:911):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(400:404): @bar
-        | | | |  ts(905:916):  𝚪.args.bar
+        | | | |  ts(894:905):  𝚪.args.bar
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(401:404): bar
-        | | | | |  ts(913:916):  bar
+        | | | | |  ts(902:905):  bar
         | | | | |
         | | | |
         | | |
@@ -303,7 +303,7 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(156:208): hbs\`\\\\r\\\\n    <HelperComponent @foo={{this.bar}} />\\\\r\\\\n  \`
-        |  ts(156:456):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(156:445):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: ElementNode
         | |  hbs(166:203): <HelperComponent @foo={{this.bar}} />
@@ -345,45 +345,45 @@ describe('Debug utilities', () => {
 
         | Mapping: Template
         |  hbs(306:437): hbs\`\\\\r\\\\n    <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>\\\\r\\\\n  \`
-        |  ts(554:959):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n}) as unknown
+        |  ts(543:937):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: ElementNode
         | |  hbs(316:432): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
-        | |  ts(734:937):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
+        | |  ts(723:926):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | |
         | | | Mapping: AttrNode
         | | |  hbs(319:332): ...attributes
-        | | |  ts(773:822):  χ.applySplattributes(𝚪.element, 𝛄.element);
+        | | |  ts(762:811):  χ.applySplattributes(𝚪.element, 𝛄.element);
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(348:356): {{@foo}}
-        | | |  ts(823:876):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | |  ts(812:865):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(350:354): @foo
-        | | | |  ts(859:870):  𝚪.args.foo
+        | | | |  ts(848:859):  𝚪.args.foo
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(351:354): foo
-        | | | | |  ts(867:870):  foo
+        | | | | |  ts(856:859):  foo
         | | | | |
         | | | |
         | | |
         | | | Mapping: MustacheCommentStatement
         | | |  hbs(367:406): {{! @glint-expect-error: no @bar arg }}
-        | | |  ts(878:878):
+        | | |  ts(867:867):
         | | |
         | | | Mapping: MustacheStatement
         | | |  hbs(414:422): {{@bar}}
-        | | |  ts(878:931):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
+        | | |  ts(867:920):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
         | | |
         | | | | Mapping: PathExpression
         | | | |  hbs(416:420): @bar
-        | | | |  ts(914:925):  𝚪.args.bar
+        | | | |  ts(903:914):  𝚪.args.bar
         | | | |
         | | | | | Mapping: Identifier
         | | | | |  hbs(417:420): bar
-        | | | | |  ts(922:925):  bar
+        | | | | |  ts(911:914):  bar
         | | | | |
         | | | |
         | | |

--- a/packages/transform/__tests__/offset-mapping.test.ts
+++ b/packages/transform/__tests__/offset-mapping.test.ts
@@ -68,7 +68,7 @@ describe('Source-to-source offset mapping', () => {
   }
 
   function findOccurrence(haystack: string, needle: string, occurrence: number): number {
-    let offset = -1;
+    let offset = haystack.indexOf('function(𝚪');
     for (let i = 0; i < occurrence + 1; i++) {
       offset = haystack.indexOf(needle, offset + 1);
 

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -25,7 +25,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glimmerx/component';
         export default class MyComponent extends Component {
-          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
         }) as unknown;
@@ -50,7 +50,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glimmerx/component';
         export default class MyComponent<K extends string> extends Component<{ value: K }> {
-          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-glimmerx/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
         }) as unknown;
@@ -71,24 +71,13 @@ describe('rewriteModule', () => {
 
       let transformedModule = rewriteModule(ts, { script }, glimmerxEnvironment);
 
-      expect(transformedModule?.errors).toEqual([
-        {
-          message: 'Classes containing templates must have a name',
-          source: script,
-          location: {
-            start: script.contents.indexOf('hbs`'),
-            end: script.contents.lastIndexOf('`') + 1,
-          },
-        },
-      ]);
-
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from '@glimmerx/component';
         export default class extends Component {
-          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
+          static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
-        });
+        }) as unknown;
         }"
       `);
     });
@@ -147,19 +136,19 @@ describe('rewriteModule', () => {
 
         const message = 'hello';
 
-        ({} as typeof import(\\"@glint/test-env\\")).template(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
+        ({} as typeof import(\\"@glint/test-env\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
           hbsCaptureAll;
           χ.emitContent(χ.resolveOrReturn(global)({}));
           χ.emitContent(χ.resolveOrReturn(message)({}));
           𝚪; χ;
         });
-        ({} as typeof import(\\"@glint/test-env\\")).template(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
+        ({} as typeof import(\\"@glint/test-env\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
           hbsCaptureSome;
           χ.emitContent(χ.resolveOrReturn(χ.Globals[\\"global\\"])({}));
           χ.emitContent(χ.resolveOrReturn(message)({}));
           𝚪; χ;
         });
-        ({} as typeof import(\\"@glint/test-env\\")).template(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
+        ({} as typeof import(\\"@glint/test-env\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/test-env\\")) {
           hbsCaptureNone;
           χ.emitContent(χ.resolveOrReturn(χ.Globals[\\"global\\"])({}));
           χ.emitContent(χ.resolveOrReturn(χ.Globals[\\"message\\"])({}));
@@ -193,9 +182,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
-        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        static {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown;
+        }) as unknown}
         }"
       `);
     });
@@ -222,9 +212,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         class MyComponent extends Component {
-        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        static {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown;
+        }) as unknown}
         }
         export default MyComponent;"
       `);
@@ -251,9 +242,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent<K extends string> extends Component<{ value: K }> {
-        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function<K extends string>(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent<K>>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        static {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown;
+        }) as unknown}
         }"
       `);
     });
@@ -275,23 +267,13 @@ describe('rewriteModule', () => {
 
       let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
 
-      expect(transformedModule?.errors).toEqual([
-        {
-          message: 'Classes with an associated template must have a name',
-          source: script,
-          location: {
-            start: script.contents.indexOf('export default'),
-            end: script.contents.lastIndexOf('}') + 1,
-          },
-        },
-      ]);
-
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class extends Component {
-        protected static '~template:undefined' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        static {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        });
+        }) as unknown}
         }"
       `);
     });
@@ -316,7 +298,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export class MyComponent extends Component {}
-        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           χ.emitContent(χ.resolveOrReturn(χ.Globals[\\"hello\\"])({}));
           𝚪; χ;
         });
@@ -346,7 +328,7 @@ describe('rewriteModule', () => {
         "import templateOnly from '@glimmer/component/template-only';
 
         export default templateOnly();
-        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<typeof import('./test').default>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(({} as unknown as typeof import('./test').default), function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
         }) as unknown;
         "
@@ -371,7 +353,7 @@ describe('rewriteModule', () => {
       expect(transformedModule?.errors).toEqual([]);
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "export default Foo;
-        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<typeof import('./test').default>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(({} as unknown as typeof import('./test').default), function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           χ.emitContent(χ.resolveOrReturn(χ.Globals[\\"hello\\"])({}));
           𝚪; χ;
         }) as unknown;
@@ -405,9 +387,10 @@ describe('rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
-        protected static '~template:MyComponent' = ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-loose/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
+        static {
+        ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown;
+        }) as unknown}
         }
         declare module '@glint/environment-ember-loose/registry' {
           export default interface Registry {
@@ -481,27 +464,23 @@ describe('rewriteModule', () => {
 
         | Mapping: Template
         |  hbs(22:74):   <template>\\\\n    Hello, {{this.target}}!\\\\n  </template>
-        |  ts(22:385):   static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-template-imports/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}));\\\\n  𝚪; χ;\\\\n}) as unknown }
+        |  ts(22:312):   static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}));\\\\n  𝚪; χ;\\\\n}) as unknown }
         |
-        | | Mapping: Identifier
-        | |  hbs(22:22):
-        | |  ts(213:224):  MyComponent
-        | |
         | | Mapping: MustacheStatement
         | |  hbs(44:59):   {{this.target}}
-        | |  ts(305:359):  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}))
+        | |  ts(232:286):  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}))
         | |
         | | | Mapping: PathExpression
         | | |  hbs(46:57):   this.target
-        | | |  ts(339:353):  𝚪.this.target
+        | | |  ts(266:280):  𝚪.this.target
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(46:50):   this
-        | | | |  ts(342:346):  this
+        | | | |  ts(269:273):  this
         | | | |
         | | | | Mapping: Identifier
         | | | |  hbs(51:57):   target
-        | | | |  ts(347:353):  target
+        | | | |  ts(274:280):  target
         | | | |
         | | |
         | |
@@ -525,19 +504,19 @@ describe('rewriteModule', () => {
 
         | Mapping: Template
         |  hbs(0:44):    <template>\\\\n  Hello, {{@target}}!\\\\n</template>
-        |  ts(0:262):    export default ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}));\\\\n  𝚪; χ;\\\\n})
+        |  ts(0:272):    export default ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}));\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: MustacheStatement
         | |  hbs(20:31):   {{@target}}
-        | |  ts(195:249):  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}))
+        | |  ts(205:259):  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}))
         | |
         | | | Mapping: PathExpression
         | | |  hbs(22:29):   @target
-        | | |  ts(229:243):  𝚪.args.target
+        | | |  ts(239:253):  𝚪.args.target
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(23:29):   target
-        | | | |  ts(237:243):  target
+        | | | |  ts(247:253):  target
         | | | |
         | | |
         | |
@@ -576,19 +555,19 @@ describe('rewriteModule', () => {
 
         | Mapping: Template
         |  hbs(56:89):   <template>{{@message}}</template>
-        |  ts(56:304):   ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).template(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}));\\\\n  𝚪; χ;\\\\n})
+        |  ts(56:314):   ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}));\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: MustacheStatement
         | |  hbs(66:78):   {{@message}}
-        | |  ts(236:291):  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}))
+        | |  ts(246:301):  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}))
         | |
         | | | Mapping: PathExpression
         | | |  hbs(68:76):   @message
-        | | |  ts(270:285):  𝚪.args.message
+        | | |  ts(280:295):  𝚪.args.message
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(69:76):   message
-        | | | |  ts(278:285):  message
+        | | | |  ts(288:295):  message
         | | | |
         | | |
         | |
@@ -596,27 +575,23 @@ describe('rewriteModule', () => {
 
         | Mapping: Template
         |  hbs(139:174): <template>{{this.title}}</template>
-        |  ts(354:716):  static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).template(function(𝚪: import(\\"@glint/environment-ember-template-imports/-private/dsl\\").ResolveContext<MyComponent>, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\\\\n  𝚪; χ;\\\\n}) as unknown }
+        |  ts(364:653):  static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\\\\n  𝚪; χ;\\\\n}) as unknown }
         |
-        | | Mapping: Identifier
-        | |  hbs(139:139):
-        | |  ts(545:556):  MyComponent
-        | |
         | | Mapping: MustacheStatement
         | |  hbs(149:163): {{this.title}}
-        | |  ts(637:690):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}))
+        | |  ts(574:627):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}))
         | |
         | | | Mapping: PathExpression
         | | |  hbs(151:161): this.title
-        | | |  ts(671:684):  𝚪.this.title
+        | | |  ts(608:621):  𝚪.this.title
         | | |
         | | | | Mapping: Identifier
         | | | |  hbs(151:155): this
-        | | | |  ts(674:678):  this
+        | | | |  ts(611:615):  this
         | | | |
         | | | | Mapping: Identifier
         | | | |  hbs(156:161): title
-        | | | |  ts(679:684):  title
+        | | | |  ts(616:621):  title
         | | | |
         | | |
         | |

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -28,7 +28,7 @@ describe('rewriteModule', () => {
           static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
-        }) as unknown;
+        });
         }"
       `);
     });
@@ -53,7 +53,7 @@ describe('rewriteModule', () => {
           static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
-        }) as unknown;
+        });
         }"
       `);
     });
@@ -77,7 +77,7 @@ describe('rewriteModule', () => {
           static template = ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {
           hbs;
           𝚪; χ;
-        }) as unknown;
+        });
         }"
       `);
     });
@@ -185,7 +185,7 @@ describe('rewriteModule', () => {
         static {
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown}
+        })}
         }"
       `);
     });
@@ -215,7 +215,7 @@ describe('rewriteModule', () => {
         static {
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown}
+        })}
         }
         export default MyComponent;"
       `);
@@ -245,7 +245,7 @@ describe('rewriteModule', () => {
         static {
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown}
+        })}
         }"
       `);
     });
@@ -273,7 +273,7 @@ describe('rewriteModule', () => {
         static {
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown}
+        })}
         }"
       `);
     });
@@ -330,7 +330,7 @@ describe('rewriteModule', () => {
         export default templateOnly();
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(({} as unknown as typeof import('./test').default), function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown;
+        });
         "
       `);
     });
@@ -356,7 +356,7 @@ describe('rewriteModule', () => {
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(({} as unknown as typeof import('./test').default), function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           χ.emitContent(χ.resolveOrReturn(χ.Globals[\\"hello\\"])({}));
           𝚪; χ;
-        }) as unknown;
+        });
         "
       `);
     });
@@ -390,7 +390,7 @@ describe('rewriteModule', () => {
         static {
         ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {
           𝚪; χ;
-        }) as unknown}
+        })}
         }
         declare module '@glint/environment-ember-loose/registry' {
           export default interface Registry {
@@ -464,7 +464,7 @@ describe('rewriteModule', () => {
 
         | Mapping: Template
         |  hbs(22:74):   <template>\\\\n    Hello, {{this.target}}!\\\\n  </template>
-        |  ts(22:312):   static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}));\\\\n  𝚪; χ;\\\\n}) as unknown }
+        |  ts(22:301):   static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}));\\\\n  𝚪; χ;\\\\n}) }
         |
         | | Mapping: MustacheStatement
         | |  hbs(44:59):   {{this.target}}
@@ -575,7 +575,7 @@ describe('rewriteModule', () => {
 
         | Mapping: Template
         |  hbs(139:174): <template>{{this.title}}</template>
-        |  ts(364:653):  static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\\\\n  𝚪; χ;\\\\n}) as unknown }
+        |  ts(364:642):  static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\\\\n  𝚪; χ;\\\\n}) }
         |
         | | Mapping: MustacheStatement
         | |  hbs(149:163): {{this.title}}

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -44,7 +44,7 @@ describe('rewriteTemplate', () => {
       ).toMatchInlineSnapshot(`
         "({} as typeof import(\\"@glint/template\\")).templateForBackingValue(someValue, function(𝚪, χ: typeof import(\\"@glint/template\\")) {
           𝚪; χ;
-        }) as unknown"
+        })"
       `);
     });
 

--- a/packages/transform/__tests__/template-to-typescript.test.ts
+++ b/packages/transform/__tests__/template-to-typescript.test.ts
@@ -31,21 +31,18 @@ describe('rewriteTemplate', () => {
     test('without any specified type parameters or context type', () => {
       expect(templateToTypescript('', { typesModule: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
-        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
-          𝚪; χ;
-        })"
-      `);
+          "({} as typeof import(\\"@glint/template\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
+            𝚪; χ;
+          })"
+        `);
     });
 
-    test('given type parameters and context type', () => {
-      let typeParams = '<T extends string>';
-      let contextType = 'MyComponent<T>';
-
+    test('given a backing value', () => {
       expect(
-        templateToTypescript('', { contextType, typeParams, typesModule: '@glint/template' }).result
-          ?.code
+        templateToTypescript('', { backingValue: 'someValue', typesModule: '@glint/template' })
+          .result?.code
       ).toMatchInlineSnapshot(`
-        "({} as typeof import(\\"@glint/template\\")).template(function<T extends string>(𝚪: import(\\"@glint/template\\").ResolveContext<MyComponent<T>>, χ: typeof import(\\"@glint/template\\")) {
+        "({} as typeof import(\\"@glint/template\\")).templateForBackingValue(someValue, function(𝚪, χ: typeof import(\\"@glint/template\\")) {
           𝚪; χ;
         }) as unknown"
       `);
@@ -56,12 +53,12 @@ describe('rewriteTemplate', () => {
 
       expect(templateToTypescript('', { preamble, typesModule: '@glint/template' }).result?.code)
         .toMatchInlineSnapshot(`
-        "({} as typeof import(\\"@glint/template\\")).template(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
-          console.log(\\"hello!\\");
-          throw new Error();
-          𝚪; χ;
-        })"
-      `);
+          "({} as typeof import(\\"@glint/template\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/template\\")) {
+            console.log(\\"hello!\\");
+            throw new Error();
+            𝚪; χ;
+          })"
+        `);
     });
   });
 

--- a/packages/transform/src/template/inlining/index.ts
+++ b/packages/transform/src/template/inlining/index.ts
@@ -10,49 +10,21 @@ export type CorrelatedSpansResult = {
   partialSpans: Array<PartialCorrelatedSpan>;
 };
 
-export type ContainingTypeInfo = {
-  inClass: boolean;
-  className: string | undefined;
-  contextType: string | undefined;
-  typeParams: string | undefined;
-};
-
 /**
- * Given an AST node for an embedded template, determines the appropriate
- * instance type to be passed to `@glint/template`'s `ResolveContext`, as well
- * as any type parameters that need to be propagated as inputs to the template's
- * root generator function.
- *
- * For example, a template declared within `class MyComponent<T extends string>`
- * would give `MyComponent<T>` as the context type, and `<T extends string>` as
- * the type params, ultimately resulting in a template function like:
- *
- *     template(function*<T extends string>(𝚪: ResolveContext<MyComponent<T>>){
- *       // ...
- *     })
+ * Given an AST node for an embedded template, determines whether it's embedded
+ * within a class in such a way that that class should be treated as its backing
+ * value.
  */
-export function getContainingTypeInfo(ts: TSLib, node: ts.Node): ContainingTypeInfo {
-  let container = findContainingClass(ts, node);
-  let inClass = Boolean(container);
-  let className = container?.name?.text;
-  let contextType = className;
-  let typeParams = undefined;
-
-  if (container?.typeParameters) {
-    let params = container.typeParameters;
-    typeParams = `<${params.map((param) => param.getText()).join(', ')}>`;
-    contextType += `<${params.map((param) => param.name.getText()).join(', ')}>`;
-  }
-
-  return { contextType, typeParams, className, inClass };
-}
-
-function findContainingClass(ts: TSLib, node: ts.Node): ts.ClassLikeDeclaration | null {
+export function isEmbeddedInClass(ts: TSLib, node: ts.Node): boolean {
   let current: ts.Node | null = node;
   do {
+    // TODO: this should likely actually filter on whether the template appears in a
+    // static block or property definition, but just "am I in a class body" is the
+    // current status quo and has been ok so far.
     if (ts.isClassLike(current)) {
-      return current;
+      return true;
     }
   } while ((current = current.parent));
-  return null;
+
+  return false;
 }

--- a/packages/transform/src/template/template-to-typescript.ts
+++ b/packages/transform/src/template/template-to-typescript.ts
@@ -86,9 +86,6 @@ export function templateToTypescript(
       }
 
       if (useJsDoc) {
-        if (backingValue) {
-          emit.text('/** @type {unknown} */ (');
-        }
         emit.text(`(/** @type {typeof import("${typesModule}")} */ ({}))`);
       } else {
         emit.text(`({} as typeof import("${typesModule}"))`);
@@ -118,17 +115,6 @@ export function templateToTypescript(
 
       emit.dedent();
       emit.text('})');
-
-      // If we have an explicit backing value, we intentionally cast the template
-      // to `unknown` because we don't care about inference and want to avoid leaking
-      // internal type details.
-      if (backingValue) {
-        if (useJsDoc) {
-          emit.text(')');
-        } else {
-          emit.text(` as unknown`);
-        }
-      }
 
       if (meta?.append) {
         emit.text(meta.append);

--- a/packages/transform/src/template/template-to-typescript.ts
+++ b/packages/transform/src/template/template-to-typescript.ts
@@ -15,8 +15,7 @@ export type TemplateToTypescriptOptions = {
   typesModule: string;
   meta?: GlintEmitMetadata | undefined;
   globals?: Array<string> | undefined;
-  contextType?: string;
-  typeParams?: string;
+  backingValue?: string;
   preamble?: Array<string>;
   useJsDoc?: boolean;
 };
@@ -32,8 +31,7 @@ export function templateToTypescript(
     typesModule,
     globals,
     meta,
-    typeParams = '',
-    contextType,
+    backingValue,
     preamble = [],
     useJsDoc = false,
   }: TemplateToTypescriptOptions
@@ -88,32 +86,21 @@ export function templateToTypescript(
       }
 
       if (useJsDoc) {
-        if (contextType) {
+        if (backingValue) {
           emit.text('/** @type {unknown} */ (');
         }
-        emit.text(`(/** @type {typeof import("${typesModule}")} */ ({})).template(function(`);
+        emit.text(`(/** @type {typeof import("${typesModule}")} */ ({}))`);
       } else {
-        emit.text(`({} as typeof import("${typesModule}")).template(function`);
-        emit.synthetic(typeParams);
-      }
-      if (!useJsDoc) {
-        emit.text('(𝚪');
+        emit.text(`({} as typeof import("${typesModule}"))`);
       }
 
-      if (contextType) {
-        if (useJsDoc) {
-          emit.text(`/** @type {import("${typesModule}").ResolveContext<`);
-          emit.synthetic(contextType);
-          emit.text('>} */ ');
-        } else {
-          emit.text(`: import("${typesModule}").ResolveContext<`);
-          emit.synthetic(contextType);
-          emit.text('>');
-        }
+      if (backingValue) {
+        emit.text(`.templateForBackingValue(${backingValue}, function(𝚪`);
+      } else {
+        emit.text(`.templateExpression(function(𝚪`);
       }
 
       if (useJsDoc) {
-        emit.text('𝚪');
         emit.text(`, /** @type {typeof import("${typesModule}")} */ χ) {`);
       } else {
         emit.text(`, χ: typeof import("${typesModule}")) {`);
@@ -132,10 +119,10 @@ export function templateToTypescript(
       emit.dedent();
       emit.text('})');
 
-      // If we have an explicit context type, we intentionally cast the template
+      // If we have an explicit backing value, we intentionally cast the template
       // to `unknown` because we don't care about inference and want to avoid leaking
       // internal type details.
-      if (contextType) {
+      if (backingValue) {
         if (useJsDoc) {
           emit.text(')');
         } else {

--- a/packages/vscode/__tests__/helpers/async.ts
+++ b/packages/vscode/__tests__/helpers/async.ts
@@ -4,7 +4,7 @@ export function sleep(ms: number): Promise<void> {
 
 export async function waitUntil(callback: () => unknown): Promise<void> {
   let start = Date.now();
-  while (Date.now() - start < 5_000) {
+  while (Date.now() - start < 15_000) {
     if (await callback()) {
       return;
     }

--- a/test-packages/ts-glimmerx-app/src/App.ts
+++ b/test-packages/ts-glimmerx-app/src/App.ts
@@ -6,6 +6,7 @@ import GreetingHeader from './GreetingHeader';
 
 export default class App extends Component {
   private logo = logo;
+  private letters = ['a', 'b', 'c'];
 
   public static template = hbs`
     <div id="intro">
@@ -17,6 +18,11 @@ export default class App extends Component {
         you can get started by editing <code>src/App.js</code>,
         and run tests by visiting <a href="./tests">/tests</a>
       </SubHeader>
+
+      Some letters:
+      <List @items={{this.letters}} as |item|>
+        {{item}}
+      </List>
     </div>
   `;
 }
@@ -28,3 +34,22 @@ interface SubHeaderSignature {
 const SubHeader: TC<SubHeaderSignature> = hbs`
   <h3>{{yield}}</h3>
 `;
+
+interface ListSignature<T> {
+  Args: {
+    items: Array<T>;
+  };
+  Blocks: {
+    default: [item: T];
+  };
+}
+
+class List<T> extends Component<ListSignature<T>> {
+  public static template = hbs`
+    <ol>
+      {{#each @items as |item|}}
+        <li>{{yield item}}</li>
+      {{/each}}
+    </ol>
+  `;
+}

--- a/test-packages/ts-template-imports-app/src/Playground.gts
+++ b/test-packages/ts-template-imports-app/src/Playground.gts
@@ -1,12 +1,38 @@
+import Component from '@glimmer/component';
 import { TOC } from '@ember/component/template-only';
 
 const lib = {
   MaybeComponent: undefined as TOC<{ Args: { arg: string } }> | undefined
 };
 
+interface ListSignature<T> {
+  Args: {
+    items: Array<T>;
+  };
+  Blocks: {
+    default: [item: T];
+  };
+}
+
+class List<T> extends Component<ListSignature<T>> {
+  <template>
+    <ol>
+      {{#each @items as |item|}}
+        <li>{{yield item}}</li>
+      {{/each}}
+    </ol>
+  </template>
+}
+
+const NUMS = [1, 2, 3];
+
 <template>
   <lib.MaybeComponent @arg="hi" />
 
   {{! @glint-expect-error: missing arg }}
   <lib.MaybeComponent />
+
+  <List @items={{NUMS}} as |item|>
+    #{{item}}
+  </List>
 </template>


### PR DESCRIPTION
## Background

Historically we've used a single `template()` function to act as the wrapper around our translated template bodies, deciding based on context whether to explicitly apply a type annotation to its `𝚪` context parameter or allow its type to be inferred.

This has generally worked for us, but it's resulted in:
 - some additional complexity during transformation to propagate type parameters and their constraints from the backing class down to the function body representing the template
 - needing to maintain a `ResolveContext` type for internal (i.e. template backing context) resolution that works completely differently from how external (i.e. invocation signature) resolution works via `resolve()`
 - special casing templates with a backing class to always emit `as unknown` (or the JSDoc equivalent) to avoid leaking complex internal type details in declarations
 - a hard requirement for users that any class associated with a template have a name
 - issues like #389.

## This Change

This change breaks `template()` into two separate functions: `templateExpression()` and `templateForBackingValue()`. The former represents the use of a tagged string or `<template>` in an general expression position, while the latter represents their use embedded in a class body (or when tied to a default export from a companion `.hbs` file).

By making this distinction, we can address each of the bullets mentioned above, since we can specialize the signature for each version of `template()` for the scenarios they matter in instead of needing to accommodate both together.

## Before and After

Concretely, given a file like this:

```tsx
const Greeting: TOC<GreetingSig> = <template>Hello</template>;

class MyComponent<T extends string> extends Component {
  <template>
    <Greeting />, World!
  </template>
}
```

Previously we would have transformed it into the equivalent of:
```ts
const Greeting: TOC<GreetingSig> = template(function(𝚪) {
  // type of 𝚪 is inferred from `TOC<GreetingSig>` in context
});

class MyComponent<T extends string> extends Component {
  static {
    template(function<T extends string>(𝚪: ResolveContext<MyComponent<T>>) {
      // type of 𝚪 is explicit based on the `ResolveContext` utility type applied
      // to the instance type of the wrapping class
    });
  }
}
```

With this change, we instead emit the equivalent of:
```ts
const Greeting: TOC<GreetingSig> = templateExpression(function(𝚪) {
  // type of 𝚪 is inferred from `TOC<GreetingSig>` in context, as above
});

class MyComponent<T extends string> extends Component {
  static {
    templateForBackingValue(this, function(𝚪) {
      // type of 𝚪 is inferred based on `this` being passed as the first arg
    });
  }
}
```

Note the code in the examples above intentionally omits things like signature definitions that aren't relevant to the specific points under discussion.