### PR TITLE
Avoid trying to load a local TypeScript instance from the LSP

### DIFF
--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -54,7 +54,7 @@ describe('Language Server: Diagnostics', () => {
               "line": 7,
             },
           },
-          "severity": 2,
+          "severity": 4,
           "source": "glint:ts(6133)",
           "tags": [
             1,
@@ -255,7 +255,7 @@ describe('Language Server: Diagnostics', () => {
               "line": 8,
             },
           },
-          "severity": 2,
+          "severity": 4,
           "source": "glint:ts(6133)",
           "tags": [
             1,
@@ -326,7 +326,7 @@ describe('Language Server: Diagnostics', () => {
               "line": 7,
             },
           },
-          "severity": 2,
+          "severity": 4,
           "source": "glint:ts(6133)",
           "tags": [
             1,

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -143,7 +143,7 @@ export default class GlintLanguageServer {
         if (!file || file.fileName !== filePath) return [];
 
         return {
-          severity: severityForDiagnostic(diagnostic),
+          severity: severityForDiagnostic(this.ts, diagnostic),
           message: this.ts.flattenDiagnosticMessageText(messageText, '\n'),
           source: `glint${diagnostic.code ? `:ts(${diagnostic.code})` : ''}`,
           tags: tagsForDiagnostic(diagnostic),
@@ -161,7 +161,7 @@ export default class GlintLanguageServer {
       .map(({ name, kind, fileName, textSpan }) => {
         let location = this.textSpanToLocation(fileName, textSpan);
         if (location) {
-          return { name, location, kind: scriptElementKindToSymbolKind(kind) };
+          return { name, location, kind: scriptElementKindToSymbolKind(this.ts, kind) };
         }
       })
       .filter((info): info is SymbolInformation => Boolean(info));
@@ -179,7 +179,7 @@ export default class GlintLanguageServer {
 
     return completions?.entries.map((completionEntry) => ({
       label: completionEntry.name,
-      kind: scriptElementKindToCompletionItemKind(completionEntry.kind),
+      kind: scriptElementKindToCompletionItemKind(this.ts, completionEntry.kind),
       data: { uri, transformedFileName, transformedOffset, source: completionEntry.source },
     }));
   }

--- a/packages/core/src/language-server/util/protocol.ts
+++ b/packages/core/src/language-server/util/protocol.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import type ts from 'typescript';
 import {
   CompletionItemKind,
   DiagnosticSeverity,
@@ -6,12 +6,15 @@ import {
   SymbolKind,
 } from 'vscode-languageserver';
 
+type TS = typeof ts;
+
 /*
  * This module contains utilities for converting between conventions used
  * by the Language Server Protocol and TypeScript's language services interface.
  */
 
 export function scriptElementKindToCompletionItemKind(
+  ts: TS,
   kind: ts.ScriptElementKind
 ): CompletionItemKind {
   switch (kind) {
@@ -55,7 +58,7 @@ export function scriptElementKindToCompletionItemKind(
   }
 }
 
-export function scriptElementKindToSymbolKind(kind: ts.ScriptElementKind): SymbolKind {
+export function scriptElementKindToSymbolKind(ts: TS, kind: ts.ScriptElementKind): SymbolKind {
   switch (kind) {
     case ts.ScriptElementKind.memberVariableElement:
     case ts.ScriptElementKind.indexSignatureElement:
@@ -104,7 +107,7 @@ export function tagsForDiagnostic(diagnostic: ts.Diagnostic): DiagnosticTag[] {
   return tags;
 }
 
-export function severityForDiagnostic(diagnostic: ts.Diagnostic): DiagnosticSeverity {
+export function severityForDiagnostic(ts: TS, diagnostic: ts.Diagnostic): DiagnosticSeverity {
   if (diagnostic.reportsUnnecessary) {
     return DiagnosticSeverity.Warning;
   }

--- a/packages/core/src/language-server/util/protocol.ts
+++ b/packages/core/src/language-server/util/protocol.ts
@@ -108,10 +108,6 @@ export function tagsForDiagnostic(diagnostic: ts.Diagnostic): DiagnosticTag[] {
 }
 
 export function severityForDiagnostic(ts: TS, diagnostic: ts.Diagnostic): DiagnosticSeverity {
-  if (diagnostic.reportsUnnecessary) {
-    return DiagnosticSeverity.Warning;
-  }
-
   switch (diagnostic.category) {
     case ts.DiagnosticCategory.Error:
       return DiagnosticSeverity.Error;


### PR DESCRIPTION
This fixes #379, as well as fixing a longstanding issue where we (inexplicably) rewrite "unused symbol" diagnostics to be warnings instead of passing them through with the severity dictated by TS itself.