### PR TITLE
Start publishing `@glint/environment-glimmerx` again

### DIFF
--- a/packages/environment-glimmerx/README.md
+++ b/packages/environment-glimmerx/README.md
@@ -1,3 +1,5 @@
 # `@glint/environment-glimmerx`
 
-This package contains the information necessary for glint to typecheck a [glimmer-experimental] project.
+This package contains the information necessary for glint to typecheck a [glimmer-experimental](https://github.com/glimmerjs/glimmer-experimental) project.
+
+See [the Glint documentation](https://typed-ember.gitbook.io/glint/using-glint/glimmerx/installation) for more detailed instructions on working with GlimmerX projects in Glint.

--- a/packages/environment-glimmerx/package.json
+++ b/packages/environment-glimmerx/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@glint/environment-glimmerx",
   "version": "0.9.1",
-  "private": true,
   "repository": "typed-ember/glint",
   "description": "A Glint environment to support GlimmerX projects",
   "license": "MIT",


### PR DESCRIPTION
In #308 we marked the `@glint/environment-glimmerx` package private to avoid publishing new versions until GlimmerX itself was in a state to support native integration. Now that the upstream changes have landed and we've made corresponding adjustments here in #384, we can start publishing that package again.