### PR TITLE
Explicitly document our expected peer versions

### DIFF
--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -38,6 +38,19 @@ To minimize spurious errors when typechecking with vanilla `tsc` or your editor'
 
 {% endhint %}
 
+## Version Requirements
+
+Because Glint uses your project-local copy of TypeScript and the packages whose types it augments for use in templates, it requires certain minimum versions of those packages for compatibility.
+
+| Package                   | Minimum Version |
+| ------------------------- | --------------- |
+| `typescript`              | 4.7.0           |
+| `@types/ember__component` | 4.0.8           |
+| `@glimmer/component`      | 1.1.2           |
+| `ember-modifier`          | 3.2.7           |
+
+It's possible to use the 4.x versions of the `@types/ember*` packages even if your project is still using an Ember 3.x LTS. Just note that any deprecated APIs you're using that were removed in 4.0 won't be available in the types, and APIs added later _will_ be present in them.
+
 ## Functions as Helpers
 
 By default, `@glint/environment-ember-loose` includes support for the [default helper manager RFC](https://github.com/emberjs/rfcs/pull/756).

--- a/docs/glimmerx/installation.md
+++ b/docs/glimmerx/installation.md
@@ -37,3 +37,12 @@ Note that, by default, Glint will assume you want it to analyze all templates in
 To minimize spurious errors when typechecking with vanilla `tsc` or your editor's TypeScript integration, you should add `import '@glint/environment-glimmerx';` somewhere in your project's source or type declarations. You may also choose to disable TypeScript's "unused symbol" warnings in your editor, since `tsserver` won't understand that templates actually are using them.
 
 {% endhint %}
+
+## Version Requirements
+
+Because Glint uses your project-local copy of TypeScript and the packages whose types it augments for use in templates, it requires certain minimum versions of those packages for compatibility.
+
+| Package       | Minimum Version |
+| ------------- | --------------- |
+| `typescript`  | 4.7.0           |
+| `@glimmerx/*` | 0.6.7           |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,9 @@
     "build": "tsc --build",
     "prepack": "yarn build"
   },
+  "peerDependencies": {
+    "typescript": "^4.7.0"
+  },
   "dependencies": {
     "@glint/config": "^0.9.2",
     "@glint/transform": "^0.9.2",

--- a/packages/environment-glimmerx/package.json
+++ b/packages/environment-glimmerx/package.json
@@ -28,6 +28,11 @@
     "@glint/config": "^0.9.2",
     "@glint/template": "^0.9.2"
   },
+  "peerDependencies": {
+    "@glimmerx/component": "^0.6.7",
+    "@glimmerx/modifier": "^0.6.7",
+    "@glimmerx/helper": "^0.6.7"
+  },
   "devDependencies": {
     "@glimmerx/component": "^0.6.7",
     "@glimmerx/modifier": "^0.6.7",


### PR DESCRIPTION
We generally say "make sure you're on the latest version of X" in Discord and elsewhere when folks ask, and for some of those things we have `peerDependencies` declared, but we're missing some peerDeps and we never explicitly say in the documentation anywhere what our minimum supported versions are.