### PR TITLE
feat: Expose Globals registry to glimmerx

### DIFF
--- a/packages/environment-glimmerx/-private/dsl/globals.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/globals.d.ts
@@ -1,4 +1,5 @@
 import * as VM from '@glint/template/-private/keywords';
+import Globals from '../../globals';
 
 interface Keywords {
   component: VM.ComponentKeyword;
@@ -14,9 +15,4 @@ interface Keywords {
   yield: void; // the `yield` keyword is implemented directly in @glint/transform
 }
 
-export interface Globals extends Keywords {
-  // GlimmerX, by design, doesn't have any global values beyond
-  // glimmer-vm keywords
-}
-
-export declare const Globals: Globals;
+export declare const Globals: Keywords & Globals;

--- a/packages/environment-glimmerx/-private/index.ts
+++ b/packages/environment-glimmerx/-private/index.ts
@@ -2,4 +2,5 @@
 // that vanilla TS will see those as long as authors have
 // `import '@glint/environment-glimmerx'` somewhere in their project.
 
+/// <reference path="../globals/index.d.ts" />
 /// <reference path="./dsl/integration-declarations.d.ts" />

--- a/packages/environment-glimmerx/.gitignore
+++ b/packages/environment-glimmerx/.gitignore
@@ -3,3 +3,4 @@
 tsconfig.tsbuildinfo
 
 !-private/dsl/**/*.d.ts
+!globals/**/*.d.ts

--- a/packages/environment-glimmerx/globals/index.d.ts
+++ b/packages/environment-glimmerx/globals/index.d.ts
@@ -1,0 +1,4 @@
+
+export default interface Globals {
+  // used to hang any macros off of that are provided by config.additionalGlobals
+}

--- a/test-packages/ts-glimmerx-app/package.json
+++ b/test-packages/ts-glimmerx-app/package.json
@@ -48,6 +48,7 @@
     "prettier": "^2.1.1",
     "qunit": "^2.9.3",
     "qunit-dom": "^1.1.0",
+    "string-replace-loader": "^3.1.0",
     "style-loader": "^1.1.3",
     "testem": "^3.0.3",
     "webpack": "^4.42.1",
@@ -78,7 +79,15 @@
       "!.*"
     ],
     "rules": {
-      "@glimmerx/template-vars": "error"
+      "@glimmerx/template-vars": [
+        2,
+        "all",
+        {
+          "nativeTokens": [
+            "t"
+          ]
+        }
+      ]
     },
     "overrides": [
       {

--- a/test-packages/ts-glimmerx-app/src/App.ts
+++ b/test-packages/ts-glimmerx-app/src/App.ts
@@ -10,6 +10,7 @@ export default class App extends Component {
 
   public static template = hbs`
     <div id="intro">
+      {{t "DOESNT EXIST"}}
       <img src={{this.logo}}/>
 
       <GreetingHeader @target="glint" @greeting={{component TestingComponentHelper name="chris"}}/>

--- a/test-packages/ts-glimmerx-app/tsconfig.json
+++ b/test-packages/ts-glimmerx-app/tsconfig.json
@@ -7,6 +7,10 @@
   },
   "exclude": ["node_modules", "tmp", "dist"],
   "glint": {
-    "environment": "glimmerx"
+    "environment": {
+      "glimmerx": {
+        "additionalGlobals": ["t"]
+      }
+    }
   }
 }

--- a/test-packages/ts-glimmerx-app/types/index.d.ts
+++ b/test-packages/ts-glimmerx-app/types/index.d.ts
@@ -1,1 +1,13 @@
 import '@glint/environment-glimmerx';
+import type { Helper } from '@glimmerx/helper';
+declare module '@glint/environment-glimmerx/globals' {
+  export default interface Globals {
+    t: Helper<{
+      Args: {
+        Positional: string[];
+        Named: Record<string, unknown>;
+      };
+      Return: string;
+    }>;
+  }
+}

--- a/test-packages/ts-glimmerx-app/webpack.config.js
+++ b/test-packages/ts-glimmerx-app/webpack.config.js
@@ -55,6 +55,14 @@ module.exports = () => {
             outputPath: 'images',
           },
         },
+        {
+          test: /App\.(js|ts)$/,
+          loader: 'string-replace-loader',
+          options: {
+            search: '{{t "DOESNT EXIST"}}',
+            replace: '',
+          },
+        },
       ],
     },
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14280,6 +14280,14 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-replace-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-replace-loader/-/string-replace-loader-3.1.0.tgz#11ac6ee76bab80316a86af358ab773193dd57a4f"
+  integrity sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 string-template@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"


### PR DESCRIPTION
While GlimmerX is a module-centric world, applications can still have
macros that are defined by the surrounding build system. This was
partially there with `config.additionalGlobals` but we actually
need to expose a registry that can be merged into so that the
globals aren't `any` types
