### PR TITLE
Document @glint directives, incorporating suggestions

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -22,6 +22,7 @@
   - [Installation](glimmerx/installation.md)
   - [Component Signatures](glimmerx/component-signatures.md)
   - [Template Components](glimmerx/template-components.md)
+- [@glint Directives](directives.md)
 - [Migrating](migrating.md)
 - [Diagnosing Common Error Messages](diagnosing-common-error-messages.md)
 - [Known Limitations](known-limitations.md)

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -22,7 +22,7 @@
   - [Installation](glimmerx/installation.md)
   - [Component Signatures](glimmerx/component-signatures.md)
   - [Template Components](glimmerx/template-components.md)
-- [@glint Directives](directives.md)
+- [`@glint` Directives](directives.md)
 - [Migrating](migrating.md)
 - [Diagnosing Common Error Messages](diagnosing-common-error-messages.md)
 - [Known Limitations](known-limitations.md)

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1,0 +1,55 @@
+# @glint Directives
+
+Glint has several directives that can be used in template comments to control
+Glint's behavior. Additional comment text can follow directives to document
+their purpose.
+
+## @glint-ignore
+
+The `@glint-ignore` directive tells Glint to ignore the line that follows it.
+Glint will not report any errors encountered on the next line.
+
+Example:
+
+```hbs
+<MyComponent @expectedArg="foo" />
+
+{{! @glint-ignore: need to update signature to accept this arg }}
+<MyComponent @unexpectedArg="bar" />
+```
+
+## @glint-expect-error
+
+The `@glint-expect-error` directive operates similarly to `@glint-ignore` in
+that it will not report type errors it encounters, but it will also produce an
+error when an error is _not_ encountered. This is useful for tests where we
+expect an invocation not to type-check (e.g. due to bad arguments) and want to
+be alerted if it does.
+
+Example:
+
+```hbs
+<MyComponent @stringArg="foo" />
+
+{{! @glint-expect-error: let me know if this starts allowing numbers }}
+<MyComponent @stringArg={{123}} />
+```
+
+## @glint-nocheck
+
+The `@glint-noceck` directive will cause glint to not report errors for the
+entire template. The template is still processed by Glint such that
+auto-complete, type look-up, jump to definition, etc. are still functional,
+but any type errors will be ignored.
+
+Example:
+
+```hbs
+{{! @glint-nocheck: this whole teplate needs work }}
+
+<MyComponent @stringArg={{123}} />
+
+<AnotherComponent @badArg="foo" />
+
+{{two-arg-helper "bar"}}
+```

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -1,24 +1,11 @@
-# @glint Directives
+# `@glint` Directives
 
 Glint has several directives that can be used in template comments to control
 Glint's behavior. Additional comment text can follow directives to document
-their purpose.
+their purpose. These directives correspond to the similarly-named directives
+in TypeScript.
 
-## @glint-ignore
-
-The `@glint-ignore` directive tells Glint to ignore the line that follows it.
-Glint will not report any errors encountered on the next line.
-
-Example:
-
-```hbs
-<MyComponent @expectedArg="foo" />
-
-{{! @glint-ignore: need to update signature to accept this arg }}
-<MyComponent @unexpectedArg="bar" />
-```
-
-## @glint-expect-error
+## `@glint-expect-error`
 
 The `@glint-expect-error` directive operates similarly to `@glint-ignore` in
 that it will not report type errors it encounters, but it will also produce an
@@ -35,12 +22,29 @@ Example:
 <MyComponent @stringArg={{123}} />
 ```
 
-## @glint-nocheck
+## `@glint-ignore`
+
+The `@glint-ignore` directive tells Glint to ignore the line that follows it.
+Glint will not report any errors encountered on the next line. In general,
+you should prefer `@glint-expect-error` unless it is not appropriate.
+
+Example:
+
+```hbs
+<MyComponent @expectedArg="foo" />
+
+{{! @glint-ignore: this doesn't typecheck in TS 4.6 due to a bug, but we still test against that version in CI }}
+<MyComponent @unexpectedArg="bar" />
+```
+
+
+## `@glint-nocheck`
 
 The `@glint-noceck` directive will cause glint to not report errors for the
 entire template. The template is still processed by Glint such that
 auto-complete, type look-up, jump to definition, etc. are still functional,
-but any type errors will be ignored.
+but any type errors will be ignored. This can be useful as a step in a
+migration process.
 
 Example:
 

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -16,7 +16,7 @@ be alerted if it does.
 Example:
 
 ```hbs
-<MyComponent @stringArg="foo" />
+<MyComponent @stringArg='foo' />
 
 {{! @glint-expect-error: let me know if this starts allowing numbers }}
 <MyComponent @stringArg={{123}} />
@@ -31,12 +31,11 @@ you should prefer `@glint-expect-error` unless it is not appropriate.
 Example:
 
 ```hbs
-<MyComponent @expectedArg="foo" />
+<MyComponent @expectedArg='foo' />
 
 {{! @glint-ignore: this doesn't typecheck in TS 4.6 due to a bug, but we still test against that version in CI }}
-<MyComponent @unexpectedArg="bar" />
+<MyComponent @unexpectedArg='bar' />
 ```
-
 
 ## `@glint-nocheck`
 
@@ -53,7 +52,7 @@ Example:
 
 <MyComponent @stringArg={{123}} />
 
-<AnotherComponent @badArg="foo" />
+<AnotherComponent @badArg='foo' />
 
-{{two-arg-helper "bar"}}
+{{two-arg-helper 'bar'}}
 ```


### PR DESCRIPTION
I took the liberty of building on the excellent work in #315 by @jamescdavis and applied the PR suggestions from @chriskrycho and @dfreeman. Having these missing from the docs deprives new users of an important adoption tool.