### PR TITLE
bugfix: Actually include globals.d.ts

### DIFF
--- a/packages/environment-glimmerx/package.json
+++ b/packages/environment-glimmerx/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "README.md",
+    "globals/index.d.ts",
     "-private/**/*.{js,d.ts}",
     "environment/**/*.{js,d.ts}",
     "modifier/**/*.{js,d.ts}",


### PR DESCRIPTION
@glint/environment-glimmerx@0.9.3 is broken because we forgot to add
`globals/index.d.ts` to `files` in package.json.
