### PR TITLE
Remove unhelpful `glint-language-server` docs page

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -26,4 +26,3 @@
 - [Migrating](migrating.md)
 - [Diagnosing Common Error Messages](diagnosing-common-error-messages.md)
 - [Known Limitations](known-limitations.md)
-- [Glint Language Server](glint-language-server.md)

--- a/docs/glint-language-server.md
+++ b/docs/glint-language-server.md
@@ -1,5 +1,0 @@
-The `glint-language-server` can be used by editor integrations to use Glint's typechecking features as you type:
-
-![A type error being shown inline for a template file in VS Code](https://user-images.githubusercontent.com/108688/111076679-995c2300-84ed-11eb-934a-3a29f21be89a.png)
-
-The language server enables your editor to provide richer help, such as typechecking, type information on hover, automated refactoring, and more. See [the VS Code extension README](https://github.com/typed-ember/glint/tree/main/packages/vscode) for further examples.


### PR DESCRIPTION
Git history clearly disagrees with me, but I feel like this is the third time I've deleted this page only to discover that it's still there. It's a remnant from when the docs were organized differently, and this remaining scrap of content about the language server isn't particularly useful to anyone.