### PR TITLE
Use Node 16 for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release-it": "echo \"Running release-it via yarn breaks publishing! Use npx or a Volta global installation.\""
   },
   "volta": {
-    "node": "14.19.1",
+    "node": "16.17.1",
     "yarn": "1.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This does not change our CI setup, which continues to use Node 14, and will do so until it leaves LTS. However, since Node 16 was the first version with support for Apple Silicon, this makes ESBuild (and thus our test setup) actually work "out of the box" on M1/M2-based Macs.

The errors provided without this are *utterly* inscrutable, such that I have wasted an hour or two dealing with it over the last months: I forget that it needs to be updated, and VS Code’s error lens does not surface enough information in its default view to make it obvious what the problem is, and when rerunning `yarn` it gets lost in the midst of many other informational messages, and then finally after 20 minutes I remember. This should solve that problem once and for all.