### PR TITLE
chore: ignore Markdown files in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,8 @@ dist/
 /packages/environment*/**/*.js
 /packages/environment*/**/*.d.ts
 !/packages/environment*/-private/dsl/**/*.d.ts
+
+# Markdown files: the formatting Prettier uses by default *does. not. match.*
+# the formatting applied by Gitbook. Having both present is a recipe for ongoing
+# CI problems.
+*.md


### PR DESCRIPTION
The formatting Prettier uses by default *does. not. match.* the formatting applied by GitBook. Having both present is a recipe for ongoing CI problems. (cf. 02e539fa)