### PR TITLE
Capture embedding syntax and actual template content separately

### DIFF
--- a/packages/config/src/environment.ts
+++ b/packages/config/src/environment.ts
@@ -29,6 +29,8 @@ export type GlintEmitMetadata = {
   templateLocation?: {
     start: number;
     end: number;
+    contentStart: number;
+    contentEnd: number;
   };
 };
 

--- a/packages/core/__tests__/cli/build.test.ts
+++ b/packages/core/__tests__/cli/build.test.ts
@@ -531,8 +531,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "../a/src/index.ts:4:17 - error TS0: Parse error on line 1:
-                  {{C} 
-              -------^
+              {{C}
+              ---^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', 'SEP', got 'INVALID'
 
               4 const A = hbs\`{{C}\`;
@@ -552,8 +552,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "src/index.ts:4:17 - error TS0: Parse error on line 1:
-                  {{C} 
-              -------^
+              {{C}
+              ---^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', 'SEP', got 'INVALID'
 
               4 const A = hbs\`{{C}\`;
@@ -723,8 +723,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "../b/src/index.ts:2:21 - error TS0: Parse error on line 1:
-                  {{123} 
-              ---------^
+              {{123}
+              -----^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'INVALID'
 
               2 const usage = hbs\`{{123}\`;
@@ -744,8 +744,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "src/index.ts:2:21 - error TS0: Parse error on line 1:
-                  {{123} 
-              ---------^
+              {{123}
+              -----^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'INVALID'
 
               2 const usage = hbs\`{{123}\`;
@@ -931,8 +931,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "../c/src/index.ts:2:19 - error TS0: Parse error on line 1:
-                  {{123} 
-              ---------^
+              {{123}
+              -----^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'INVALID'
 
               2 const Bad = hbs\`{{123}\`;
@@ -952,8 +952,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "../c/src/index.ts:2:19 - error TS0: Parse error on line 1:
-                  {{123} 
-              ---------^
+              {{123}
+              -----^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'INVALID'
 
               2 const Bad = hbs\`{{123}\`;
@@ -973,8 +973,8 @@ describe('CLI: single-pass build mode typechecking', () => {
             expect(checkResult.stdout).toEqual('');
             expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
               "src/index.ts:2:19 - error TS0: Parse error on line 1:
-                  {{123} 
-              ---------^
+              {{123}
+              -----^
               Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED', 'OPEN_SEXPR', 'CLOSE_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'INVALID'
 
               2 const Bad = hbs\`{{123}\`;

--- a/packages/core/__tests__/utils/project.ts
+++ b/packages/core/__tests__/utils/project.ts
@@ -6,7 +6,6 @@ import GlintLanguageServer from '../../src/language-server/glint-language-server
 import { filePathToUri, normalizeFilePath } from '../../src/language-server/util';
 import DocumentCache from '../../src/common/document-cache';
 import TransformManager from '../../src/common/transform-manager';
-import { parseTsconfig } from '../../src/language-server/pool';
 import { GlintConfigInput } from '@glint/config/lib/config';
 
 const ROOT = normalizeFilePath(path.resolve(__dirname, '../../../../test-packages/ephemeral'));
@@ -50,14 +49,8 @@ export default class Project {
     let glintConfig = new ConfigLoader().configForDirectory(this.rootDir)!;
     let documents = new DocumentCache(glintConfig);
     let transformManager = new TransformManager(glintConfig, documents);
-    let tsConfig = parseTsconfig(glintConfig, transformManager);
 
-    return (this.server = new GlintLanguageServer(
-      glintConfig,
-      documents,
-      transformManager,
-      tsConfig
-    ));
+    return (this.server = new GlintLanguageServer(glintConfig, documents, transformManager));
   }
 
   /**

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -44,9 +44,10 @@ export default class GlintLanguageServer {
   constructor(
     private glintConfig: GlintConfig,
     private documents: DocumentCache,
-    private transformManager: TransformManager,
-    parsedConfig: ts.ParsedCommandLine
+    private transformManager: TransformManager
   ) {
+    let parsedConfig = this.parseTsconfig(glintConfig, transformManager);
+
     this.ts = glintConfig.ts;
     this.openFileNames = new Set();
     this.rootFileNames = new Set(parsedConfig.fileNames);
@@ -418,5 +419,22 @@ export default class GlintLanguageServer {
         yield name;
       }
     }
+  }
+
+  private parseTsconfig(
+    glintConfig: GlintConfig,
+    transformManager: TransformManager
+  ): ts.ParsedCommandLine {
+    let { ts } = glintConfig;
+    let contents = ts.readConfigFile(glintConfig.configPath, ts.sys.readFile).config;
+    let host = { ...ts.sys, readDirectory: transformManager.readDirectory };
+
+    return ts.parseJsonConfigFileContent(
+      contents,
+      host,
+      glintConfig.rootDir,
+      undefined,
+      glintConfig.configPath
+    );
   }
 }

--- a/packages/core/src/language-server/pool.ts
+++ b/packages/core/src/language-server/pool.ts
@@ -1,5 +1,4 @@
 import { ConfigLoader, GlintConfig } from '@glint/config';
-import type ts from 'typescript';
 import {
   Connection,
   MessageType,
@@ -80,9 +79,8 @@ export class LanguageServerPool {
   private launchServer(glintConfig: GlintConfig): ServerDetails {
     let documentCache = new DocumentCache(glintConfig);
     let transformManager = new TransformManager(glintConfig, documentCache);
-    let tsconfig = parseTsconfig(glintConfig, transformManager);
     let rootDir = glintConfig.rootDir;
-    let server = new GlintLanguageServer(glintConfig, documentCache, transformManager, tsconfig);
+    let server = new GlintLanguageServer(glintConfig, documentCache, transformManager);
     let scheduleDiagnostics = this.buildDiagnosticScheduler(server, glintConfig);
 
     return { server, rootDir, scheduleDiagnostics };
@@ -128,23 +126,6 @@ export class LanguageServerPool {
   private sendMessage(type: MessageType, message: string): void {
     this.connection.sendNotification(ShowMessageNotification.type, { message, type });
   }
-}
-
-export function parseTsconfig(
-  glintConfig: GlintConfig,
-  transformManager: TransformManager
-): ts.ParsedCommandLine {
-  let { ts } = glintConfig;
-  let contents = ts.readConfigFile(glintConfig.configPath, ts.sys.readFile).config;
-  let host = { ...ts.sys, readDirectory: transformManager.readDirectory };
-
-  return ts.parseJsonConfigFileContent(
-    contents,
-    host,
-    glintConfig.rootDir,
-    undefined,
-    glintConfig.configPath
-  );
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/environment-ember-template-imports/__tests__/transformation.test.ts
+++ b/packages/environment-ember-template-imports/__tests__/transformation.test.ts
@@ -103,6 +103,11 @@ describe('Environment: ETI', () => {
       let { meta, sourceFile } = applyTransform(source);
       let templateNode = (sourceFile.statements[1] as ts.ExpressionStatement).expression;
 
+      let start = source.indexOf('<template>');
+      let contentStart = start + '<template>'.length;
+      let contentEnd = source.indexOf('</template>');
+      let end = contentEnd + '</template>'.length;
+
       expect(meta).toEqual(
         new Map([
           [
@@ -110,8 +115,10 @@ describe('Environment: ETI', () => {
             {
               prepend: 'export default ',
               templateLocation: {
-                start: source.indexOf('<template>'),
-                end: source.indexOf('</template>') + '</template>'.length,
+                start,
+                contentStart,
+                contentEnd,
+                end,
               },
             },
           ],
@@ -140,6 +147,16 @@ describe('Environment: ETI', () => {
         ).body.statements[0] as ts.ExpressionStatement
       ).expression;
 
+      let firstStart = source.indexOf('<template>');
+      let firstContentStart = firstStart + '<template>'.length;
+      let firstContentEnd = source.indexOf('</template>');
+      let firstEnd = firstContentEnd + '</template>'.length;
+
+      let secondStart = source.indexOf('<template>', classStart);
+      let secondContentStart = secondStart + '<template>'.length;
+      let secondContentEnd = source.indexOf('</template>', classStart);
+      let secondEnd = secondContentEnd + '</template>'.length;
+
       expect(meta).toEqual(
         new Map<ts.Node, GlintEmitMetadata>([
           [
@@ -147,8 +164,10 @@ describe('Environment: ETI', () => {
             {
               prepend: 'export default ',
               templateLocation: {
-                start: source.indexOf('<template>'),
-                end: source.indexOf('</template>') + '</template>'.length,
+                start: firstStart,
+                contentStart: firstContentStart,
+                contentEnd: firstContentEnd,
+                end: firstEnd,
               },
             },
           ],
@@ -158,8 +177,10 @@ describe('Environment: ETI', () => {
               prepend: 'static { ',
               append: ' }',
               templateLocation: {
-                start: source.indexOf('<template>', classStart),
-                end: source.indexOf('</template>', classStart) + '</template>'.length,
+                start: secondStart,
+                contentStart: secondContentStart,
+                contentEnd: secondContentEnd,
+                end: secondEnd,
               },
             },
           ],

--- a/packages/transform/__tests__/debug.test.ts
+++ b/packages/transform/__tests__/debug.test.ts
@@ -36,126 +36,131 @@ describe('Debug utilities', () => {
       expect(transformedModule?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
         |  ts(131:697):  ({} as typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")) {\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: BlockStatement
+        | | Mapping: Template
         | |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
-        | |  ts(310:685):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
+        | |  ts(310:686):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
         | |
-        | | | Mapping: PathExpression
-        | | |  hbs(3:7):     each
-        | | |  ts(355:372):  χ.Globals[\\"each\\"]
-        | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(3:7):     each
-        | | | |  ts(366:370):  each
-        | | | |
-        | | |
-        | | | Mapping: SubExpression
-        | | |  hbs(8:43):    (array \\"world\\" \\"planet\\" \\"universe\\")
-        | | |  ts(378:409):  [\\"world\\", \\"planet\\", \\"universe\\"]
-        | | |
-        | | | | Mapping: StringLiteral
-        | | | |  hbs(15:22):   \\"world\\"
-        | | | |  ts(379:386):  \\"world\\"
-        | | | |
-        | | | | Mapping: StringLiteral
-        | | | |  hbs(23:31):   \\"planet\\"
-        | | | |  ts(388:396):  \\"planet\\"
-        | | | |
-        | | | | Mapping: StringLiteral
-        | | | |  hbs(32:42):   \\"universe\\"
-        | | | |  ts(398:408):  \\"universe\\"
-        | | | |
-        | | |
-        | | | Mapping: Identifier
-        | | |  hbs(48:54):   target
-        | | |  ts(432:438):  target
-        | | |
-        | | | Mapping: Identifier
-        | | |  hbs(55:60):   index
-        | | |  ts(440:445):  index
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(66:67):   #
-        | | |  ts(476:476):
-        | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(67:82):   {{add index 1}}
-        | | |  ts(476:538):  χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
+        | | | Mapping: BlockStatement
+        | | |  hbs(0:123):   {{#each (array \\"world\\" \\"planet\\" \\"universe\\") as |target index|}}\\\\n  #{{add index 1}}: {{this.message}}, {{target}}!\\\\n{{/each}}
+        | | |  ts(310:685):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"each\\"])({}, [\\"world\\", \\"planet\\", \\"universe\\"]));\\\\n    {\\\\n      const [target, index] = 𝛄.blockParams[\\"default\\"];\\\\n      χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1));\\\\n      χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}));\\\\n      χ.emitContent(χ.resolveOrReturn(target)({}));\\\\n    }\\\\n    χ.Globals[\\"each\\"];\\\\n  }
         | | |
         | | | | Mapping: PathExpression
-        | | | |  hbs(69:72):   add
-        | | | |  ts(506:522):  χ.Globals[\\"add\\"]
+        | | | |  hbs(3:7):     each
+        | | | |  ts(355:372):  χ.Globals[\\"each\\"]
         | | | |
         | | | | | Mapping: Identifier
-        | | | | |  hbs(69:72):   add
-        | | | | |  ts(517:520):  add
+        | | | | |  hbs(3:7):     each
+        | | | | |  ts(366:370):  each
         | | | | |
         | | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(73:78):   index
-        | | | |  ts(528:533):  index
+        | | | | Mapping: SubExpression
+        | | | |  hbs(8:43):    (array \\"world\\" \\"planet\\" \\"universe\\")
+        | | | |  ts(378:409):  [\\"world\\", \\"planet\\", \\"universe\\"]
         | | | |
-        | | | | | Mapping: Identifier
+        | | | | | Mapping: StringLiteral
+        | | | | |  hbs(15:22):   \\"world\\"
+        | | | | |  ts(379:386):  \\"world\\"
+        | | | | |
+        | | | | | Mapping: StringLiteral
+        | | | | |  hbs(23:31):   \\"planet\\"
+        | | | | |  ts(388:396):  \\"planet\\"
+        | | | | |
+        | | | | | Mapping: StringLiteral
+        | | | | |  hbs(32:42):   \\"universe\\"
+        | | | | |  ts(398:408):  \\"universe\\"
+        | | | | |
+        | | | |
+        | | | | Mapping: Identifier
+        | | | |  hbs(48:54):   target
+        | | | |  ts(432:438):  target
+        | | | |
+        | | | | Mapping: Identifier
+        | | | |  hbs(55:60):   index
+        | | | |  ts(440:445):  index
+        | | | |
+        | | | | Mapping: TextContent
+        | | | |  hbs(66:67):   #
+        | | | |  ts(476:476):
+        | | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(67:82):   {{add index 1}}
+        | | | |  ts(476:538):  χ.emitContent(χ.resolve(χ.Globals[\\"add\\"])({}, index, 1))
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(69:72):   add
+        | | | | |  ts(506:522):  χ.Globals[\\"add\\"]
+        | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(69:72):   add
+        | | | | | |  ts(517:520):  add
+        | | | | | |
+        | | | | |
+        | | | | | Mapping: PathExpression
         | | | | |  hbs(73:78):   index
         | | | | |  ts(528:533):  index
         | | | | |
-        | | | |
-        | | | | Mapping: NumberLiteral
-        | | | |  hbs(79:80):   1
-        | | | |  ts(535:536):  1
-        | | | |
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(82:83):   :
-        | | |  ts(540:540):
-        | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(84:100):  {{this.message}}
-        | | |  ts(540:599):  χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}))
-        | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(86:98):   this.message
-        | | | |  ts(578:593):  𝚪.this.message
-        | | | |
-        | | | | | Mapping: Identifier
-        | | | | |  hbs(86:90):   this
-        | | | | |  ts(581:585):  this
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(73:78):   index
+        | | | | | |  ts(528:533):  index
+        | | | | | |
         | | | | |
-        | | | | | Mapping: Identifier
-        | | | | |  hbs(91:98):   message
-        | | | | |  ts(586:593):  message
+        | | | | | Mapping: NumberLiteral
+        | | | | |  hbs(79:80):   1
+        | | | | |  ts(535:536):  1
         | | | | |
         | | | |
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(100:101): ,
-        | | |  ts(601:601):
-        | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(102:112): {{target}}
-        | | |  ts(601:651):  χ.emitContent(χ.resolveOrReturn(target)({}))
-        | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(104:110): target
-        | | | |  ts(639:645):  target
+        | | | | Mapping: TextContent
+        | | | |  hbs(82:83):   :
+        | | | |  ts(540:540):
         | | | |
-        | | | | | Mapping: Identifier
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(84:100):  {{this.message}}
+        | | | |  ts(540:599):  χ.emitContent(χ.resolveOrReturn(𝚪.this.message)({}))
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(86:98):   this.message
+        | | | | |  ts(578:593):  𝚪.this.message
+        | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(86:90):   this
+        | | | | | |  ts(581:585):  this
+        | | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(91:98):   message
+        | | | | | |  ts(586:593):  message
+        | | | | | |
+        | | | | |
+        | | | |
+        | | | | Mapping: TextContent
+        | | | |  hbs(100:101): ,
+        | | | |  ts(601:601):
+        | | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(102:112): {{target}}
+        | | | |  ts(601:651):  χ.emitContent(χ.resolveOrReturn(target)({}))
+        | | | |
+        | | | | | Mapping: PathExpression
         | | | | |  hbs(104:110): target
         | | | | |  ts(639:645):  target
         | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(104:110): target
+        | | | | | |  ts(639:645):  target
+        | | | | | |
+        | | | | |
         | | | |
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(112:113): !
-        | | |  ts(653:653):
-        | | |
-        | | | Mapping: Identifier
-        | | |  hbs(117:121): each
-        | | |  ts(674:678):  each
+        | | | | Mapping: TextContent
+        | | | |  hbs(112:113): !
+        | | | |  ts(653:653):
+        | | | |
+        | | | | Mapping: Identifier
+        | | | |  hbs(117:121): each
+        | | | |  ts(674:678):  each
+        | | | |
         | | |
         | |
         |"
@@ -194,124 +199,134 @@ describe('Debug utilities', () => {
       expect(transformedModule?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(151:201): hbs\`\\\\n    <HelperComponent @foo={{this.bar}} />\\\\n  \`
         |  ts(151:440):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: TextContent
-        | |  hbs(151:160): hbs\`
-        | |  ts(331:331):
+        | | Mapping: Template
+        | |  hbs(155:200): <HelperComponent @foo={{this.bar}} />
+        | |  ts(324:429):  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
         | |
-        | | Mapping: ElementNode
-        | |  hbs(160:197): <HelperComponent @foo={{this.bar}} />
-        | |  ts(331:429):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
-        | |
-        | | | Mapping: Identifier
-        | | |  hbs(161:176): HelperComponent
-        | | |  ts(376:391):  HelperComponent
+        | | | Mapping: TextContent
+        | | |  hbs(155:160):
+        | | |  ts(331:331):
         | | |
-        | | | Mapping: AttrNode
-        | | |  hbs(177:194): @foo={{this.bar}}
-        | | |  ts(395:411):  foo: 𝚪.this.bar
+        | | | Mapping: ElementNode
+        | | |  hbs(160:197): <HelperComponent @foo={{this.bar}} />
+        | | |  ts(331:429):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
         | | |
         | | | | Mapping: Identifier
-        | | | |  hbs(178:181): foo
-        | | | |  ts(395:398):  foo
+        | | | |  hbs(161:176): HelperComponent
+        | | | |  ts(376:391):  HelperComponent
         | | | |
-        | | | | Mapping: MustacheStatement
-        | | | |  hbs(182:194): {{this.bar}}
-        | | | |  ts(400:411):  𝚪.this.bar
+        | | | | Mapping: AttrNode
+        | | | |  hbs(177:194): @foo={{this.bar}}
+        | | | |  ts(395:411):  foo: 𝚪.this.bar
         | | | |
-        | | | | | Mapping: PathExpression
-        | | | | |  hbs(184:192): this.bar
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(178:181): foo
+        | | | | |  ts(395:398):  foo
+        | | | | |
+        | | | | | Mapping: MustacheStatement
+        | | | | |  hbs(182:194): {{this.bar}}
         | | | | |  ts(400:411):  𝚪.this.bar
         | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(184:188): this
-        | | | | | |  ts(403:407):  this
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(184:192): this.bar
+        | | | | | |  ts(400:411):  𝚪.this.bar
         | | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(189:192): bar
-        | | | | | |  ts(408:411):  bar
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(184:188): this
+        | | | | | | |  ts(403:407):  this
+        | | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(189:192): bar
+        | | | | | | |  ts(408:411):  bar
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | |
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(197:201): \`
-        | |  ts(429:429):
+        | | | Mapping: TextContent
+        | | |  hbs(197:200):
+        | | |  ts(429:429):
+        | | |
         | |
         |
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(295:419): hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>\\\\n  \`
         |  ts(534:928):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: TextContent
-        | |  hbs(295:304): hbs\`
-        | |  ts(714:714):
+        | | Mapping: Template
+        | |  hbs(299:418): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
+        | |  ts(707:917):  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | |
-        | | Mapping: ElementNode
-        | |  hbs(304:415): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
-        | |  ts(714:917):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
-        | |
-        | | | Mapping: AttrNode
-        | | |  hbs(307:320): ...attributes
-        | | |  ts(753:802):  χ.applySplattributes(𝚪.element, 𝛄.element);
-        | | |
         | | | Mapping: TextContent
-        | | |  hbs(328:334): Hello,
-        | | |  ts(803:803):
+        | | |  hbs(299:304):
+        | | |  ts(714:714):
         | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(335:343): {{@foo}}
-        | | |  ts(803:856):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | | Mapping: ElementNode
+        | | |  hbs(304:415): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
+        | | |  ts(714:917):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(337:341): @foo
-        | | | |  ts(839:850):  𝚪.args.foo
+        | | | | Mapping: AttrNode
+        | | | |  hbs(307:320): ...attributes
+        | | | |  ts(753:802):  χ.applySplattributes(𝚪.element, 𝛄.element);
         | | | |
-        | | | | | Mapping: Identifier
-        | | | | |  hbs(338:341): foo
-        | | | | |  ts(847:850):  foo
+        | | | | Mapping: TextContent
+        | | | |  hbs(328:334): Hello,
+        | | | |  ts(803:803):
+        | | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(335:343): {{@foo}}
+        | | | |  ts(803:856):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(337:341): @foo
+        | | | | |  ts(839:850):  𝚪.args.foo
+        | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(338:341): foo
+        | | | | | |  ts(847:850):  foo
+        | | | | | |
         | | | | |
         | | | |
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(343:344): !
-        | | |  ts(858:858):
-        | | |
-        | | | Mapping: MustacheCommentStatement
-        | | |  hbs(352:391): {{! @glint-expect-error: no @bar arg }}
-        | | |  ts(858:858):
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(392:398):
-        | | |  ts(858:858):
-        | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(398:406): {{@bar}}
-        | | |  ts(858:911):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
-        | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(400:404): @bar
-        | | | |  ts(894:905):  𝚪.args.bar
+        | | | | Mapping: TextContent
+        | | | |  hbs(343:344): !
+        | | | |  ts(858:858):
         | | | |
-        | | | | | Mapping: Identifier
-        | | | | |  hbs(401:404): bar
-        | | | | |  ts(902:905):  bar
+        | | | | Mapping: MustacheCommentStatement
+        | | | |  hbs(352:391): {{! @glint-expect-error: no @bar arg }}
+        | | | |  ts(858:858):
+        | | | |
+        | | | | Mapping: TextContent
+        | | | |  hbs(392:398):
+        | | | |  ts(858:858):
+        | | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(398:406): {{@bar}}
+        | | | |  ts(858:911):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(400:404): @bar
+        | | | | |  ts(894:905):  𝚪.args.bar
+        | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(401:404): bar
+        | | | | | |  ts(902:905):  bar
+        | | | | | |
         | | | | |
         | | | |
+        | | | | Mapping: TextContent
+        | | | |  hbs(406:411):
+        | | | |  ts(913:913):
+        | | | |
         | | |
         | | | Mapping: TextContent
-        | | |  hbs(406:411):
-        | | |  ts(913:913):
+        | | |  hbs(415:418):
+        | | |  ts(917:917):
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(415:419): \`
-        | |  ts(917:917):
         | |
         |"
       `);
@@ -349,124 +364,134 @@ describe('Debug utilities', () => {
       expect(transformedModule?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(156:208): hbs\`\\\\r\\\\n    <HelperComponent @foo={{this.bar}} />\\\\r\\\\n  \`
         |  ts(156:445):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: TextContent
-        | |  hbs(156:166): hbs\`
-        | |  ts(336:336):
+        | | Mapping: Template
+        | |  hbs(160:207): <HelperComponent @foo={{this.bar}} />
+        | |  ts(329:434):  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
         | |
-        | | Mapping: ElementNode
-        | |  hbs(166:203): <HelperComponent @foo={{this.bar}} />
-        | |  ts(336:434):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
-        | |
-        | | | Mapping: Identifier
-        | | |  hbs(167:182): HelperComponent
-        | | |  ts(381:396):  HelperComponent
+        | | | Mapping: TextContent
+        | | |  hbs(160:166):
+        | | |  ts(336:336):
         | | |
-        | | | Mapping: AttrNode
-        | | |  hbs(183:200): @foo={{this.bar}}
-        | | |  ts(400:416):  foo: 𝚪.this.bar
+        | | | Mapping: ElementNode
+        | | |  hbs(166:203): <HelperComponent @foo={{this.bar}} />
+        | | |  ts(336:434):  {\\\\n    const 𝛄 = χ.emitComponent(χ.resolve(HelperComponent)({ foo: 𝚪.this.bar }));\\\\n    𝛄;\\\\n  }
         | | |
         | | | | Mapping: Identifier
-        | | | |  hbs(184:187): foo
-        | | | |  ts(400:403):  foo
+        | | | |  hbs(167:182): HelperComponent
+        | | | |  ts(381:396):  HelperComponent
         | | | |
-        | | | | Mapping: MustacheStatement
-        | | | |  hbs(188:200): {{this.bar}}
-        | | | |  ts(405:416):  𝚪.this.bar
+        | | | | Mapping: AttrNode
+        | | | |  hbs(183:200): @foo={{this.bar}}
+        | | | |  ts(400:416):  foo: 𝚪.this.bar
         | | | |
-        | | | | | Mapping: PathExpression
-        | | | | |  hbs(190:198): this.bar
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(184:187): foo
+        | | | | |  ts(400:403):  foo
+        | | | | |
+        | | | | | Mapping: MustacheStatement
+        | | | | |  hbs(188:200): {{this.bar}}
         | | | | |  ts(405:416):  𝚪.this.bar
         | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(190:194): this
-        | | | | | |  ts(408:412):  this
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(190:198): this.bar
+        | | | | | |  ts(405:416):  𝚪.this.bar
         | | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(195:198): bar
-        | | | | | |  ts(413:416):  bar
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(190:194): this
+        | | | | | | |  ts(408:412):  this
+        | | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(195:198): bar
+        | | | | | | |  ts(413:416):  bar
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | |
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(203:208): \`
-        | |  ts(434:434):
+        | | | Mapping: TextContent
+        | | |  hbs(203:207):
+        | | |  ts(434:434):
+        | | |
         | |
         |
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(306:437): hbs\`\\\\r\\\\n    <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>\\\\r\\\\n  \`
         |  ts(543:937):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: TextContent
-        | |  hbs(306:316): hbs\`
-        | |  ts(723:723):
+        | | Mapping: Template
+        | |  hbs(310:436): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
+        | |  ts(716:926):  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | |
-        | | Mapping: ElementNode
-        | |  hbs(316:432): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
-        | |  ts(723:926):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
-        | |
-        | | | Mapping: AttrNode
-        | | |  hbs(319:332): ...attributes
-        | | |  ts(762:811):  χ.applySplattributes(𝚪.element, 𝛄.element);
-        | | |
         | | | Mapping: TextContent
-        | | |  hbs(340:347): Hello,
-        | | |  ts(812:812):
+        | | |  hbs(310:316):
+        | | |  ts(723:723):
         | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(348:356): {{@foo}}
-        | | |  ts(812:865):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | | Mapping: ElementNode
+        | | |  hbs(316:432): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
+        | | |  ts(723:926):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}));\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}));\\\\n  }
         | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(350:354): @foo
-        | | | |  ts(848:859):  𝚪.args.foo
+        | | | | Mapping: AttrNode
+        | | | |  hbs(319:332): ...attributes
+        | | | |  ts(762:811):  χ.applySplattributes(𝚪.element, 𝛄.element);
         | | | |
-        | | | | | Mapping: Identifier
-        | | | | |  hbs(351:354): foo
-        | | | | |  ts(856:859):  foo
+        | | | | Mapping: TextContent
+        | | | |  hbs(340:347): Hello,
+        | | | |  ts(812:812):
+        | | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(348:356): {{@foo}}
+        | | | |  ts(812:865):  χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)({}))
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(350:354): @foo
+        | | | | |  ts(848:859):  𝚪.args.foo
+        | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(351:354): foo
+        | | | | | |  ts(856:859):  foo
+        | | | | | |
         | | | | |
         | | | |
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(356:359): !
-        | | |  ts(867:867):
-        | | |
-        | | | Mapping: MustacheCommentStatement
-        | | |  hbs(367:406): {{! @glint-expect-error: no @bar arg }}
-        | | |  ts(867:867):
-        | | |
-        | | | Mapping: TextContent
-        | | |  hbs(408:414):
-        | | |  ts(867:867):
-        | | |
-        | | | Mapping: MustacheStatement
-        | | |  hbs(414:422): {{@bar}}
-        | | |  ts(867:920):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
-        | | |
-        | | | | Mapping: PathExpression
-        | | | |  hbs(416:420): @bar
-        | | | |  ts(903:914):  𝚪.args.bar
+        | | | | Mapping: TextContent
+        | | | |  hbs(356:359): !
+        | | | |  ts(867:867):
         | | | |
-        | | | | | Mapping: Identifier
-        | | | | |  hbs(417:420): bar
-        | | | | |  ts(911:914):  bar
+        | | | | Mapping: MustacheCommentStatement
+        | | | |  hbs(367:406): {{! @glint-expect-error: no @bar arg }}
+        | | | |  ts(867:867):
+        | | | |
+        | | | | Mapping: TextContent
+        | | | |  hbs(408:414):
+        | | | |  ts(867:867):
+        | | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(414:422): {{@bar}}
+        | | | |  ts(867:920):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)({}))
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(416:420): @bar
+        | | | | |  ts(903:914):  𝚪.args.bar
+        | | | | |
+        | | | | | | Mapping: Identifier
+        | | | | | |  hbs(417:420): bar
+        | | | | | |  ts(911:914):  bar
+        | | | | | |
         | | | | |
         | | | |
+        | | | | Mapping: TextContent
+        | | | |  hbs(422:428):
+        | | | |  ts(922:922):
+        | | | |
         | | |
         | | | Mapping: TextContent
-        | | |  hbs(422:428):
-        | | |  ts(922:922):
+        | | |  hbs(432:436):
+        | | |  ts(926:926):
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(432:437): \`
-        | |  ts(926:926):
         | |
         |"
       `);

--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -462,35 +462,40 @@ describe('rewriteModule', () => {
       expect(rewritten?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(22:74):   <template>\\\\n    Hello, {{this.target}}!\\\\n  </template>
         |  ts(22:301):   static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}));\\\\n  𝚪; χ;\\\\n}) }
         |
-        | | Mapping: TextContent
-        | |  hbs(37:43):   Hello,
-        | |  ts(232:232):
+        | | Mapping: Template
+        | |  hbs(32:63):   Hello, {{this.target}}!
+        | |  ts(232:288):  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}));
         | |
-        | | Mapping: MustacheStatement
-        | |  hbs(44:59):   {{this.target}}
-        | |  ts(232:286):  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}))
-        | |
-        | | | Mapping: PathExpression
-        | | |  hbs(46:57):   this.target
-        | | |  ts(266:280):  𝚪.this.target
+        | | | Mapping: TextContent
+        | | |  hbs(37:43):   Hello,
+        | | |  ts(232:232):
         | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(46:50):   this
-        | | | |  ts(269:273):  this
+        | | | Mapping: MustacheStatement
+        | | |  hbs(44:59):   {{this.target}}
+        | | |  ts(232:286):  χ.emitContent(χ.resolveOrReturn(𝚪.this.target)({}))
+        | | |
+        | | | | Mapping: PathExpression
+        | | | |  hbs(46:57):   this.target
+        | | | |  ts(266:280):  𝚪.this.target
         | | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(51:57):   target
-        | | | |  ts(274:280):  target
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(46:50):   this
+        | | | | |  ts(269:273):  this
+        | | | | |
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(51:57):   target
+        | | | | |  ts(274:280):  target
+        | | | | |
         | | | |
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(59:60):   !
-        | |  ts(288:288):
+        | | | Mapping: TextContent
+        | | |  hbs(59:60):   !
+        | | |  ts(288:288):
+        | | |
         | |
         |"
       `);
@@ -510,31 +515,36 @@ describe('rewriteModule', () => {
       expect(rewriteModule(ts, { script }, customEnv)?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(0:44):    <template>\\\\n  Hello, {{@target}}!\\\\n</template>
         |  ts(0:272):    export default ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}));\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: TextContent
-        | |  hbs(13:19):   Hello,
-        | |  ts(205:205):
+        | | Mapping: Template
+        | |  hbs(10:33):   Hello, {{@target}}!
+        | |  ts(205:261):  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}));
         | |
-        | | Mapping: MustacheStatement
-        | |  hbs(20:31):   {{@target}}
-        | |  ts(205:259):  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}))
-        | |
-        | | | Mapping: PathExpression
-        | | |  hbs(22:29):   @target
-        | | |  ts(239:253):  𝚪.args.target
+        | | | Mapping: TextContent
+        | | |  hbs(13:19):   Hello,
+        | | |  ts(205:205):
         | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(23:29):   target
-        | | | |  ts(247:253):  target
+        | | | Mapping: MustacheStatement
+        | | |  hbs(20:31):   {{@target}}
+        | | |  ts(205:259):  χ.emitContent(χ.resolveOrReturn(𝚪.args.target)({}))
+        | | |
+        | | | | Mapping: PathExpression
+        | | | |  hbs(22:29):   @target
+        | | | |  ts(239:253):  𝚪.args.target
+        | | | |
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(23:29):   target
+        | | | | |  ts(247:253):  target
+        | | | | |
         | | | |
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(31:32):   !
-        | |  ts(261:261):
+        | | | Mapping: TextContent
+        | | |  hbs(31:32):   !
+        | | |  ts(261:261):
+        | | |
         | |
         |"
       `);
@@ -569,63 +579,57 @@ describe('rewriteModule', () => {
       expect(rewritten?.toDebugString()).toMatchInlineSnapshot(`
         "TransformedModule
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(56:89):   <template>{{@message}}</template>
         |  ts(56:314):   ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}));\\\\n  𝚪; χ;\\\\n})
         |
-        | | Mapping: TextContent
-        | |  hbs(56:66):   <template>
-        | |  ts(246:246):
-        | |
-        | | Mapping: MustacheStatement
+        | | Mapping: Template
         | |  hbs(66:78):   {{@message}}
-        | |  ts(246:301):  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}))
+        | |  ts(246:303):  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}));
         | |
-        | | | Mapping: PathExpression
-        | | |  hbs(68:76):   @message
-        | | |  ts(280:295):  𝚪.args.message
+        | | | Mapping: MustacheStatement
+        | | |  hbs(66:78):   {{@message}}
+        | | |  ts(246:301):  χ.emitContent(χ.resolveOrReturn(𝚪.args.message)({}))
         | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(69:76):   message
-        | | | |  ts(288:295):  message
+        | | | | Mapping: PathExpression
+        | | | |  hbs(68:76):   @message
+        | | | |  ts(280:295):  𝚪.args.message
+        | | | |
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(69:76):   message
+        | | | | |  ts(288:295):  message
+        | | | | |
         | | | |
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(78:89):   </template>
-        | |  ts(303:303):
         | |
         |
 
-        | Mapping: Template
+        | Mapping: TemplateEmbedding
         |  hbs(139:174): <template>{{this.title}}</template>
         |  ts(364:642):  static { ({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {\\\\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\\\\n  𝚪; χ;\\\\n}) }
         |
-        | | Mapping: TextContent
-        | |  hbs(139:149): <template>
-        | |  ts(574:574):
-        | |
-        | | Mapping: MustacheStatement
+        | | Mapping: Template
         | |  hbs(149:163): {{this.title}}
-        | |  ts(574:627):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}))
+        | |  ts(574:629):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));
         | |
-        | | | Mapping: PathExpression
-        | | |  hbs(151:161): this.title
-        | | |  ts(608:621):  𝚪.this.title
+        | | | Mapping: MustacheStatement
+        | | |  hbs(149:163): {{this.title}}
+        | | |  ts(574:627):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}))
         | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(151:155): this
-        | | | |  ts(611:615):  this
+        | | | | Mapping: PathExpression
+        | | | |  hbs(151:161): this.title
+        | | | |  ts(608:621):  𝚪.this.title
         | | | |
-        | | | | Mapping: Identifier
-        | | | |  hbs(156:161): title
-        | | | |  ts(616:621):  title
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(151:155): this
+        | | | | |  ts(611:615):  this
+        | | | | |
+        | | | | | Mapping: Identifier
+        | | | | |  hbs(156:161): title
+        | | | | |  ts(616:621):  title
+        | | | | |
         | | | |
         | | |
-        | |
-        | | Mapping: TextContent
-        | |  hbs(163:174): </template>
-        | |  ts(629:629):
         | |
         |"
       `);

--- a/packages/transform/src/template/inlining/tagged-strings.ts
+++ b/packages/transform/src/template/inlining/tagged-strings.ts
@@ -30,11 +30,7 @@ export function calculateTaggedTemplateSpans(
     );
 
     let { typesModule, globals } = info.tagConfig;
-    let tagName = tag.text;
-    let contents = node.template.rawText ?? node.template.text;
-
-    // Pad the template to account for the tag and surrounding ` characters
-    let template = `${''.padStart(tagName.length)} ${contents} `;
+    let template = node.template.rawText ?? node.template.text;
 
     // environment-specific transforms may emit templateLocation in meta, in
     // which case we use that. Otherwise we use the reported location from the
@@ -47,9 +43,14 @@ export function calculateTaggedTemplateSpans(
       contentEnd: node.template.getEnd() - 1,
     };
 
+    let embeddingSyntax = {
+      prefix: script.contents.slice(templateLocation.start, templateLocation.contentStart),
+      suffix: script.contents.slice(templateLocation.contentEnd, templateLocation.end),
+    };
+
     let preamble = [];
     if (!info.importedBinding.synthetic) {
-      preamble.push(`${tagName};`);
+      preamble.push(`${tag.text};`);
     }
 
     let transformedTemplate = templateToTypescript(template, {
@@ -57,6 +58,7 @@ export function calculateTaggedTemplateSpans(
       meta,
       preamble,
       globals,
+      embeddingSyntax,
       backingValue: isEmbeddedInClass(ts, node) ? 'this' : undefined,
       useJsDoc: environment.isUntypedScript(script.filename),
     });

--- a/packages/transform/src/template/inlining/tagged-strings.ts
+++ b/packages/transform/src/template/inlining/tagged-strings.ts
@@ -43,6 +43,8 @@ export function calculateTaggedTemplateSpans(
     let templateLocation = meta?.templateLocation ?? {
       start: node.getStart(),
       end: node.getEnd(),
+      contentStart: node.template.getStart() + 1,
+      contentEnd: node.template.getEnd() - 1,
     };
 
     let preamble = [];

--- a/packages/transform/src/template/mapping-tree.ts
+++ b/packages/transform/src/template/mapping-tree.ts
@@ -2,7 +2,7 @@ import { AST } from '@glimmer/syntax';
 import { Range } from './transformed-module';
 import { Identifier } from './map-template-contents';
 
-export type MappingSource = AST.Node | TextContent | Identifier | ParseError;
+export type MappingSource = AST.Node | TemplateEmbedding | TextContent | Identifier | ParseError;
 
 /**
  * In cases where we're unable to parse a template, we still want to
@@ -23,6 +23,15 @@ export class ParseError {
  */
 export class TextContent {
   public readonly type = 'TextContent';
+}
+
+/**
+ * This node represents the root of an embedded template, including any
+ * boilerplate like tagged template syntax or `<template>` that designates
+ * the surrounded contents as a template.
+ */
+export class TemplateEmbedding {
+  public readonly type = 'TemplateEmbedding';
 }
 
 /**


### PR DESCRIPTION
## Background

Today when we capture embedded template content, we have a blurry notion of where the syntax that denotes the embedding, like the `hbs` tag and backticks or `<template>` wrapper, actually falls. From a mapping perspective, we treat it as effectively part of the template, and we generate extra whitespace around the template body before parsing it to account for the space that that embedding syntax takes up in the overall source.

This generally works fine, but it means that we never actually keep track of the real original contents of the template, only the whitespace-padded version. That makes it difficult to automate operations like adding `{{! @glint-nocheck }}` that, to be effective, want to understand things like the indentation of a template body.

As we look to the future where `<template>` may accept attributes that we want to map to particular spans in the resulting boilerplate, our haziness around the representation of that area of the mapping becomes even more of a problem.

## This Change

This change introduces a new root-level `MappingTree` node called a `TemplateEmbedding`, and it cleans up the representation of the `Template` (which was previously the typical root) to _only_ capture the actual contents of the template, not its embedding syntax.

Concretely for the template `<template>{{this.title}}</template>`, this means we move from something like this, where a `Template` contains a synthetic `TextContent` mapping to account for padding where `<template>` is:

```
| Mapping: Template
|  hbs(139:174): <template>{{this.title}}</template>
|  ts(364:642):  static { ({} as typeof import("...")).templateForBackingValue(this, function(𝚪, χ) {\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\n  𝚪; χ;\n}) }
|
| | Mapping: TextContent
| |  hbs(139:149): <template>
| |  ts(574:574):
| |
| | Mapping: MustacheStatement
| |  hbs(149:163): {{this.title}}
| |  ts(574:627):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}))
| |
| | | ...
```

To something like this, where the `TemplateEmbedding` mapping includes the embedding syntax in the source text and the template boilerplate in the transformed text, while its `Template` child only contains the verbatim contents of the template:
```
| Mapping: TemplateEmbedding
|  hbs(139:174): <template>{{this.title}}</template>
|  ts(364:642):  static { ({} as typeof import("...")).templateForBackingValue(this, function(𝚪, χ) {\n  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));\n  𝚪; χ;\n}) }
|
| | Mapping: Template
| |  hbs(149:163): {{this.title}}
| |  ts(574:629):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}));
| |
| | | Mapping: MustacheStatement
| | |  hbs(149:163): {{this.title}}
| | |  ts(574:627):  χ.emitContent(χ.resolveOrReturn(𝚪.this.title)({}))
| | |
| | | | ...
```

## Other Notes

I'm tagging this PR `internal`, as even though it _does_ affect our published artifacts, it shouldn't have any visible impact to users. This change is really just about cleaning up some internal ambiguity in our mapping layer to enable future improvements.