### PR TITLE
Honor `incremental: true` in `tsconfig.json`

### DIFF
--- a/packages/core/src/cli/options.ts
+++ b/packages/core/src/cli/options.ts
@@ -3,8 +3,12 @@ import { type CompilerOptions } from 'typescript';
 export function determineOptionsToExtend(argv: {
   declaration?: boolean | undefined;
   incremental?: boolean | undefined;
-}): import('typescript').CompilerOptions {
-  let options: CompilerOptions = { incremental: argv.incremental };
+}): CompilerOptions {
+  let options: CompilerOptions = {};
+
+  if ('incremental' in argv) {
+    options.incremental = argv.incremental;
+  }
 
   if ('declaration' in argv) {
     options.noEmit = !argv.declaration;


### PR DESCRIPTION
If the `incremental` key is present in the options we pass to TypeScript when performing a check, that takes precedence over what's in the project's `tsconfig.json`, even if it's `undefined`.

This ensures we only set that key if the `--incremental` flag was passed, otherwise falling back to whatever's in the project config.