### PR TITLE
Fix `render` inference in TS 4.8+

### DIFF
--- a/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
@@ -101,7 +101,7 @@ import '@ember/test-helpers';
 import 'ember-cli-htmlbars';
 
 type TestTemplate<T> = abstract new () => HasContext<
-  TemplateContext<T, EmptyObject, EmptyObject, null>
+  TemplateContext<T, EmptyObject, EmptyObject, void>
 >;
 
 declare module '@ember/test-helpers' {

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -19,8 +19,8 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "test": "npm-run-all lint test:*",
-    "typecheck": "glint",
+    "test": "npm-run-all test:*",
+    "test:typecheck": "glint",
     "test:tsc": "tsc --noEmit",
     "test:browsers": "ember test"
   },

--- a/test-packages/ts-ember-app/tests/integration/components/render-test.ts
+++ b/test-packages/ts-ember-app/tests/integration/components/render-test.ts
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import type { TestContext } from '@ember/test-helpers';
+
+module('Integration | Component | bar', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('with no type arg', function () {
+    test('is fine with static content', async function (assert) {
+      await render(hbs`Hello!`);
+
+      assert.dom().hasText('Hello!');
+    });
+
+    test('causes a type error when accessing properties on `this`', async function (assert) {
+      await render(hbs`
+        {{! 
+          @glint-ignore
+          In TS <= 4.7, this is incorrectly allowed because TS infers 'never' as the type of 'this'.
+          In TS 4.8+, this correctly produces an error.
+          TODO: Once we only support 4.8+, this should become a @glint-expect-error.
+        }}
+        Hello, {{this.target}}!
+      `);
+
+      assert.dom().hasText('Hello, !');
+    });
+
+    test('causes a type error when accessing @args', async function (assert) {
+      await render(hbs`
+        {{! @glint-expect-error: no args in test templates }}
+        Hello, {{@target}}!
+      `);
+
+      assert.dom().hasText('Hello, !');
+    });
+  });
+
+  module('with a type arg', function (hooks) {
+    interface MyContext extends TestContext {
+      target: string;
+    }
+
+    hooks.beforeEach(function (this: MyContext) {
+      this.target = 'World';
+    });
+
+    test('is fine with static content', async function (assert) {
+      await render<MyContext>(hbs`Hello!`);
+
+      assert.dom().hasText('Hello!');
+    });
+
+    test('is fine accessing existing properties on `this`', async function (assert) {
+      await render<MyContext>(hbs`
+        Hello, {{this.target}}!
+      `);
+
+      assert.dom().hasText('Hello, World!');
+    });
+
+    test('causes a type error when accessing nonexistent properties on `this`', async function (assert) {
+      await render<MyContext>(hbs`
+        {{! @glint-expect-error: foo isn't a defined property }}
+        Hello, {{this.foo}}!
+      `);
+
+      assert.dom().hasText('Hello, !');
+    });
+
+    test('causes a type error when accessing @args', async function (assert) {
+      await render(hbs`
+        {{! @glint-expect-error: no args in test templates }}
+        Hello, {{@target}}!
+      `);
+
+      assert.dom().hasText('Hello, !');
+    });
+  });
+});


### PR DESCRIPTION
## Background

TS improved inference behaviors in a variety of ways in 4.8, one of which caught a discrepancy in our types. In 4.8+, using `render()` without a type parameter causes a super obtuse type error.

## This Change

This change fixes the type inconsistency, and adds an explicit set of tests to capture our expected behavior for various usage in templates in `render` calls, both with and without an explicit `this` type.

Thanks to the inference improvements in 4.8, we no longer infer `never` for the `this` type in test templates when it's unspecified, meaning folks may (correctly) see some new red squiggles under `{{this.foo}}` when they upgrade. Anyone who wants to preserve the existing "don't bother checking what's on `this`" behavior can use `render<any>(...)` to make that explicit.

## Notes

Normally we'd catch changes like this with our weekly test runs against TS nightly, but it turns out that, specifically for the `ts-ember-app` test package, we were only running `tsc` in CI, not `glint`. That's now fixed.

Fixes #406.