### PR TITLE
Fix JS-backed types

### DIFF
--- a/packages/transform/__tests__/rewrite.test.ts
+++ b/packages/transform/__tests__/rewrite.test.ts
@@ -335,6 +335,35 @@ describe('rewriteModule', () => {
       `);
     });
 
+    test('with an opaque default export from JS file', () => {
+      let script = {
+        filename: 'test.js',
+        contents: stripIndent`
+          import templateOnly from '@glimmer/component/template-only';
+
+          export default templateOnly();
+        `,
+      };
+
+      let template = {
+        filename: 'test.hbs',
+        contents: stripIndent``,
+      };
+
+      let transformedModule = rewriteModule(ts, { script, template }, emberLooseEnvironment);
+
+      expect(transformedModule?.errors).toEqual([]);
+      expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
+        "import templateOnly from '@glimmer/component/template-only';
+
+        export default templateOnly();
+        (/** @type {typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")} */ ({})).templateForBackingValue((/** @type {typeof import('./test').default} */ ({})), function(𝚪, /** @type {typeof import(\\"@glint/environment-ember-loose/-private/dsl\\")} */ χ) {
+          𝚪; χ;
+        });
+        "
+      `);
+    });
+
     test('with an unresolvable default export', () => {
       let script = {
         filename: 'test.ts',

--- a/packages/transform/src/template/inlining/companion-file.ts
+++ b/packages/transform/src/template/inlining/companion-file.ts
@@ -49,7 +49,9 @@ export function calculateCompanionTemplateSpans(
     let backingValue: string | undefined;
     if (targetNode) {
       let moduleName = path.basename(script.filename, path.extname(script.filename));
-      backingValue = `({} as unknown as typeof import('./${moduleName}').default)`;
+      backingValue = useJsDoc
+        ? `(/** @type {typeof import('./${moduleName}').default} */ ({}))`
+        : `({} as unknown as typeof import('./${moduleName}').default)`;
     }
 
     let rewriteResult = templateToTypescript(template.contents, {


### PR DESCRIPTION
Previously, there were some cases where `as` could be used in a generated .js file. TS isn't happy about this.