### PR TITLE
Add `{{unique-id}}` to `environment-ember-loose`

### DIFF
--- a/packages/environment-ember-loose/-private/dsl/globals.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/globals.d.ts
@@ -16,6 +16,7 @@ import { OnModifier } from '../intrinsics/on';
 import { OutletKeyword } from '../intrinsics/outlet';
 import { TextareaComponent } from '../intrinsics/textarea';
 import { UnboundKeyword } from '../intrinsics/unbound';
+import { UniqueIdHelper } from '../intrinsics/unique-id';
 
 import Registry from '../../registry';
 
@@ -282,6 +283,16 @@ export interface Globals extends Keywords, Registry {
     [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea
    */
   Textarea: TextareaComponent;
+
+  /**
+  Use the `{{unique-id}}` helper to generate a unique ID string suitable for use as an ID
+  attribute in the DOM.
+ 
+  See [the API documentation] for further details.
+
+  [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/unique-id?anchor=unique-id
+   */
+  'unique-id': UniqueIdHelper;
 }
 
 export declare const Globals: Globals;

--- a/packages/environment-ember-loose/-private/intrinsics/unique-id.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/unique-id.d.ts
@@ -1,0 +1,5 @@
+import { HelperLike } from '@glint/template';
+
+export type UniqueIdHelper = HelperLike<{
+  Return: string;
+}>;

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/unique-id.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/unique-id.test.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from 'expect-type';
+import { Globals, resolve } from '@glint/environment-ember-loose/-private/dsl';
+
+let uniqueId = resolve(Globals['unique-id']);
+
+// Basic plumbing
+expectTypeOf(uniqueId({})).toEqualTypeOf<string>();
+
+// @ts-expect-error: invalid named arg
+uniqueId({ hello: 'hi' });
+
+// @ts-expect-error: invalid positional arg
+uniqueId({}, 'hi');

--- a/test-packages/ts-ember-app/app/components/ember-component.hbs
+++ b/test-packages/ts-ember-app/app/components/ember-component.hbs
@@ -1,4 +1,4 @@
-<div ...attributes>
+<div ...attributes id={{unique-id}}>
   {{this.required}}
   {{this.optional}}
   {{this.hasDefault}}


### PR DESCRIPTION
We'll still need to expose an import for `environment-ember-template-imports` once the actual runtime implementation is landed in Ember itself (and the base type is in DT and the preview types for us to stick a signature on), but for now this makes `{{unique-id}}` available as a global in loose mode.

Fixes #378