### PR TITLE
Improve custom diagnostic messages

### DIFF
--- a/packages/transform/src/diagnostics/augmentation.ts
+++ b/packages/transform/src/diagnostics/augmentation.ts
@@ -58,7 +58,8 @@ function checkAssignabilityError(
     node.type === 'MustacheStatement' &&
     (parentNode.type === 'Template' ||
       parentNode.type === 'BlockStatement' ||
-      parentNode.type === 'ElementNode')
+      parentNode.type === 'ElementNode') &&
+    !(node.path.type === 'PathExpression' && node.path.original === 'yield')
   ) {
     // Otherwise, if it's on a full {{mustache}} and it's in a top-level position,
     // it's a DOM content type issue.


### PR DESCRIPTION
This PR updates some of our custom diagnostic augmentations:
 - taking care of a false-positive detection for no-arg `{{yield}}` (fixes #375)
 - suggesting a missing registry entry for a failed global lookup (fixes #398)
 - clarifying the message when the first arg to `{{component}}` is bad (fixes #373)
 - explicitly calling out that directly invoking a component via the `{{component}}` helper isn't possible with Glint and suggesting a workaround (also captured in #373)