### PR TITLE
Handle out-of-scope files more cleanly in the language server

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@glint/test-utils": "^0.9.7",
-    "@types/node": "^18.7.6",
+    "@types/node": "^18.11.5",
     "@types/resolve": "^1.17.1",
     "@types/uuid": "^8.3.4",
     "@types/yargs": "^17.0.10",

--- a/test-packages/ts-ember-app/app/components/js-component.hbs
+++ b/test-packages/ts-ember-app/app/components/js-component.hbs
@@ -1,0 +1,1 @@
+{{this.message}}

--- a/test-packages/ts-ember-app/app/components/js-component.js
+++ b/test-packages/ts-ember-app/app/components/js-component.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class MyComponent extends Component {
+  message = 'hi';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,10 +2574,10 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.7.6":
-  version "18.7.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
-  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.11.5":
+  version "18.11.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.5.tgz#1bc94cf2f9ab5fe33353bc7c79c797dcc5325bef"
+  integrity sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==
 
 "@types/node@^9.6.0":
   version "9.6.61"


### PR DESCRIPTION
Currently if you open a file we _might_ be able to provide diagnostics for but in fact isn't something the language server is aware of, you can get an error like this:

```
Glint encountered an error computing diagnostics for this file. This is likely a bug in Glint; please file an issue, including any code and/or steps to follow to reproduce the error.

Error: Could not find source file: 'app/components/my-component.js'.
```

This might happen if you open a `.js` file with `allowJs: false`, or a `.gts` file in a project without the template-imports environment. Depending on the order files are opened in, it can also happen if we accidentally synthesize a `.ts` backing file for a `.hbs` one that actually has a `.js` module somewhere.

This change ensures we're a bit more careful in those situations and do a better job determining:
 - whether we should be trying to analyze a file at all
 - whether a `.hbs` file has a backing module other than the default one we would create for it

Fixes #380 