### PR TITLE
Further autocomplete improvements

### DIFF
--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -57,6 +57,26 @@ describe('Language Server: Completions', () => {
     expect(completions).toBeUndefined();
   });
 
+  test('in a template with syntax errors', () => {
+    project.setGlintConfig({ environment: 'ember-loose' });
+
+    let code = stripIndent`
+      Hello, {{this.target.}}!
+    `;
+
+    project.write('index.hbs', code);
+
+    let server = project.startLanguageServer();
+    let completions = server.getCompletions(project.fileURI('index.hbs'), {
+      line: 0,
+      character: 4,
+    });
+
+    // Ensure we don't spew all ~900 completions available at the top level
+    // in module scope in a JS/TS file.
+    expect(completions).toBeUndefined();
+  });
+
   test('passing component args', () => {
     let code = stripIndent`
       import Component, { hbs } from '@glimmerx/component';

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -1,5 +1,4 @@
 import {
-  CompletionTriggerKind,
   Connection,
   FileChangeType,
   ServerCapabilities,
@@ -70,13 +69,11 @@ export function bindLanguageServerPool({ connection, pool, openDocuments }: Bind
     );
   });
 
-  connection.onCompletion(async ({ context, textDocument, position }) => {
-    if (context?.triggerKind !== CompletionTriggerKind.Invoked) {
-      // If this wasn't triggered by an explicit request for completions, pause briefly to allow
-      // any editor change events to be transmitted as well. VS Code explicitly sends the
-      // the autocomplete request BEFORE it sends the document update notification.
-      await new Promise((r) => setTimeout(r, 25));
-    }
+  connection.onCompletion(async ({ textDocument, position }) => {
+    // Pause briefly to allow any editor change events to be transmitted as well.
+    // VS Code explicitly sends the the autocomplete request BEFORE it sends the
+    // document update notification.
+    await new Promise((r) => setTimeout(r, 25));
 
     return pool.withServerForURI(textDocument.uri, ({ server }) =>
       server.getCompletions(textDocument.uri, position)

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -192,6 +192,7 @@ export default class GlintLanguageServer {
       label: completionEntry.name,
       kind: scriptElementKindToCompletionItemKind(this.ts, completionEntry.kind),
       data: { uri, transformedFileName, transformedOffset, source: completionEntry.source },
+      sortText: completionEntry.sortText,
     }));
   }
 

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -178,7 +178,12 @@ export default class GlintLanguageServer {
       transformedOffset
     );
 
-    if (mapping?.sourceNode.type === 'TextContent') {
+    // If we're in a free-text region of a template, or if there's no mapping and yet
+    // we're in a template file, then we have no completions to offer.
+    if (
+      mapping?.sourceNode.type === 'TextContent' ||
+      (!mapping && this.glintConfig.environment.isTemplate(uri))
+    ) {
       return;
     }
 


### PR DESCRIPTION
As with #393, this still doesn't solve our underlying "only syntactically-valid templates can produce completions" problem, but it _does_ resolve the main issue called out in #436.

At a high level, several different related issues were coming together to produce the behavior described in #436:
 - completions triggered as the result of typing a partial identifier are always considered `CompletionTriggerKind.Invoked` (this is per the LSP, not just a weird choice on Code's part)
 - we weren't forwarding TS's sorting information through the LSP, so items didn't necessarily display in order of relevance
 - standalone templates with a syntax error end up mapping to a 0-length span at the top level of the corresponding backing module, meaning that when we tried to produce completions for e.g. `{{foo.}}`, we'd return the full list of hundreds of available globals

Fixing those three errors, completion now looks like this:

<img src="https://user-images.githubusercontent.com/108688/198067920-6f30a90c-3e9a-4261-b02e-4a0eeb4df46a.gif" width=400 alt="Glint providing mostly-reasonable completion for a let-bound local value and one of its properties in a template">

(Note that in a loose-mode template we can't provide completions for `myHashObject`, as we have to assume during emit that e.g. `myH` is referring to some global and not an incomplete reference to a local identifier)