### PR TITLE
Update addon docs with the outcome of #439

### DIFF
--- a/docs/ember/authoring-addons.md
+++ b/docs/ember/authoring-addons.md
@@ -10,20 +10,20 @@ The first step is adding the proper Glint signature types to all the addon's com
 
 If all apps were already using [first class component templates] (i.e. [strict mode] templates), this would be all we need to do. But as this is certainly not the case for the time being, we will need to find a way to expose the required [Template Registry] entries to the consuming app, in an easy but also flexible way.
 
-As described in the [Using Addons] guide, the _easy_ way for users is to import a file from the addon containing all the registry entries. This is for the most common case in which the app is consuming the addon provided components, helpers and modifiers as they are. The convention here is for the addon - when published on npm - to provide a `glint.d.ts` file, that the app will import as `import 'awesome-addon/glint'`. For a (v1) addon using [`ember-cli-typescript`][ect] this would be a `/addon/glint.ts` file, which needs to contain all the registry entries for all the public components (helpers, modifiers) the addon exposes to the app (in the addon's `/app` tree):
+As described in the [Using Addons] guide, the _easy_ way for users is to import an interface from the addon containing all the registry entries. This is for the most common case in which the app is consuming the addon provided components, helpers and modifiers as they are. The convention here is for the addon - when published on npm - to provide a `template-registry.d.ts` file, that the app will import as `import AwesomeAddonRegistry from 'awesome-addon/template-registry'` and then use to extend its own global registry.
 
-{% code title="/addon/glint.ts" %}
+For a (v1) addon using [`ember-cli-typescript`][ect] this would be a `/addon/template-registry.ts` file, which needs to contain registry entries for all the public components (helpers, modifiers) the addon exposes to the app (in the addon's `/app` tree):
+
+{% code title="/addon/template-registry.ts" %}
 
 ```typescript
 import type AwesomeButton from 'awesome-addon/components/awesome-button';
 import type AwesomeModal from 'awesome-addon/components/awesome-modal';
 
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    AwesomeButton: typeof AwesomeButton;
-    AwesomeModal: typeof AwesomeModal;
-    // ...
-  }
+export default interface AwesomeAddonRegistry {
+  AwesomeButton: typeof AwesomeButton;
+  AwesomeModal: typeof AwesomeModal;
+  // ...
 }
 ```
 
@@ -33,13 +33,13 @@ While this easy way, which only requires the app to import this single file, is 
 
 This is given by letting the app manage the registry entries on its own, thereby being able to pick what to import from the addon directly and what to replace with its own custom types.
 
-Note: in apps, we generally define the registry entries right in the actual file itself so that it is nicely co-located with the signature and implementation. If an app imported such a module from an addon, though, TypeScript would see the registry declaration there and apply it, which is exactly what we want to prevent. For addons it is therefore recommended that all the registry entries are only added to the `/addon/glint.ts` file as described above, and _not_ to the file containing the actual class!
+Note: in apps, we generally define the registry entries right in the actual file itself so that it is nicely co-located with the signature and implementation. If an app imported such a module from an addon, though, TypeScript would see the registry declaration there and apply it, which is exactly what we want to prevent. For addons it is therefore recommended that all the registry entries are exposed as an importable type in `/addon/template-registry.ts` as described above, and _not_ to the file containing the actual class!
 
 A real world example of this setup can be seen in [`ember-responsive-image`][eri]
 
 ## Adding Glint types to addons not written in TypeScript
 
-Even if an addon author has choosen not to adopt TypeScript, the addon can still ship Glint types! The setup, however, will be slightly different. First, without [`ember-cli-typescript`][ect], types in `/addon/glint.ts` won't be emitted to `/glint.d.ts` on publish, so you'll need to do what you would have done in `/addon/glint.ts` in `/glint.d.ts` instead. Also, since the components, helpers, and modifiers are not written in TypeScript, we can't add type signatures to them directly. Instead we'll need to create declaration files for them. And these files will need to use the importable path directly from the root of the addon (not under `/addon/`). Here's an example:
+Even if an addon author has choosen not to adopt TypeScript, the addon can still ship Glint types! The setup, however, will be slightly different. First, without [`ember-cli-typescript`][ect], types in `/addon/template-registry.ts` won't be emitted to `/template-registry.d.ts` on publish, so you'll need to do what you would have done in `/addon/template-registry.ts` in `/template-registry.d.ts` instead. Also, since the components, helpers, and modifiers are not written in TypeScript, we can't add type signatures to them directly. Instead we'll need to create declaration files for them. And these files will need to use the importable path directly from the root of the addon (not under `/addon/`). Here's an example:
 
 {% code title="/components/awesome-button.d.ts" %}
 
@@ -75,24 +75,22 @@ export default class AwesomeSauce extends Helper<AwesomeSauceSignature> {}
 
 {% endcode %}
 
-{% code title="/glint.d.ts" %}
+{% code title="/template-registry.d.ts" %}
 
 ```typescript
 import type AwesomeButton from './components/awesome-button';
 import type AwesomeSauce from './helpers/awesome-sauce';
 
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry {
-    AwesomeButton: typeof AwesomeButton;
-    'awesome-sauce': typeof AwesomeSauce;
-    // ...
-  }
+export default interface AwesomeAddonRegistry {
+  AwesomeButton: typeof AwesomeButton;
+  'awesome-sauce': typeof AwesomeSauce;
+  // ...
 }
 ```
 
 {% endcode %}
 
-By defining the component, helper, and modifier types in separate importable files (rather than just directly in `glint.d.ts`), consumers can import them individually and manually add to the registry if they so choose.
+By defining the component, helper, and modifier types in separate importable files (rather than just directly in `template-registry.d.ts`), consumers using [first class component templates] can import them from the correct paths.
 
 ## Stability Note
 


### PR DESCRIPTION
Based on the discussion in #439, we want to advise addon authors to export a registry type from `<addon-name>/template-registry` rather than relying on declaration merging in `<addon-name>/glint`. This updates the documentation originally written by @simonihmig accordingly.

Closes #446 