### PR TITLE
Add support for equality operators (Ember RFC 560)

### DIFF
--- a/packages/core/__tests__/transform/template-to-typescript.test.ts
+++ b/packages/core/__tests__/transform/template-to-typescript.test.ts
@@ -585,6 +585,32 @@ describe('Transform: rewriteTemplate', () => {
         `);
       });
     });
+
+    describe('{{eq}}', () => {
+      test('emits ===', () => {
+        let template = stripIndent`
+          {{log (testEq 1 2)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testEq'], specialForms: { testEq: '===' } }))
+          .toMatchInlineSnapshot(`
+          "χ.emitContent(χ.resolve(log)((1 === 2)));"
+        `);
+      });
+    });
+
+    describe('{{neq}}', () => {
+      test('emits !==', () => {
+        let template = stripIndent`
+          {{log (testNeq 1 2)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testNeq'], specialForms: { testNeq: '!==' } }))
+          .toMatchInlineSnapshot(`
+          "χ.emitContent(χ.resolve(log)((1 !== 2)));"
+        `);
+      });
+    });
   });
 
   describe('inline curlies', () => {
@@ -1237,6 +1263,62 @@ describe('Transform: rewriteTemplate', () => {
         {
           message: '{{testArray}} only accepts positional parameters',
           location: { start: 11, end: 38 },
+        },
+      ]);
+    });
+
+    test('{{eq}} with named parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testEq 123 foo="bar"}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testEq: '===' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testEq}} only accepts positional parameters',
+          location: { start: 11, end: 35 },
+        },
+      ]);
+    });
+
+    test('{{eq}} with wrong number of parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testEq 123 456 789}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testEq: '===' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testEq}} requires exactly two parameters',
+          location: { start: 11, end: 33 },
+        },
+      ]);
+    });
+
+    test('{{neq}} with named parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testNeq 123 foo="bar"}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testNeq: '!==' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testNeq}} only accepts positional parameters',
+          location: { start: 11, end: 36 },
+        },
+      ]);
+    });
+
+    test('{{neq}} with wrong number of parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testNeq 123 456 789}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testNeq: '!==' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testNeq}} requires exactly two parameters',
+          location: { start: 11, end: 34 },
         },
       ]);
     });

--- a/packages/core/src/config/types.cts
+++ b/packages/core/src/config/types.cts
@@ -45,7 +45,14 @@ export type GlintExtensionTransform<T> = (
   }
 ) => ts.Transformer<ts.Node>;
 
-export type GlintSpecialForm = 'if' | 'if-not' | 'yield' | 'object-literal' | 'array-literal';
+export type GlintSpecialForm =
+  | 'if'
+  | 'if-not'
+  | 'yield'
+  | 'object-literal'
+  | 'array-literal'
+  | '==='
+  | '!==';
 export type GlintSpecialFormConfig = {
   globals?: { [global: string]: GlintSpecialForm };
   imports?: {

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -195,6 +195,11 @@ export function templateToTypescript(
           emitArrayExpression(formInfo, node);
           break;
 
+        case '===':
+        case '!==':
+          emitBinaryOperatorExpression(formInfo, node);
+          break;
+
         default:
           record.error(`${formInfo.name} is not valid in inline form`, rangeForNode(node));
           emit.text('undefined');
@@ -311,6 +316,27 @@ export function templateToTypescript(
           emit.text('undefined');
         }
 
+        emit.text(')');
+      });
+    }
+
+    function emitBinaryOperatorExpression(
+      formInfo: SpecialFormInfo,
+      node: AST.MustacheStatement | AST.SubExpression
+    ): void {
+      emit.forNode(node, () => {
+        assert(
+          node.hash.pairs.length === 0,
+          `{{${formInfo.name}}} only accepts positional parameters`
+        );
+        assert(node.params.length === 2, `{{${formInfo.name}}} requires exactly two parameters`);
+
+        const [left, right] = node.params;
+
+        emit.text('(');
+        emitExpression(left);
+        emit.text(` ${formInfo.form} `);
+        emitExpression(right);
         emit.text(')');
       });
     }

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -327,9 +327,12 @@ export function templateToTypescript(
       emit.forNode(node, () => {
         assert(
           node.hash.pairs.length === 0,
-          `{{${formInfo.name}}} only accepts positional parameters`
+          () => `{{${formInfo.name}}} only accepts positional parameters`
         );
-        assert(node.params.length === 2, `{{${formInfo.name}}} requires exactly two parameters`);
+        assert(
+          node.params.length === 2,
+          () => `{{${formInfo.name}}} requires exactly two parameters`
+        );
 
         const [left, right] = node.params;
 

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -1,4 +1,9 @@
-import { GlintEnvironmentConfig, GlintSpecialForm, PathCandidate } from '@glint/core/config-types';
+import {
+  GlintEnvironmentConfig,
+  GlintSpecialForm,
+  GlintSpecialFormConfig,
+  PathCandidate,
+} from '@glint/core/config-types';
 
 const REGEXES = {
   JS_SCRIPT_EXT: /\.js$/,
@@ -19,12 +24,18 @@ export default function emberLooseEnvironment(
     typesModule += '/without-function-resolution';
   }
 
+  let additionalSpecialForms =
+    typeof options['additionalSpecialForms'] === 'object'
+      ? (options['additionalSpecialForms'] as GlintSpecialFormConfig)
+      : {};
+
   let specialForms: Record<string, GlintSpecialForm> = {
     if: 'if',
     unless: 'if-not',
     yield: 'yield',
     array: 'array-literal',
     hash: 'object-literal',
+    ...(additionalSpecialForms.globals ?? {}),
   };
 
   return {
@@ -32,7 +43,7 @@ export default function emberLooseEnvironment(
       'ember-cli-htmlbars': {
         hbs: {
           typesModule,
-          specialForms: { globals: specialForms },
+          specialForms: { globals: specialForms, imports: additionalSpecialForms.imports },
         },
       },
     },

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -35,7 +35,7 @@ export default function emberLooseEnvironment(
     yield: 'yield',
     array: 'array-literal',
     hash: 'object-literal',
-    ...(additionalSpecialForms.globals ?? {}),
+    ...additionalSpecialForms.globals,
   };
 
   return {

--- a/packages/environment-ember-template-imports/-private/environment/index.ts
+++ b/packages/environment-ember-template-imports/-private/environment/index.ts
@@ -1,8 +1,17 @@
-import { GlintEnvironmentConfig } from '@glint/core/config-types';
+import { GlintEnvironmentConfig, GlintSpecialFormConfig } from '@glint/core/config-types';
 import { preprocess } from './preprocess';
 import { transform } from './transform';
 
-export default function emberTemplateImportsEnvironment(): GlintEnvironmentConfig {
+export default function emberTemplateImportsEnvironment(
+  options: Record<string, unknown>
+): GlintEnvironmentConfig {
+  let additionalSpecialForms =
+    typeof options['additionalSpecialForms'] === 'object'
+      ? (options['additionalSpecialForms'] as GlintSpecialFormConfig)
+      : {};
+
+  const additionalGlobalSpecialForms = additionalSpecialForms.globals ?? {};
+
   return {
     tags: {
       'ember-template-imports': {
@@ -13,12 +22,15 @@ export default function emberTemplateImportsEnvironment(): GlintEnvironmentConfi
               if: 'if',
               unless: 'if-not',
               yield: 'yield',
+              ...additionalGlobalSpecialForms,
             },
             imports: {
               '@ember/helper': {
                 array: 'array-literal',
                 hash: 'object-literal',
+                ...(additionalSpecialForms.imports?.['@ember/helper'] ?? {}),
               },
+              ...(additionalSpecialForms.imports ?? {}),
             },
           },
           globals: [
@@ -40,6 +52,7 @@ export default function emberTemplateImportsEnvironment(): GlintEnvironmentConfi
             'unless',
             'with',
             'yield',
+            ...Object.keys(additionalGlobalSpecialForms),
           ],
         },
       },

--- a/packages/environment-ember-template-imports/-private/environment/index.ts
+++ b/packages/environment-ember-template-imports/-private/environment/index.ts
@@ -28,9 +28,9 @@ export default function emberTemplateImportsEnvironment(
               '@ember/helper': {
                 array: 'array-literal',
                 hash: 'object-literal',
-                ...(additionalSpecialForms.imports?.['@ember/helper'] ?? {}),
+                ...additionalSpecialForms.imports?.['@ember/helper'],
               },
-              ...(additionalSpecialForms.imports ?? {}),
+              ...additionalSpecialForms.imports,
             },
           },
           globals: [


### PR DESCRIPTION
Resolves #221

As these helpers have not yet been merged into Ember, you can opt in by adding to your glint config:

```
"glint": {
  "environment": {
    "ember-loose": {
      "additionalSpecialForms": {
        "globals": {
          "eq": "===",
          "not-eq": "!=="
        }
      }
    },
    "ember-template-imports": {
      "additionalSpecialForms": {
        "imports": {
          "ember-truth-helpers/helpers/eq": { "default": "===" },
          "ember-truth-helpers/helpers/not-eq": { "default": "!==" }
        }
      }
    }
  }
}
```