### PR TITLE
Rename block param identifiers that conflict with JS/TS keywords.

### DIFF
--- a/packages/core/__tests__/transform/template-to-typescript.test.ts
+++ b/packages/core/__tests__/transform/template-to-typescript.test.ts
@@ -759,9 +759,9 @@ describe('Transform: rewriteTemplate', () => {
           test('a shadowed global identifier', () => {
             let template = '{{#let foo as |bar|}}<Greet @message={{bar}} />{{/let}}';
 
-            expect(templateBody(template, { globals: ['foo'] })).toMatchInlineSnapshot(`
+            expect(templateBody(template, { globals: ['let', 'foo'] })).toMatchInlineSnapshot(`
               "{
-                const 𝛄 = χ.emitComponent(χ.resolve(let)(χ.Globals[\\"foo\\"]));
+                const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"let\\"])(χ.Globals[\\"foo\\"]));
                 {
                   const [bar] = 𝛄.blockParams[\\"default\\"];
                   {
@@ -769,7 +769,7 @@ describe('Transform: rewriteTemplate', () => {
                     𝛄;
                   }
                 }
-                let;
+                χ.Globals[\\"let\\"];
               }"
             `);
           });
@@ -1145,6 +1145,26 @@ describe('Transform: rewriteTemplate', () => {
                 class: \\"foo\\",
               });
             }
+          }
+          χ.Globals[\\"Foo\\"];
+        }"
+      `);
+    });
+
+    test('with a reserved block param identifier', () => {
+      let template = stripIndent`
+        <Foo as |switch|>
+          {{switch}}
+        </Foo>
+      `;
+
+      expect(templateBody(template)).toMatchInlineSnapshot(`
+        "{
+          const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])());
+          𝛄;
+          {
+            const [__switch] = 𝛄.blockParams[\\"default\\"];
+            χ.emitContent(χ.resolveOrReturn(__switch)());
           }
           χ.Globals[\\"Foo\\"];
         }"

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -388,7 +388,7 @@ export function templateToTypescript(
         emit.identifier(JSON.stringify(name).slice(1, -1), hbsOffset, name.length);
         emit.text('"]');
       } else {
-        emit.identifier(name, hbsOffset);
+        emit.identifier(makeJSSafe(name), hbsOffset, name.length);
       }
     }
 
@@ -957,7 +957,7 @@ export function templateToTypescript(
         if (index) emit.text(', ');
 
         start = template.indexOf(param, start);
-        emit.identifier(param, start);
+        emit.identifier(makeJSSafe(param), start, param.length);
       }
 
       emit.text('] = 𝛄.blockParams');
@@ -1139,4 +1139,67 @@ export function templateToTypescript(
       return /^[a-z_$][a-z0-9_$]*$/i.test(key);
     }
   });
+}
+
+const JSKeywords = new Set([
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'eval',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'null',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'undefined',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);
+
+function isJSKeyword(token: string): boolean {
+  return JSKeywords.has(token);
+}
+
+function makeJSSafe(identifier: string): string {
+  if (isJSKeyword(identifier) || identifier.startsWith('__')) {
+    return `__${identifier}`;
+  }
+
+  return identifier;
 }


### PR DESCRIPTION
Avoid generating illegal TypeScript by emitting block param names such as `switch`, `default`, `var`, and so on.

Fixes #444.
