### PR TITLE
Add an export statement to */-private/index.ts

### DIFF
--- a/packages/environment-ember-loose/-private/index.ts
+++ b/packages/environment-ember-loose/-private/index.ts
@@ -4,3 +4,4 @@
 
 /// <reference path="../registry/index.d.ts" />
 /// <reference path="./dsl/integration-declarations.d.ts" />
+export {};

--- a/packages/environment-ember-template-imports/-private/index.ts
+++ b/packages/environment-ember-template-imports/-private/index.ts
@@ -3,3 +3,4 @@
 // `import '@glint/environment-ember-template-imports'` somewhere in their project.
 
 /// <reference path="./dsl/integration-declarations.d.ts" />
+export {};

--- a/packages/environment-glimmerx/-private/index.ts
+++ b/packages/environment-glimmerx/-private/index.ts
@@ -4,3 +4,4 @@
 
 /// <reference path="../globals/index.d.ts" />
 /// <reference path="./dsl/integration-declarations.d.ts" />
+export {};


### PR DESCRIPTION
This avoids compile error when building with --isolatedModules, which affects projects that directly link the sources for glint instead of importing it from npm.

There is no change to the compiled output.

Fixes #455