### PR TITLE
Clean up package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ TypeScript-powered tooling for Glimmer templates.
 
 ## Getting Started
 
-Glint is broken into several different packages that you may use, depending on the details of your project. Typically you'll add `@glint/core` and a Glint environment package that reflects the type of project you're working on, then add a `"glint"` key to your `tsconfig.json` that tells Glint what it should look at.
+Glint is broken into several different packages that you may use, depending on the details of your project. Typically you'll add `@glint/core`, `@glint/template` and a Glint environment package that reflects the type of project you're working on, then add a `"glint"` key to your `tsconfig.json` that tells Glint what it should look at.
 
 For more specific details on setting up Glint in your project, take a look at [the documentation], in particular the Installation pages [for Ember.js projects] and [for GlimmerX projects].
 

--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -1,17 +1,17 @@
-To use Glint with [Ember](https://github.com/emberjs/ember.js) v3.24 or higher, you'll add the `@glint/core` and `@glint/environment-ember-loose` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
+To use Glint with [Ember](https://github.com/emberjs/ember.js) v3.24 or higher, you'll add the `@glint/core`, `@glint/template` and `@glint/environment-ember-loose` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
 
 {% tabs %}
 {% tab title="Yarn" %}
 
 ```sh
-yarn add --dev @glint/core @glint/environment-ember-loose
+yarn add --dev @glint/core @glint/template @glint/environment-ember-loose
 ```
 
 {% endtab %}
 {% tab title="npm" %}
 
 ```sh
-npm install -D @glint/core @glint/environment-ember-loose
+npm install -D @glint/core @glint/template @glint/environment-ember-loose
 ```
 
 {% endtab %}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ## Setup
 
-First, add `@glint/core` and an appropriate Glint environment to your project's `devDependencies`.
+First, add `@glint/core`, `@glint/template` and an appropriate Glint environment to your project's `devDependencies`.
 
 Then, add a `"glint"` key in your `tsconfig.json` that tells Glint what environment you're working in and, optionally, which files it should include in its typechecking.
 

--- a/docs/glimmerx/installation.md
+++ b/docs/glimmerx/installation.md
@@ -1,17 +1,17 @@
-To use Glint with [GlimmerX](https://github.com/glimmerjs/glimmer-experimental), you'll add the `@glint/core` and `@glint/environment-glimmerx` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
+To use Glint with [GlimmerX](https://github.com/glimmerjs/glimmer-experimental), you'll add the `@glint/core`, `@glint/template` and `@glint/environment-glimmerx` packages to your project's `devDependencies`, then add a `"glint"` key to your project's `tsconfig.json`.
 
 {% tabs %}
 {% tab title="Yarn" %}
 
 ```sh
-yarn add --dev @glint/core @glint/environment-glimmerx
+yarn add --dev @glint/core @glint/template @glint/environment-glimmerx
 ```
 
 {% endtab %}
 {% tab title="npm" %}
 
 ```sh
-npm install -D @glint/core @glint/environment-glimmerx
+npm install -D @glint/core @glint/template @glint/environment-glimmerx
 ```
 
 {% endtab %}

--- a/docs/with-js.md
+++ b/docs/with-js.md
@@ -15,13 +15,13 @@ Thus, installation for a JS setup looks like this:
 {% tabs %}
 {% tab title="Yarn" %}
 ```shell-session
-yarn add --dev typescript @glint/core @glint/environment-ember-loose
+yarn add --dev typescript @glint/core @glint/template @glint/environment-ember-loose
 ```
 {% endtab %}
 
 {% tab title="npm" %}
 ```shell-session
-npm install -D typescript @glint/core @glint/environment-ember-loose
+npm install -D typescript @glint/core @glint/template @glint/environment-ember-loose
 ```
 {% endtab %}
 {% endtabs %}

--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -372,20 +372,19 @@ describe('Language Server: Diagnostic Augmentation', () => {
     let server = project.startLanguageServer();
     let diagnostics = server.getDiagnostics(project.fileURI('index.gts'));
 
+    // TS 5.0 nightlies generate a slightly different format of "here are all the overloads
+    // and why they don't work" message, so for the time being we're truncating everything
+    // after the first line of the error message. In the future when we reach a point where
+    // we don't test against 4.x, we can go back to snapshotting the full message.
+    diagnostics = diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      message: diagnostic.message.slice(0, diagnostic.message.indexOf('\n')),
+    }));
+
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-              Property '[InvokeDirect]' is missing in type '{}' but required in type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-              Type '{}' provides no match for the signature 'new (...args: unknown[]): InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.
-              Type '{}' provides no match for the signature '(...params: any): any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 19,
@@ -401,14 +400,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 20,
@@ -424,14 +416,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 26,
@@ -447,14 +432,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 25,
@@ -470,14 +448,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 26,
@@ -493,14 +464,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 24,
@@ -516,14 +480,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 30,
@@ -539,14 +496,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "message": "The given value does not appear to be usable as a component, modifier or helper.
-        No overload matches this call.
-          Overload 1 of 3, '(item: DirectInvokable<AnyFunction>): AnyFunction', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'DirectInvokable<AnyFunction>'.
-          Overload 2 of 3, '(item: (abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>) | null | undefined): (...args: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type 'abstract new (...args: unknown[]) => InvokableInstance<AnyFunction>'.
-          Overload 3 of 3, '(item: ((...params: any) => any) | null | undefined): (...params: any) => any', gave the following error.
-            Argument of type '{}' is not assignable to parameter of type '(...params: any) => any'.",
+          "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
               "character": 29,

--- a/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
@@ -8,6 +8,11 @@ import {
   HasContext,
   TemplateContext,
 } from '@glint/template/-private/integration';
+import {
+  ComponentSignatureArgs,
+  ComponentSignatureBlocks,
+  ComponentSignatureElement,
+} from '@glint/template/-private/signature';
 
 //////////////////////////////////////////////////////////////////////
 // Components
@@ -16,13 +21,11 @@ import '@ember/component';
 import '@ember/component/template-only';
 import '@glimmer/component';
 
-import { ExpandSignature } from '@glimmer/component/-private/component';
-
 type ComponentContext<This, S> = TemplateContext<
   This,
-  ExpandSignature<S>['Args']['Named'],
-  FlattenBlockParams<ExpandSignature<S>['Blocks']>,
-  ExpandSignature<S>['Element']
+  ComponentSignatureArgs<S>['Named'],
+  FlattenBlockParams<ComponentSignatureBlocks<S>>,
+  ComponentSignatureElement<S>
 >;
 
 declare module '@glimmer/component' {

--- a/packages/environment-ember-loose/-private/intrinsics/get.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/get.d.ts
@@ -1,7 +1,6 @@
 import { DirectInvokable } from '@glint/template/-private/integration';
 import ObjectProxy from '@ember/object/proxy';
 import { UnwrapComputedPropertyGetter } from '@ember/object/-private/types';
-import 'foo/bar/baz';
 
 export type GetHelper = DirectInvokable<{
   <T, K extends keyof T>(obj: T, key: K): UnwrapComputedPropertyGetter<T[K]>;

--- a/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
@@ -7,7 +7,7 @@ import {
   NamedArgsMarker,
 } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
-import { EmptyObject } from '@glimmer/component/-private/component';
+import { EmptyObject } from '@glint/template/-private/integration';
 import type { ComponentLike } from '@glint/template';
 
 {

--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -6,7 +6,7 @@ import {
   emitComponent,
   NamedArgsMarker,
 } from '@glint/environment-ember-loose/-private/dsl';
-import { EmptyObject } from '@glimmer/component/-private/component';
+import { EmptyObject } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
 import { ComponentLike } from '@glint/template';
 
@@ -45,7 +45,6 @@ import { ComponentLike } from '@glint/template';
         expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
         expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
         expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
-        expectTypeOf(𝚪.this.args).toEqualTypeOf<Readonly<EmptyObject>>();
       });
     }
   }

--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -5,10 +5,9 @@ import {
   emitComponent,
   NamedArgsMarker,
 } from '@glint/environment-ember-loose/-private/dsl';
-import { ComponentReturn, NamedArgs } from '@glint/template/-private/integration';
+import { ComponentReturn, EmptyObject, NamedArgs } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
 import { ComponentKeyword } from '../../-private/intrinsics/component';
-import { EmptyObject } from '@glimmer/component/-private/component';
 import { ComponentLike, WithBoundArgs } from '@glint/template';
 
 {

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -28,15 +28,33 @@
     "-private/**/*.{js,d.ts}",
     "registry/**/*.{js,d.ts}"
   ],
-  "dependencies": {
-    "@glint/template": "^0.9.7"
-  },
   "peerDependencies": {
     "@glimmer/component": "^1.1.2",
+    "@glint/template": "^0.9.7",
+    "@types/ember__array": "^4.0.2",
+    "@types/ember__component": "^4.0.10",
+    "@types/ember__controller": "^4.0.2",
+    "@types/ember__object": "^4.0.4",
+    "@types/ember__routing": "^4.0.11",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-modifier": "^3.2.7"
   },
   "peerDependenciesMeta": {
+    "@types/ember__array": {
+      "optional": true
+    },
+    "@types/ember__component": {
+      "optional": true
+    },
+    "@types/ember__controller": {
+      "optional": true
+    },
+    "@types/ember__object": {
+      "optional": true
+    },
+    "@types/ember__routing": {
+      "optional": true
+    },
     "ember-cli-htmlbars": {
       "optional": true
     },
@@ -46,7 +64,11 @@
   },
   "devDependencies": {
     "@glimmer/component": "^1.1.2",
-    "@types/ember__component": "~4.0.8",
+    "@types/ember__array": "^4.0.2",
+    "@types/ember__component": "^4.0.10",
+    "@types/ember__controller": "^4.0.2",
+    "@types/ember__object": "^4.0.4",
+    "@types/ember__routing": "^4.0.11",
     "ember-modifier": "^3.2.7",
     "expect-type": "0.11.0",
     "vitest": "^0.22.0"

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -25,17 +25,35 @@
     "README.md",
     "-private/**/*.{js,d.ts}"
   ],
-  "dependencies": {
-    "@glint/template": "^0.9.7"
-  },
   "peerDependencies": {
     "@glint/environment-ember-loose": "^0.9.7",
+    "@glint/template": "^0.9.7",
+    "@types/ember__component": "^4.0.10",
+    "@types/ember__helper": "^4.0.1",
+    "@types/ember__modifier": "^4.0.3",
+    "@types/ember__routing": "^4.0.12",
     "ember-template-imports": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/ember__component": {
+      "optional": true
+    },
+    "@types/ember__helper": {
+      "optional": true
+    },
+    "@types/ember__modifier": {
+      "optional": true
+    },
+    "@types/ember__routing": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/ember": "^4.0.0",
-    "@types/ember__helper": "^4.0.0",
-    "@types/ember__modifier": "^4.0.0",
+    "@types/ember__component": "^4.0.10",
+    "@types/ember__helper": "^4.0.1",
+    "@types/ember__modifier": "^4.0.3",
+    "@types/ember__routing": "^4.0.12",
     "ember-template-imports": "^3.0.0",
     "vitest": "^0.22.0"
   },

--- a/packages/environment-glimmerx/-private/dsl/index.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/index.d.ts
@@ -51,14 +51,16 @@ export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;
 // Longer term we should rationalize this to a type that doesn't carry extra baggage
 // and likely comes from a more sensible path.
 
-import { TemplateComponent } from '@glimmerx/component';
+import { TemplateComponentInstance } from '@glimmerx/component';
 
 export declare function templateExpression<
   Signature extends AnyFunction = () => ComponentReturn<EmptyObject>,
   Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
 >(
   f: (𝚪: Context, χ: never) => void
-): TemplateComponent<never> & (new () => InvokableInstance<Signature> & HasContext<Context>);
+): abstract new () => TemplateComponentInstance<never> &
+  InvokableInstance<Signature> &
+  HasContext<Context>;
 
 // We customize `applyModifier` to accept `void | () => void` as a valid modifier return type
 export function applyModifier(modifierResult: ModifierReturn | void | (() => void)): void;

--- a/packages/environment-glimmerx/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/integration-declarations.d.ts
@@ -13,16 +13,14 @@ import {
 
 import '@glimmerx/component';
 
-import { ExpandSignature } from '@glimmer/component/-private/component';
-
 // Declaring that `hbs` returns a `TemplateComponent` prevents vanilla `tsc` from freaking out when
 // it sees code like `const MyThing: TC<Sig> = hbs...`. Glint itself will never see `hbs` get used, as
 // it's transformed to the template DSL before typechecking.
 type ComponentContext<This, S> = TemplateContext<
   This,
-  ExpandSignature<S>['Args']['Named'],
-  FlattenBlockParams<ExpandSignature<S>['Blocks']>,
-  ExpandSignature<S>['Element']
+  ComponentSignatureArgs<S>['Named'],
+  FlattenBlockParams<ComponentSignatureBlocks<S>>,
+  ComponentSignatureElement<S>
 >;
 
 declare module '@glimmerx/component' {
@@ -90,6 +88,11 @@ declare module '@glimmerx/helper' {
 // Modifiers
 
 import '@glimmerx/modifier';
+import {
+  ComponentSignatureArgs,
+  ComponentSignatureBlocks,
+  ComponentSignatureElement,
+} from '@glint/template/-private/signature';
 
 export interface OnModifierArgs {
   capture?: boolean;

--- a/packages/environment-glimmerx/package.json
+++ b/packages/environment-glimmerx/package.json
@@ -30,13 +30,22 @@
     "helper/**/*.{js,d.ts}",
     "component/**/*.{js,d.ts}"
   ],
-  "dependencies": {
-    "@glint/template": "^0.9.7"
-  },
   "peerDependencies": {
+    "@glint/template": "^0.9.7",
     "@glimmerx/component": "^0.6.7",
     "@glimmerx/modifier": "^0.6.7",
     "@glimmerx/helper": "^0.6.7"
+  },
+  "peerDependenciesMeta": {
+    "@glimmerx/component": {
+      "optional": true
+    },
+    "@glimmerx/helper": {
+      "optional": true
+    },
+    "@glimmerx/modifier": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@glimmerx/component": "^0.6.7",

--- a/packages/template/-private/integration.d.ts
+++ b/packages/template/-private/integration.d.ts
@@ -1,9 +1,13 @@
-// While the entire `@glint/template` package is currently private, this
-// module exports the symbols and types necessary to declare a class or
-// other entity as integrating with Glint's template system.
+// While everything in the `@glint/template` package other than its main
+// entrypoint is "private", this module exports the symbols and types
+// necessary to declare a class or other entity as integrating with Glint's
+// template system.
+// In most cases it should be possible to declare integrations in terms of
+// `ComponentLike`/`HelperLike`/`ModifierLike`, but these declarations are
+// the primitives on which those types are built.
 
-import { EmptyObject } from '@glimmer/component/-private/component';
-export { EmptyObject };
+declare const Empty: unique symbol;
+export type EmptyObject = { [Empty]?: true };
 
 /** Any function, which is the tighest bound we can put on an object's `[Invoke]` field. */
 export type AnyFunction = (...params: any) => any;
@@ -23,12 +27,6 @@ export type Invokable<F extends AnyFunction> = abstract new (...args: any) => In
 
 export declare const Context: unique symbol;
 export type HasContext<T extends AnyContext = AnyContext> = { [Context]: T };
-
-// These shenanigans are necessary to get TS to report when named args
-// are passed to a signature that doesn't expect any, because `{}` is
-// special-cased in the type system not to trigger EPC.
-
-export type GuardEmpty<T> = T extends any ? (keyof T extends never ? EmptyObject : T) : never;
 
 declare const Element: unique symbol;
 declare const Modifier: unique symbol;
@@ -83,8 +81,3 @@ export type NamedArgNames<T extends Invokable<AnyFunction>> = T extends Invokabl
   : never;
 
 export type UnwrapNamedArgs<T> = T extends NamedArgs<infer U> ? U : T;
-
-export type MaybeNamed<T> = {} extends UnwrapNamedArgs<T> ? [named?: T] : [named: T];
-
-export type Get<T, K, Otherwise = unknown> = K extends keyof T ? T[K] : Otherwise;
-export type Constrain<T, Constraint, Otherwise = Constraint> = T extends Constraint ? T : Otherwise;

--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -1,0 +1,61 @@
+// This module contains utilities for converting signature types defined
+// in userspace into our internal representation of an invokable's
+// function type signature.
+
+import { EmptyObject, NamedArgs, UnwrapNamedArgs } from './integration';
+
+/**
+ * Given an "args hash" (e.g. `{ Named: {...}; Positional: [...] }`),
+ * returns a tuple type representing the parameters
+ */
+export type InvokableArgs<Args> = [
+  ...positional: Constrain<Get<Args, 'Positional'>, Array<unknown>, []>,
+  ...named: MaybeNamed<NamedArgs<GuardEmpty<Get<Args, 'Named'>>>>
+];
+
+/** Given a signature `S`, get back the normalized `Args` type. */
+export type ComponentSignatureArgs<S> = S extends {
+  Args: infer Args;
+}
+  ? Args extends {
+      Named?: object;
+      Positional?: unknown[];
+    }
+    ? {
+        Named: Get<S['Args'], 'Named', EmptyObject>;
+        Positional: Get<S['Args'], 'Positional', []>;
+      }
+    : {
+        Named: S['Args'];
+        Positional: [];
+      }
+  : {
+      Named: keyof S extends 'Args' | 'Blocks' | 'Element' ? EmptyObject : S;
+      Positional: [];
+    };
+
+/** Given a signature `S`, get back the normalized `Blocks` type. */
+export type ComponentSignatureBlocks<S> = S extends { Blocks: infer Blocks }
+  ? {
+      [Block in keyof Blocks]: Blocks[Block] extends unknown[]
+        ? { Params: { Positional: Blocks[Block] } }
+        : Blocks[Block];
+    }
+  : EmptyObject;
+
+/** Given a component signature `S`, get back the `Element` type. */
+export type ComponentSignatureElement<S> = S extends { Element: infer Element } ? Element : null;
+
+// These shenanigans are necessary to get TS to report when named args
+// are passed to a signature that doesn't expect any, because `{}` is
+// special-cased in the type system not to trigger EPC.
+export type GuardEmpty<T> = T extends any ? (keyof T extends never ? EmptyObject : T) : never;
+
+export type PrebindArgs<T, Args extends keyof UnwrapNamedArgs<T>> = NamedArgs<
+  Omit<UnwrapNamedArgs<T>, Args> & Partial<Pick<UnwrapNamedArgs<T>, Args>>
+>;
+
+export type MaybeNamed<T> = {} extends UnwrapNamedArgs<T> ? [named?: T] : [named: T];
+
+export type Get<T, K, Otherwise = unknown> = K extends keyof T ? T[K] : Otherwise;
+export type Constrain<T, Constraint, Otherwise = Constraint> = T extends Constraint ? T : Otherwise;

--- a/packages/template/__tests__/signature-test.test.ts
+++ b/packages/template/__tests__/signature-test.test.ts
@@ -1,0 +1,156 @@
+import { expectTypeOf } from 'expect-type';
+import { EmptyObject } from '../-private/integration';
+import {
+  ComponentSignatureArgs,
+  ComponentSignatureBlocks,
+  ComponentSignatureElement,
+} from '../-private/signature';
+
+type LegacyArgs = {
+  foo: number;
+};
+
+expectTypeOf<ComponentSignatureArgs<LegacyArgs>>().toEqualTypeOf<{
+  Named: LegacyArgs;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<LegacyArgs>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureElement<LegacyArgs>>().toEqualTypeOf<null>();
+
+// Here, we are testing that the types propertly distribute over union types,
+// generics which extend other types, etc.
+type LegacyArgsDistributive = { foo: number } | { bar: string; baz: boolean };
+
+expectTypeOf<ComponentSignatureArgs<LegacyArgsDistributive>>().toEqualTypeOf<
+  | { Named: { foo: number }; Positional: [] }
+  | { Named: { bar: string; baz: boolean }; Positional: [] }
+>();
+expectTypeOf<ComponentSignatureBlocks<LegacyArgsDistributive>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureElement<LegacyArgsDistributive>>().toEqualTypeOf<null>();
+
+interface ArgsOnly {
+  Args: LegacyArgs;
+}
+
+expectTypeOf<ComponentSignatureArgs<ArgsOnly>>().toEqualTypeOf<{
+  Named: LegacyArgs;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<ArgsOnly>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureElement<ArgsOnly>>().toEqualTypeOf<null>();
+
+interface ElementOnly {
+  Element: HTMLParagraphElement;
+}
+
+expectTypeOf<ComponentSignatureArgs<ElementOnly>>().toEqualTypeOf<{
+  Named: EmptyObject;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<ElementOnly>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureElement<ElementOnly>>().toEqualTypeOf<HTMLParagraphElement>();
+
+interface Blocks {
+  default: [name: string];
+  inverse: [];
+}
+
+interface BlockOnlySig {
+  Blocks: Blocks;
+}
+
+expectTypeOf<ComponentSignatureArgs<BlockOnlySig>>().toEqualTypeOf<{
+  Named: EmptyObject;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<BlockOnlySig>>().toEqualTypeOf<{
+  default: {
+    Params: {
+      Positional: [name: string];
+    };
+  };
+  inverse: {
+    Params: {
+      Positional: [];
+    };
+  };
+}>();
+expectTypeOf<ComponentSignatureElement<BlockOnlySig>>().toEqualTypeOf<null>();
+
+interface ArgsAndBlocks {
+  Args: LegacyArgs;
+  Blocks: Blocks;
+}
+
+expectTypeOf<ComponentSignatureArgs<ArgsAndBlocks>>().toEqualTypeOf<{
+  Named: LegacyArgs;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<ArgsAndBlocks>>().toEqualTypeOf<{
+  default: {
+    Params: {
+      Positional: [name: string];
+    };
+  };
+  inverse: {
+    Params: {
+      Positional: [];
+    };
+  };
+}>();
+expectTypeOf<ComponentSignatureElement<ArgsAndBlocks>>().toEqualTypeOf<null>();
+
+interface ArgsAndEl {
+  Args: LegacyArgs;
+  Element: HTMLParagraphElement;
+}
+
+expectTypeOf<ComponentSignatureArgs<ArgsAndEl>>().toEqualTypeOf<{
+  Named: LegacyArgs;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<ArgsAndEl>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureElement<ArgsAndEl>>().toEqualTypeOf<HTMLParagraphElement>();
+
+interface FullShortSig {
+  Args: LegacyArgs;
+  Element: HTMLParagraphElement;
+  Blocks: Blocks;
+}
+
+expectTypeOf<ComponentSignatureArgs<FullShortSig>>().toEqualTypeOf<{
+  Named: LegacyArgs;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<FullShortSig>>().toEqualTypeOf<{
+  default: {
+    Params: {
+      Positional: [name: string];
+    };
+  };
+  inverse: {
+    Params: {
+      Positional: [];
+    };
+  };
+}>();
+expectTypeOf<ComponentSignatureElement<FullShortSig>>().toEqualTypeOf<HTMLParagraphElement>();
+
+interface FullLongSig {
+  Args: {
+    Named: LegacyArgs;
+    Positional: [];
+  };
+  Element: HTMLParagraphElement;
+  Blocks: {
+    default: {
+      Params: {
+        Positional: [name: string];
+      };
+    };
+  };
+}
+
+expectTypeOf<ComponentSignatureArgs<FullLongSig>>().toEqualTypeOf<FullLongSig['Args']>();
+expectTypeOf<ComponentSignatureBlocks<FullLongSig>>().toEqualTypeOf<FullLongSig['Blocks']>();
+expectTypeOf<ComponentSignatureElement<FullLongSig>>().toEqualTypeOf<FullLongSig['Element']>();

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -14,9 +14,6 @@
     "-private",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@glimmer/component": "^1.1.2"
-  },
   "devDependencies": {
     "@glimmer/component": "^1.1.2",
     "@glimmerx/component": "^0.6.7",

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -8,7 +8,7 @@ A Visual Studio Code extension for the [Glint] language server.
 
 See the [Glint home page] for a more detailed Getting Started guide.
 
-1. Add `@glint/core` and an appropriate environment package to your project's `devDependencies`.
+1. Add `@glint/core`, `@glint/template` and an appropriate environment package to your project's `devDependencies`.
 1. Add a `"glint"` key to your project's `tsconfig.json` or `jsconfig.json` specifying your environment and any other relevant configuration.
 1. Consider disabling the built-in `vscode.typescript-language-features` extension for any workspaces where you use Glint to avoid extraneous diagnostics. <details><summary>Screenshot</summary>
 <img src="https://user-images.githubusercontent.com/108688/111069039-6dc84100-84cb-11eb-8339-18a589be2ac5.png" width="500">


### PR DESCRIPTION
## Background

This change addresses some long-standing issues with the dependency declarations in some of our packages:
 1. Our environments should be declaring peerDeps on _every_ package they attempt to augment in order to ensure the target package is actually visible
 2. Environments currently declare a direct dependency on `@glint/template`, which means they can end up getting their own copy, but `@glint/template` really needs to be a highlander package because all consumers need to be on the same page about the symbols it uses for branding
 3. `@glint/template` forces a dependency on `@glimmer/component` for its `ExpandSignature` utility type, even though consumers of `@glint/template` may not need or want `@glimmer/component` themselves

## Change Overview

For (1), this primarily means we add a bunch of optional `peerDependencies` to the environment packages, which ultimately has minimal impact on consumers other than ensuring strict package managers arrange things so that those packages are visible to the environments for type augmentation.

For (2), we instead make `@glint/template` a _peer_ dependency of the environment packages. This is the key breaking change in this PR, as it requires end consumers to depend on `@glint/template` themselves. This is reasonable, though, as in practice those consumers end up frequently importing from `@glint/template` to add declarations to their own registries, and because as noted there _must_ only be one copy of the package in play.

For (3), we inline `ExpandSignature` from `@glimmer/component` into `@glint/template` and then actually deconstruct it slightly, since we never care about the combined expanded signature as a whole, but only ever its individual pieces. I also pulled in and adapted the types tests for `ExpandSignature` to make sure we're still honoring everything that worked there before.

## Notes

The change in (3) ultimately means we can probably simplify and stop exporting `ExpandSignature` from `@glimmer/component`, since Glint was meant to be the only external consumer of that, but I don't think there's any particular urgency there.

Also: with these changes we should be able to finally address the assignability issues raised in #396, and I _think_ at the end of everything we can probably drop `EmptyObject` entirely.