### PR TITLE
Use a `./glint-environment-definition` entrypoint for env packages

### DIFF
--- a/packages/core/__tests__/config/environment.test.ts
+++ b/packages/core/__tests__/config/environment.test.ts
@@ -163,7 +163,9 @@ describe('Config: Environments', () => {
         `${envDir}/package.json`,
         JSON.stringify({
           name: '@glint/environment-test-env',
-          'glint-environment': 'env',
+          exports: {
+            './glint-environment-definition': './env.js',
+          },
         })
       );
 
@@ -184,7 +186,9 @@ describe('Config: Environments', () => {
         `${envDir}/package.json`,
         JSON.stringify({
           name: 'some-other-environment',
-          'glint-environment': 'third-party-env',
+          exports: {
+            './glint-environment-definition': './third-party-env.js',
+          },
         })
       );
 
@@ -202,7 +206,7 @@ describe('Config: Environments', () => {
         'module.exports = () => ({ tags: { internal: {} } });'
       );
 
-      let env = GlintEnvironment.load('./lib/my-internal-env', { rootDir: testDir });
+      let env = GlintEnvironment.load('./lib/my-internal-env.js', { rootDir: testDir });
 
       expect(env.getConfiguredTemplateTags()).toEqual({ internal: {} });
     });
@@ -217,7 +221,9 @@ describe('Config: Environments', () => {
         `${dir}/package.json`,
         JSON.stringify({
           name: `@glint/environment-${name}`,
-          'glint-environment': 'env',
+          exports: {
+            './glint-environment-definition': './env.js',
+          },
         })
       );
 

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -5,12 +5,11 @@
   "description": "A Glint environment to support loose-mode Ember.js projects",
   "license": "MIT",
   "author": "Dan Freeman (https://github.com/dfreeman)",
-  "glint-environment": "-private/environment/index.js",
   "main": "-private/index.js",
   "exports": {
     ".": "./-private/index.js",
-    "./package.json": "./package.json",
     "./registry": "./registry/index.js",
+    "./glint-environment-definition": "./-private/environment/index.js",
     "./-private/dsl": "./-private/dsl/index.js",
     "./-private/dsl/without-function-resolution": "./-private/dsl/without-function-resolution.js"
   },

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -5,11 +5,10 @@
   "description": "A Glint environment to support ember-template-imports projects",
   "license": "MIT",
   "author": "Dan Freeman (https://github.com/dfreeman)",
-  "glint-environment": "-private/environment/index.js",
   "main": "-private/index.js",
   "exports": {
     ".": "./-private/index.js",
-    "./package.json": "./package.json",
+    "./glint-environment-definition": "./-private/environment/index.js",
     "./-private/dsl": "./-private/dsl/index.js"
   },
   "keywords": [

--- a/packages/environment-glimmerx/package.json
+++ b/packages/environment-glimmerx/package.json
@@ -5,12 +5,11 @@
   "description": "A Glint environment to support GlimmerX projects",
   "license": "MIT",
   "author": "Dan Freeman (https://github.com/dfreeman)",
-  "glint-environment": "-private/environment/index.js",
   "main": "./-private/index.js",
   "exports": {
     ".": "./-private/index.js",
-    "./package.json": "./package.json",
     "./globals": "./globals/index.js",
+    "./glint-environment-definition": "./-private/environment/index.js",
     "./-private/dsl": "./-private/dsl/index.js"
   },
   "keywords": [


### PR DESCRIPTION
Glint environments need to expose two public entrypoints: one that triggers any type augmentations the environment provides, and one that exposes its actual definition to `@glint/core`.

Today, environments use their `main` entrypoint for the former, allowing consumers to write `import '@glint/environment-x'` to pull in type augmentations.

For the latter, we've used an ad-hoc `"glint-environment"` key in `package.json`. Now that we've switched environment packages over to conventionally use `exports`, though, this means that packages need to explicitly expose their `package.json` to be importable. Moreover, `exports` makes the `"glint-environment"` key itself an unnecessary layer of indirection.

This change moves to have environment packages expose a `./glint-environment-definition` entrypoint in their `exports` and does away with the old top-level `glint-environment` key. This simplifies our loading logic by just "using the platform".

This is a breaking change if anyone has reverse-engineered our environment interface and built their own, though to my knowledge that isn't super commonplace.