### PR TITLE
Validate assignability rules for `ComponentLike` and friends

### DIFF
--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -792,7 +792,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
         },
         {
           "message": "The {{component}} helper can't be used to directly invoke a component under Glint. Consider first binding the result to a variable, e.g. '{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as '<ComponentName @arg={{value}} />'.
-        Argument of type 'Invokable<(named?: PrebindArgs<{ message?: string | undefined; }, \\"message\\"> | undefined) => ComponentReturn<FlattenBlockParams<{ default: { Params: { Positional: []; }; }; }>, null>>' is not assignable to parameter of type 'ContentValue'.",
+        Argument of type 'Invokable<(named?: PrebindArgs<{ message?: string | undefined; }, \\"message\\"> | undefined) => ComponentReturn<FlattenBlockParams<{ default: { Params: { Positional: []; }; }; }>, unknown>>' is not assignable to parameter of type 'ContentValue'.",
           "range": {
             "end": {
               "character": 41,
@@ -827,7 +827,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
         },
         {
           "message": "The {{component}} helper can't be used to directly invoke a component under Glint. Consider first binding the result to a variable, e.g. '{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as '<ComponentName @arg={{value}}>...</ComponentName>'.
-        Argument of type 'Invokable<(named?: PrebindArgs<{ message?: string | undefined; }, \\"message\\"> | undefined) => ComponentReturn<FlattenBlockParams<{ default: { Params: { Positional: []; }; }; }>, null>>' is not assignable to parameter of type 'ComponentReturn<any, any>'.",
+        Argument of type 'Invokable<(named?: PrebindArgs<{ message?: string | undefined; }, \\"message\\"> | undefined) => ComponentReturn<FlattenBlockParams<{ default: { Params: { Positional: []; }; }; }>, unknown>>' is not assignable to parameter of type 'ComponentReturn<any, any>'.",
           "range": {
             "end": {
               "character": 56,

--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -59,7 +59,7 @@ describe('Language Server: Diagnostics', () => {
       expect(templateDiagnostics).toMatchInlineSnapshot(`
         [
           {
-            "message": "Property 'missingArg' does not exist on type 'EmptyObject'.",
+            "message": "Property 'missingArg' does not exist on type '{}'.",
             "range": {
               "end": {
                 "character": 13,
@@ -118,7 +118,7 @@ describe('Language Server: Diagnostics', () => {
 
       expect(diagnostics).toMatchObject([
         {
-          message: "Property 'foo' does not exist on type 'EmptyObject'.",
+          message: "Property 'foo' does not exist on type '{}'.",
           source: 'glint:ts(2339)',
         },
       ]);
@@ -159,7 +159,7 @@ describe('Language Server: Diagnostics', () => {
 
       expect(diagnostics).toMatchObject([
         {
-          message: "Property 'foo' does not exist on type 'EmptyObject'.",
+          message: "Property 'foo' does not exist on type '{}'.",
           source: 'glint:ts(2339)',
         },
       ]);
@@ -358,7 +358,7 @@ describe('Language Server: Diagnostics', () => {
     expect(server.getDiagnostics(project.fileURI('component-a.ts'))).toMatchInlineSnapshot(`
       [
         {
-          "message": "Property 'version' does not exist on type 'EmptyObject'.",
+          "message": "Property 'version' does not exist on type '{}'.",
           "range": {
             "end": {
               "character": 36,

--- a/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
@@ -3,7 +3,6 @@
 import { ComponentLike, HelperLike, ModifierLike } from '@glint/template';
 import {
   Context,
-  EmptyObject,
   FlattenBlockParams,
   HasContext,
   TemplateContext,
@@ -85,7 +84,7 @@ declare module '@ember/routing/route' {
     [Context]: TemplateContext<
       Controller & ModelField<ModelForRoute<this>>,
       ModelField<ModelForRoute<this>>,
-      EmptyObject,
+      {},
       null
     >;
   }
@@ -93,7 +92,7 @@ declare module '@ember/routing/route' {
 
 declare module '@ember/controller' {
   export default interface Controller {
-    [Context]: TemplateContext<this, ModelField<this['model']>, EmptyObject, null>;
+    [Context]: TemplateContext<this, ModelField<this['model']>, {}, null>;
   }
 }
 
@@ -103,9 +102,7 @@ declare module '@ember/controller' {
 import '@ember/test-helpers';
 import 'ember-cli-htmlbars';
 
-type TestTemplate<T> = abstract new () => HasContext<
-  TemplateContext<T, EmptyObject, EmptyObject, void>
->;
+type TestTemplate<T> = abstract new () => HasContext<TemplateContext<T, {}, {}, void>>;
 
 declare module '@ember/test-helpers' {
   export function render<T>(template: TestTemplate<T>): Promise<void>;

--- a/packages/environment-ember-loose/-private/intrinsics/component.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/component.d.ts
@@ -1,7 +1,6 @@
 import { WithBoundArgs } from '@glint/template';
 import {
   ComponentReturn,
-  EmptyObject,
   DirectInvokable,
   InvokableInstance,
   Invokable,
@@ -14,8 +13,8 @@ import {
 type ComponentNamedArgs<Component> = Component extends Invokable<(...args: infer Args) => any>
   ? Args extends [...positional: infer _, named?: infer Named]
     ? UnwrapNamedArgs<Named>
-    : EmptyObject
-  : EmptyObject;
+    : {}
+  : {};
 
 type PartiallyAppliedComponent<Component, Args> = Component extends Invokable<AnyFunction>
   ? WithBoundArgs<

--- a/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
@@ -7,7 +7,6 @@ import {
   NamedArgsMarker,
 } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
-import { EmptyObject } from '@glint/template/-private/integration';
 import type { ComponentLike } from '@glint/template';
 
 {
@@ -50,7 +49,7 @@ import type { ComponentLike } from '@glint/template';
       templateForBackingValue(this, function* (𝚪) {
         expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
         expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
-        expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
+        expectTypeOf(𝚪.args).toEqualTypeOf<{}>();
       });
     }
   }

--- a/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/ember-component.test.ts
@@ -18,12 +18,6 @@ import type { ComponentLike } from '@glint/template';
     }
   }
 
-  resolve(NoArgsComponent)({
-    // @ts-expect-error: extra named arg
-    foo: 'bar',
-    ...NamedArgsMarker,
-  });
-
   resolve(NoArgsComponent)(
     // @ts-expect-error: extra positional arg
     'oops'

--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -6,7 +6,6 @@ import {
   emitComponent,
   NamedArgsMarker,
 } from '@glint/environment-ember-loose/-private/dsl';
-import { EmptyObject } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
 import { ComponentLike } from '@glint/template';
 
@@ -44,7 +43,7 @@ import { ComponentLike } from '@glint/template';
       templateForBackingValue(this, function* (𝚪) {
         expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
         expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
-        expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
+        expectTypeOf(𝚪.args).toEqualTypeOf<{}>();
       });
     }
   }

--- a/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/glimmer-component.test.ts
@@ -12,12 +12,6 @@ import { ComponentLike } from '@glint/template';
 {
   class NoArgsComponent extends Component {}
 
-  resolve(NoArgsComponent)({
-    // @ts-expect-error: extra named arg
-    foo: 'bar',
-    ...NamedArgsMarker,
-  });
-
   resolve(NoArgsComponent)(
     // @ts-expect-error: extra positional arg
     'oops'

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -1,4 +1,4 @@
-import Helper, { helper, EmptyObject } from '@ember/component/helper';
+import Helper, { helper } from '@ember/component/helper';
 import { resolve } from '@glint/environment-ember-loose/-private/dsl';
 import {
   NamedArgsMarker,
@@ -6,7 +6,7 @@ import {
 } from '@glint/environment-ember-loose/-private/dsl/without-function-resolution';
 import { expectTypeOf } from 'expect-type';
 import { HelperLike } from '@glint/template';
-import { EmptyObject as GlintEmptyObject, NamedArgs } from '@glint/template/-private/integration';
+import { NamedArgs } from '@glint/template/-private/integration';
 
 // Functional helper: fixed signature params
 {
@@ -56,7 +56,9 @@ import { EmptyObject as GlintEmptyObject, NamedArgs } from '@glint/template/-pri
   let definition = helper(<T, U>([a, b]: [T, U]) => a || b);
   let or = resolve(definition);
 
-  expectTypeOf(or).toEqualTypeOf<{ <T, U>(t: T, u: U, named?: NamedArgs<EmptyObject>): T | U }>();
+  // Using `toMatch` rather than `toEqual` because helper resolution (currently)
+  // uses a special `EmptyObject` type to represent empty named args.
+  expectTypeOf(or).toMatchTypeOf<{ <T, U>(t: T, u: U, named?: NamedArgs<{}>): T | U }>();
 
   or('a', 'b', {
     // @ts-expect-error: extra named arg
@@ -190,9 +192,7 @@ import { EmptyObject as GlintEmptyObject, NamedArgs } from '@glint/template/-pri
 
   let maybeString = resolve(MaybeStringHelper);
 
-  expectTypeOf(maybeString).toEqualTypeOf<
-    (args?: NamedArgs<GlintEmptyObject>) => string | undefined
-  >();
+  expectTypeOf(maybeString).toEqualTypeOf<() => string | undefined>();
 }
 
 // Helpers are `HelperLike`

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -160,12 +160,12 @@ import { NamedArgs } from '@glint/template/-private/integration';
   let repeat = resolve(RepeatHelper);
 
   expectTypeOf(repeat).toEqualTypeOf<{
-    <T>(value: T, count?: number | undefined, args?: NamedArgs<GlintEmptyObject>): Array<T>;
+    <T>(value: T, count?: number | undefined): Array<T>;
   }>();
 
   repeat(
     'hello',
-    // @ts-expect-error: extra named arg
+    // @ts-expect-error: unexpected named args
     { word: 'hi', ...NamedArgsMarker }
   );
 

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/mut.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/mut.test.ts
@@ -14,8 +14,8 @@ expectTypeOf(fn(mut('hello'))).toEqualTypeOf<(value: string) => void>();
 // @ts-expect-error: missing value
 mut();
 
+// @ts-expect-error: unexpected named args
 mut('hello', {
-  // @ts-expect-error: invalid named arg
   hello: 'hi',
   ...NamedArgsMarker,
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/outlet.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/outlet.test.ts
@@ -9,8 +9,8 @@ expectTypeOf(outlet('outlet-name')).toEqualTypeOf<void>();
 // Nameless main outlet
 outlet();
 
+// @ts-expect-error: unexpected named args
 outlet('outlet-name', {
-  // @ts-expect-error: invalid named arg
   hello: 'hi',
   ...NamedArgsMarker,
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/unbound.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/unbound.test.ts
@@ -10,8 +10,8 @@ expectTypeOf(unbound(123)).toEqualTypeOf<number>();
 // @ts-expect-error: missing value
 unbound();
 
+// @ts-expect-error: unexpected named args
 unbound('hello', {
-  // @ts-expect-error: invalid named arg
   hello: 'hi',
   ...NamedArgsMarker,
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/unique-id.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/unique-id.test.ts
@@ -6,8 +6,8 @@ let uniqueId = resolve(Globals['unique-id']);
 // Basic plumbing
 expectTypeOf(uniqueId()).toEqualTypeOf<string>();
 
+// @ts-expect-error: unexpected named args
 uniqueId({
-  // @ts-expect-error: invalid named arg
   hello: 'hi',
   ...NamedArgsMarker,
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/route-and-controller.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/route-and-controller.test.ts
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import Controller from '@ember/controller';
 import { expectTypeOf } from 'expect-type';
-import { EmptyObject } from '@glint/template/-private/integration';
 import { templateForBackingValue } from '../../-private/dsl';
 
 class TestRoute extends Route {
@@ -14,7 +13,7 @@ templateForBackingValue(TestRoute, function (routeContext) {
   expectTypeOf(routeContext.args).toEqualTypeOf<{ model: { message: string } }>();
   expectTypeOf(routeContext.element).toBeNull();
   expectTypeOf(routeContext.this).toEqualTypeOf<Controller & { model: { message: string } }>();
-  expectTypeOf(routeContext.blocks).toEqualTypeOf<EmptyObject>();
+  expectTypeOf(routeContext.blocks).toEqualTypeOf<{}>();
 });
 
 class TestController extends Controller {
@@ -29,5 +28,5 @@ templateForBackingValue(TestController, function (controllerContext) {
   expectTypeOf(controllerContext.args).toEqualTypeOf<{ model: { name: string; age: number } }>();
   expectTypeOf(controllerContext.element).toBeNull();
   expectTypeOf(controllerContext.this).toEqualTypeOf<TestController>();
-  expectTypeOf(controllerContext.blocks).toEqualTypeOf<EmptyObject>();
+  expectTypeOf(controllerContext.blocks).toEqualTypeOf<{}>();
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -13,14 +13,7 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
 {
   const NoArgsComponent = templateOnlyComponent();
 
-  resolve(NoArgsComponent)({
-    // @ts-expect-error: extra named arg
-    foo: 'bar',
-    ...NamedArgsMarker,
-  });
-
   resolve(NoArgsComponent)(
-    { ...NamedArgsMarker },
     // @ts-expect-error: extra positional arg
     'oops'
   );

--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -5,7 +5,7 @@ import {
   emitComponent,
   NamedArgsMarker,
 } from '@glint/environment-ember-loose/-private/dsl';
-import { ComponentReturn, EmptyObject, NamedArgs } from '@glint/template/-private/integration';
+import { ComponentReturn, NamedArgs } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
 import { ComponentKeyword } from '../../-private/intrinsics/component';
 import { ComponentLike, WithBoundArgs } from '@glint/template';
@@ -38,9 +38,9 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
 
   templateForBackingValue(NoArgsComponent, function (𝚪) {
     expectTypeOf(𝚪.this).toBeNull();
-    expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
     expectTypeOf(𝚪.element).toBeNull();
-    expectTypeOf(𝚪.blocks).toEqualTypeOf<EmptyObject>();
+    expectTypeOf(𝚪.args).toEqualTypeOf<{}>();
+    expectTypeOf(𝚪.blocks).toEqualTypeOf<{}>();
   });
 }
 
@@ -124,7 +124,7 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
 
   const CurriedWithNothing = resolve(componentKeyword)('curried-component');
   expectTypeOf(resolve(CurriedWithNothing)).toEqualTypeOf<
-    (args: NamedArgs<{ a: string; b: number }>) => ComponentReturn<EmptyObject>
+    (args: NamedArgs<{ a: string; b: number }>) => ComponentReturn<{}>
   >();
 
   const CurriedWithA = resolve(componentKeyword)('curried-component', {
@@ -132,7 +132,7 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
     ...NamedArgsMarker,
   });
   expectTypeOf(resolve(CurriedWithA)).toEqualTypeOf<
-    (args: NamedArgs<{ a?: string; b: number }>) => ComponentReturn<EmptyObject>
+    (args: NamedArgs<{ a?: string; b: number }>) => ComponentReturn<{}>
   >();
 }
 

--- a/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/template-only.test.ts
@@ -31,8 +31,8 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
 
   templateForBackingValue(NoArgsComponent, function (𝚪) {
     expectTypeOf(𝚪.this).toBeNull();
-    expectTypeOf(𝚪.element).toBeNull();
     expectTypeOf(𝚪.args).toEqualTypeOf<{}>();
+    expectTypeOf(𝚪.element).toBeUnknown();
     expectTypeOf(𝚪.blocks).toEqualTypeOf<{}>();
   });
 }

--- a/packages/environment-ember-template-imports/-private/dsl/index.d.ts
+++ b/packages/environment-ember-template-imports/-private/dsl/index.d.ts
@@ -9,7 +9,6 @@ import {
   AnyContext,
   AnyFunction,
   DirectInvokable,
-  EmptyObject,
   HasContext,
   InvokableInstance,
   Invoke,
@@ -38,8 +37,8 @@ export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;
 import { TemplateOnlyComponent } from '@ember/component/template-only';
 
 export declare function templateExpression<
-  Signature extends AnyFunction = () => ComponentReturn<EmptyObject>,
-  Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
+  Signature extends AnyFunction = () => ComponentReturn<{}>,
+  Context extends AnyContext = TemplateContext<void, {}, {}, void>
 >(
   f: (𝚪: Context, χ: never) => void
 ): TemplateOnlyComponent<never> &

--- a/packages/environment-glimmerx/-private/dsl/index.d.ts
+++ b/packages/environment-glimmerx/-private/dsl/index.d.ts
@@ -27,7 +27,6 @@ import {
   AnyContext,
   AnyFunction,
   DirectInvokable,
-  EmptyObject,
   HasContext,
   InvokableInstance,
   Invoke,
@@ -54,8 +53,8 @@ export declare const resolveOrReturn: ResolveOrReturn<typeof resolve>;
 import { TemplateComponentInstance } from '@glimmerx/component';
 
 export declare function templateExpression<
-  Signature extends AnyFunction = () => ComponentReturn<EmptyObject>,
-  Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
+  Signature extends AnyFunction = () => ComponentReturn<{}>,
+  Context extends AnyContext = TemplateContext<void, {}, {}, void>
 >(
   f: (𝚪: Context, χ: never) => void
 ): abstract new () => TemplateComponentInstance<never> &

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -167,7 +167,7 @@ import { ComponentReturn } from '@glint/template/-private/integration';
   let YieldingTC: TC<YieldingTCSignature> = templateExpression(function (𝚪) {
     expectTypeOf(𝚪.this).toEqualTypeOf(null);
     expectTypeOf(𝚪.args).toEqualTypeOf<{ values: Array<number> }>();
-    expectTypeOf(𝚪.element).toBeNull();
+    expectTypeOf(𝚪.element).toBeUnknown();
     expectTypeOf(𝚪.blocks).toEqualTypeOf<YieldingTCSignature['Blocks']>();
 
     if (𝚪.args.values.length) {

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -17,12 +17,6 @@ import { ComponentReturn } from '@glint/template/-private/integration';
     });
   }
 
-  resolve(NoArgsComponent)({
-    // @ts-expect-error: extra named arg
-    foo: 'bar',
-    ...NamedArgsMarker,
-  });
-
   resolve(NoArgsComponent)(
     // @ts-expect-error: bad positional arg
     'oops'

--- a/packages/environment-glimmerx/__tests__/component.test.ts
+++ b/packages/environment-glimmerx/__tests__/component.test.ts
@@ -8,7 +8,7 @@ import {
   NamedArgsMarker,
 } from '@glint/environment-glimmerx/-private/dsl';
 import { expectTypeOf } from 'expect-type';
-import { ComponentReturn, EmptyObject } from '@glint/template/-private/integration';
+import { ComponentReturn } from '@glint/template/-private/integration';
 
 {
   class NoArgsComponent extends Component {
@@ -47,7 +47,7 @@ import { ComponentReturn, EmptyObject } from '@glint/template/-private/integrati
     static template = templateForBackingValue(this, function (𝚪) {
       expectTypeOf(𝚪.this.foo).toEqualTypeOf<string>();
       expectTypeOf(𝚪.this).toEqualTypeOf<StatefulComponent>();
-      expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
+      expectTypeOf(𝚪.args).toEqualTypeOf<{}>();
     });
   }
 
@@ -152,11 +152,11 @@ import { ComponentReturn, EmptyObject } from '@glint/template/-private/integrati
   const NoAnnotationTC = templateExpression(function (𝚪) {
     expectTypeOf(𝚪.this).toBeVoid();
     expectTypeOf(𝚪.element).toBeVoid();
-    expectTypeOf(𝚪.args).toEqualTypeOf<EmptyObject>();
-    expectTypeOf(𝚪.blocks).toEqualTypeOf<EmptyObject>();
+    expectTypeOf(𝚪.args).toEqualTypeOf<{}>();
+    expectTypeOf(𝚪.blocks).toEqualTypeOf<{}>();
   });
 
-  expectTypeOf(resolve(NoAnnotationTC)).toEqualTypeOf<() => ComponentReturn<EmptyObject>>();
+  expectTypeOf(resolve(NoAnnotationTC)).toEqualTypeOf<() => ComponentReturn<{}>>();
 }
 
 {

--- a/packages/environment-glimmerx/__tests__/helper.test.ts
+++ b/packages/environment-glimmerx/__tests__/helper.test.ts
@@ -1,6 +1,6 @@
 import { emitContent, NamedArgsMarker, resolve } from '@glint/environment-glimmerx/-private/dsl';
 import { helper, fn as fnDefinition } from '@glimmerx/helper';
-import { EmptyObject, NamedArgs } from '@glint/template/-private/integration';
+import { NamedArgs } from '@glint/template/-private/integration';
 import { expectTypeOf } from 'expect-type';
 import '@glint/environment-glimmerx';
 
@@ -32,7 +32,7 @@ import '@glint/environment-glimmerx';
   let definition = helper(<T, U>([a, b]: [T, U]) => a || b);
   let or = resolve(definition);
 
-  expectTypeOf(or).toEqualTypeOf<{ <T, U>(t: T, u: U, named?: NamedArgs<EmptyObject>): T | U }>();
+  expectTypeOf(or).toEqualTypeOf<{ <T, U>(t: T, u: U): T | U }>();
 
   or('a', 'b', {
     // @ts-expect-error: extra named arg

--- a/packages/environment-glimmerx/__tests__/helper.test.ts
+++ b/packages/environment-glimmerx/__tests__/helper.test.ts
@@ -34,11 +34,12 @@ import '@glint/environment-glimmerx';
 
   expectTypeOf(or).toEqualTypeOf<{ <T, U>(t: T, u: U): T | U }>();
 
-  or('a', 'b', {
-    // @ts-expect-error: extra named arg
-    hello: true,
-    ...NamedArgsMarker,
-  });
+  or(
+    'a',
+    'b',
+    // @ts-expect-error: unexpected named args
+    { hello: true, ...NamedArgsMarker }
+  );
 
   // @ts-expect-error: missing positional arg
   or('a');

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -4,7 +4,6 @@ import {
   AnyContext,
   AnyFunction,
   ModifierReturn,
-  EmptyObject,
   HasContext,
   InvokableInstance,
   TemplateContext,
@@ -80,8 +79,8 @@ export declare function emitComponent<T extends ComponentReturn<any, any>>(
  * environment's DSL export.
  */
 export declare function templateExpression<
-  Signature extends AnyFunction = () => ComponentReturn<EmptyObject>,
-  Context extends AnyContext = TemplateContext<void, EmptyObject, EmptyObject, void>
+  Signature extends AnyFunction = () => ComponentReturn<{}>,
+  Context extends AnyContext = TemplateContext<void, {}, {}, void>
 >(f: (𝚪: Context, χ: never) => void): new () => InvokableInstance<Signature> & HasContext<Context>;
 
 /*

--- a/packages/template/-private/integration.d.ts
+++ b/packages/template/-private/integration.d.ts
@@ -6,9 +6,6 @@
 // `ComponentLike`/`HelperLike`/`ModifierLike`, but these declarations are
 // the primitives on which those types are built.
 
-declare const Empty: unique symbol;
-export type EmptyObject = { [Empty]?: true };
-
 /** Any function, which is the tighest bound we can put on an object's `[Invoke]` field. */
 export type AnyFunction = (...params: any) => any;
 

--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -2,7 +2,7 @@
 // in userspace into our internal representation of an invokable's
 // function type signature.
 
-import { EmptyObject, NamedArgs, UnwrapNamedArgs } from './integration';
+import { NamedArgs, UnwrapNamedArgs } from './integration';
 
 /**
  * Given an "args hash" (e.g. `{ Named: {...}; Positional: [...] }`),
@@ -10,7 +10,7 @@ import { EmptyObject, NamedArgs, UnwrapNamedArgs } from './integration';
  */
 export type InvokableArgs<Args> = [
   ...positional: Constrain<Get<Args, 'Positional'>, Array<unknown>, []>,
-  ...named: MaybeNamed<NamedArgs<GuardEmpty<Get<Args, 'Named'>>>>
+  ...named: MaybeNamed<NamedArgs<Get<Args, 'Named'>>>
 ];
 
 /** Given a signature `S`, get back the normalized `Args` type. */
@@ -22,7 +22,7 @@ export type ComponentSignatureArgs<S> = S extends {
       Positional?: unknown[];
     }
     ? {
-        Named: Get<S['Args'], 'Named', EmptyObject>;
+        Named: Get<S['Args'], 'Named', {}>;
         Positional: Get<S['Args'], 'Positional', []>;
       }
     : {
@@ -30,7 +30,7 @@ export type ComponentSignatureArgs<S> = S extends {
         Positional: [];
       }
   : {
-      Named: keyof S extends 'Args' | 'Blocks' | 'Element' ? EmptyObject : S;
+      Named: keyof S extends 'Args' | 'Blocks' | 'Element' ? {} : S;
       Positional: [];
     };
 
@@ -41,15 +41,10 @@ export type ComponentSignatureBlocks<S> = S extends { Blocks: infer Blocks }
         ? { Params: { Positional: Blocks[Block] } }
         : Blocks[Block];
     }
-  : EmptyObject;
+  : {};
 
 /** Given a component signature `S`, get back the `Element` type. */
 export type ComponentSignatureElement<S> = S extends { Element: infer Element } ? Element : null;
-
-// These shenanigans are necessary to get TS to report when named args
-// are passed to a signature that doesn't expect any, because `{}` is
-// special-cased in the type system not to trigger EPC.
-export type GuardEmpty<T> = T extends any ? (keyof T extends never ? EmptyObject : T) : never;
 
 export type PrebindArgs<T, Args extends keyof UnwrapNamedArgs<T>> = NamedArgs<
   Omit<UnwrapNamedArgs<T>, Args> & Partial<Pick<UnwrapNamedArgs<T>, Args>>

--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -50,7 +50,11 @@ export type PrebindArgs<T, Args extends keyof UnwrapNamedArgs<T>> = NamedArgs<
   Omit<UnwrapNamedArgs<T>, Args> & Partial<Pick<UnwrapNamedArgs<T>, Args>>
 >;
 
-export type MaybeNamed<T> = {} extends UnwrapNamedArgs<T> ? [named?: T] : [named: T];
+export type MaybeNamed<T> = {} extends UnwrapNamedArgs<T>
+  ? keyof UnwrapNamedArgs<T> extends never
+    ? []
+    : [named?: T]
+  : [named: T];
 
 export type Get<T, K, Otherwise = unknown> = K extends keyof T ? T[K] : Otherwise;
 export type Constrain<T, Constraint, Otherwise = Constraint> = T extends Constraint ? T : Otherwise;

--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -44,7 +44,11 @@ export type ComponentSignatureBlocks<S> = S extends { Blocks: infer Blocks }
   : {};
 
 /** Given a component signature `S`, get back the `Element` type. */
-export type ComponentSignatureElement<S> = S extends { Element: infer Element } ? Element : null;
+export type ComponentSignatureElement<S> = S extends { Element: infer Element }
+  ? NonNullable<Element> extends never
+    ? unknown
+    : Element
+  : unknown;
 
 export type PrebindArgs<T, Args extends keyof UnwrapNamedArgs<T>> = NamedArgs<
   Omit<UnwrapNamedArgs<T>, Args> & Partial<Pick<UnwrapNamedArgs<T>, Args>>

--- a/packages/template/__tests__/component-like.test.ts
+++ b/packages/template/__tests__/component-like.test.ts
@@ -6,16 +6,10 @@ import { ComponentReturn, NamedArgs } from '../-private/integration';
 {
   const NoArgsComponent = {} as ComponentLike<{}>;
 
+  // @ts-expect-error: extra arg
   resolve(NoArgsComponent)({
-    // @ts-expect-error: extra named arg
-    foo: 'bar',
     ...NamedArgsMarker,
   });
-
-  resolve(NoArgsComponent)(
-    // @ts-expect-error: extra positional arg
-    'oops'
-  );
 
   {
     const component = emitComponent(resolve(NoArgsComponent)());
@@ -103,7 +97,7 @@ import { ComponentReturn, NamedArgs } from '../-private/integration';
   const PositionalArgsComponent = {} as ComponentLike<PositionalArgsComponentSignature>;
 
   // @ts-expect-error: missing required positional arg
-  resolve(PositionalArgsComponent)();
+  resolve(PositionalArgsComponent)({ ...NamedArgsMarker });
 
   resolve(PositionalArgsComponent)(
     'hello',

--- a/packages/template/__tests__/component-like.test.ts
+++ b/packages/template/__tests__/component-like.test.ts
@@ -2,6 +2,7 @@ import { ComponentLike, WithBoundArgs } from '@glint/template';
 import { resolve, emitComponent, NamedArgsMarker } from '@glint/template/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { ComponentReturn, NamedArgs } from '../-private/integration';
+import TestComponent from './test-component';
 
 {
   const NoArgsComponent = {} as ComponentLike<{}>;
@@ -130,5 +131,82 @@ import { ComponentReturn, NamedArgs } from '../-private/integration';
     (
       args: NamedArgs<{ foo?: string; bar: number }>
     ) => ComponentReturn<{ default: [] }, HTMLCanvasElement>
+  >();
+}
+
+// Assignability
+{
+  // A component with no signaure is a `ComponentLike` with no signature
+  expectTypeOf(TestComponent<{}>).toMatchTypeOf<ComponentLike>();
+
+  // A component whose args are all optional is a `ComponentLike` with no signature
+  expectTypeOf(TestComponent<{ Args: { optional?: true } }>).toMatchTypeOf<ComponentLike>();
+
+  // A component with a required arg can't be used as a blank `ComponentLike`
+  expectTypeOf(TestComponent<{ Args: { optional: false } }>).not.toMatchTypeOf<ComponentLike>();
+
+  // A component that yields a given block can be used without ever passing any blocks
+  expectTypeOf(TestComponent<{ Blocks: { default: [string] } }>).toMatchTypeOf<ComponentLike>();
+
+  // A component that yields specific args can be used as one that cares about fewer of them
+  expectTypeOf(TestComponent<{ Blocks: { default: [string, number] } }>).toMatchTypeOf<
+    ComponentLike<{ Blocks: { default: [string, ...unknown[]] } }>
+  >();
+
+  // A component that never yields can't be used as one that accepts a specific block
+  expectTypeOf(TestComponent).not.toMatchTypeOf<ComponentLike<{ Blocks: { default: [] } }>>();
+
+  // `T | null` is useful to humans to signify that a component might splat its ...attributes,
+  // but from a type perspective it's just the same as `T`
+  expectTypeOf<ComponentLike<{ Element: HTMLDivElement | null }>>().toEqualTypeOf<
+    ComponentLike<{ Element: HTMLDivElement }>
+  >();
+
+  // Our canonical internal representation of a no-splattributes component's `Element` is `unknown`
+  expectTypeOf<ComponentLike>().toEqualTypeOf<ComponentLike<{ Element: unknown }>>();
+  expectTypeOf<ComponentLike<{ Element: null }>>().toEqualTypeOf<
+    ComponentLike<{ Element: unknown }>
+  >();
+
+  // A component with all-optional args and any arbitrary element/blocks should be usable
+  // as a blank `ComponentLike`.
+  expectTypeOf(
+    TestComponent<{
+      Args: { foo?: string };
+      Element: HTMLImageElement;
+      Blocks: { default: [] };
+    }>
+  ).toMatchTypeOf<ComponentLike>();
+
+  // Components are contravariant with their named `Args` type
+  expectTypeOf<ComponentLike<{ Args: { name: string } }>>().toMatchTypeOf<
+    ComponentLike<{ Args: { name: 'Dan' } }>
+  >();
+  expectTypeOf<ComponentLike<{ Args: { name: 'Dan' } }>>().not.toMatchTypeOf<
+    ComponentLike<{ Args: { name: string } }>
+  >();
+
+  // Components are contravariant with their positional `Args` type
+  expectTypeOf<ComponentLike<{ Args: { Positional: [name: string] } }>>().toMatchTypeOf<
+    ComponentLike<{ Args: { Positional: [name: 'Dan'] } }>
+  >();
+  expectTypeOf<ComponentLike<{ Args: { Positional: [name: 'Dan'] } }>>().not.toMatchTypeOf<
+    ComponentLike<{ Args: { Positional: [name: string] } }>
+  >();
+
+  // Components are covariant with their `Element` type
+  expectTypeOf<ComponentLike<{ Element: HTMLAudioElement }>>().toMatchTypeOf<
+    ComponentLike<{ Element: HTMLElement }>
+  >();
+  expectTypeOf<ComponentLike<{ Element: HTMLElement }>>().not.toMatchTypeOf<
+    ComponentLike<{ Element: HTMLAudioElement }>
+  >();
+
+  // Components are covariant with their `Blocks`' `Params` types
+  expectTypeOf(TestComponent<{ Blocks: { default: ['abc', 123] } }>).toMatchTypeOf<
+    ComponentLike<{ Blocks: { default: [string, number] } }>
+  >();
+  expectTypeOf(TestComponent<{ Blocks: { default: [string, number] } }>).not.toMatchTypeOf<
+    ComponentLike<{ Blocks: { default: ['abc', 123] } }>
   >();
 }

--- a/packages/template/__tests__/helper-like.test.ts
+++ b/packages/template/__tests__/helper-like.test.ts
@@ -81,3 +81,30 @@ import { NamedArgs } from '../-private/integration';
     (args: NamedArgs<{ age: number; name?: string }>) => string
   >();
 }
+
+// Assignability
+{
+  // Helpers are contravariant with their named `Args` type
+  expectTypeOf<HelperLike<{ Args: { Named: { name: string } } }>>().toMatchTypeOf<
+    HelperLike<{ Args: { Named: { name: 'Dan' } } }>
+  >();
+  expectTypeOf<HelperLike<{ Args: { Named: { name: 'Dan' } } }>>().not.toMatchTypeOf<
+    HelperLike<{ Args: { Named: { name: string } } }>
+  >();
+
+  // Helpers are contravariant with their positional `Args` type
+  expectTypeOf<HelperLike<{ Args: { Positional: [name: string] } }>>().toMatchTypeOf<
+    HelperLike<{ Args: { Positional: [name: 'Dan'] } }>
+  >();
+  expectTypeOf<HelperLike<{ Args: { Positional: [name: 'Dan'] } }>>().not.toMatchTypeOf<
+    HelperLike<{ Args: { Positional: [name: string] } }>
+  >();
+
+  // Helpers are contravariant with their `Element` type
+  expectTypeOf<HelperLike<{ Return: 'Hello, World' }>>().toMatchTypeOf<
+    HelperLike<{ Return: string }>
+  >();
+  expectTypeOf<HelperLike<{ Return: string }>>().not.toMatchTypeOf<
+    HelperLike<{ Return: 'Hello, World' }>
+  >();
+}

--- a/packages/template/__tests__/helper-like.test.ts
+++ b/packages/template/__tests__/helper-like.test.ts
@@ -59,9 +59,8 @@ import { NamedArgs } from '../-private/integration';
   or(
     'a',
     'b',
-    'c',
     // @ts-expect-error: extra positional arg
-    { ...NamedArgsMarker }
+    'c'
   );
 
   expectTypeOf(or('a', 'b')).toEqualTypeOf<string>();

--- a/packages/template/__tests__/helper-like.test.ts
+++ b/packages/template/__tests__/helper-like.test.ts
@@ -1,7 +1,7 @@
 import { NamedArgsMarker, resolve } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { HelperLike, WithBoundArgs } from '@glint/template';
-import { EmptyObject, NamedArgs } from '../-private/integration';
+import { NamedArgs } from '../-private/integration';
 
 // Fixed signature params
 {
@@ -54,13 +54,7 @@ import { EmptyObject, NamedArgs } from '../-private/integration';
   let definition!: new <T, U>() => InstanceType<HelperLike<GenericSignature<T, U>>>;
   let or = resolve(definition);
 
-  expectTypeOf(or).toEqualTypeOf<{ <T, U>(t: T, u: U, args?: NamedArgs<EmptyObject>): T | U }>();
-
-  or('a', 'b', {
-    // @ts-expect-error: extra named arg
-    hello: true,
-    ...NamedArgsMarker,
-  });
+  expectTypeOf(or).toEqualTypeOf<{ <T, U>(t: T, u: U): T | U }>();
 
   or(
     'a',

--- a/packages/template/__tests__/modifier-like.test.ts
+++ b/packages/template/__tests__/modifier-like.test.ts
@@ -96,3 +96,30 @@ import { ModifierLike, WithBoundArgs } from '@glint/template';
     ) => ModifierReturn
   >();
 }
+
+// Assignability
+{
+  // Modifiers are contravariant with their named `Args` type
+  expectTypeOf<ModifierLike<{ Args: { Named: { name: string } } }>>().toMatchTypeOf<
+    ModifierLike<{ Args: { Named: { name: 'Dan' } } }>
+  >();
+  expectTypeOf<ModifierLike<{ Args: { Named: { name: 'Dan' } } }>>().not.toMatchTypeOf<
+    ModifierLike<{ Args: { Named: { name: string } } }>
+  >();
+
+  // Modifiers are contravariant with their positional `Args` type
+  expectTypeOf<ModifierLike<{ Args: { Positional: [name: string] } }>>().toMatchTypeOf<
+    ModifierLike<{ Args: { Positional: [name: 'Dan'] } }>
+  >();
+  expectTypeOf<ModifierLike<{ Args: { Positional: [name: 'Dan'] } }>>().not.toMatchTypeOf<
+    ModifierLike<{ Args: { Positional: [name: string] } }>
+  >();
+
+  // Modifiers are contravariant with their `Element` type
+  expectTypeOf<ModifierLike<{ Element: HTMLElement }>>().toMatchTypeOf<
+    ModifierLike<{ Element: HTMLAudioElement }>
+  >();
+  expectTypeOf<ModifierLike<{ Element: HTMLAudioElement }>>().not.toMatchTypeOf<
+    ModifierLike<{ Element: HTMLElement }>
+  >();
+}

--- a/packages/template/__tests__/signature-test.test.ts
+++ b/packages/template/__tests__/signature-test.test.ts
@@ -13,8 +13,8 @@ expectTypeOf<ComponentSignatureArgs<LegacyArgs>>().toEqualTypeOf<{
   Named: LegacyArgs;
   Positional: [];
 }>();
-expectTypeOf<ComponentSignatureElement<LegacyArgs>>().toEqualTypeOf<null>();
 expectTypeOf<ComponentSignatureBlocks<LegacyArgs>>().toEqualTypeOf<{}>();
+expectTypeOf<ComponentSignatureElement<LegacyArgs>>().toEqualTypeOf<unknown>();
 
 // Here, we are testing that the types propertly distribute over union types,
 // generics which extend other types, etc.
@@ -24,8 +24,8 @@ expectTypeOf<ComponentSignatureArgs<LegacyArgsDistributive>>().toEqualTypeOf<
   | { Named: { foo: number }; Positional: [] }
   | { Named: { bar: string; baz: boolean }; Positional: [] }
 >();
-expectTypeOf<ComponentSignatureElement<LegacyArgsDistributive>>().toEqualTypeOf<null>();
 expectTypeOf<ComponentSignatureBlocks<LegacyArgsDistributive>>().toEqualTypeOf<{}>();
+expectTypeOf<ComponentSignatureElement<LegacyArgsDistributive>>().toEqualTypeOf<unknown>();
 
 interface ArgsOnly {
   Args: LegacyArgs;
@@ -35,8 +35,8 @@ expectTypeOf<ComponentSignatureArgs<ArgsOnly>>().toEqualTypeOf<{
   Named: LegacyArgs;
   Positional: [];
 }>();
-expectTypeOf<ComponentSignatureElement<ArgsOnly>>().toEqualTypeOf<null>();
 expectTypeOf<ComponentSignatureBlocks<ArgsOnly>>().toEqualTypeOf<{}>();
+expectTypeOf<ComponentSignatureElement<ArgsOnly>>().toEqualTypeOf<unknown>();
 
 interface ElementOnly {
   Element: HTMLParagraphElement;
@@ -74,7 +74,7 @@ expectTypeOf<ComponentSignatureBlocks<BlockOnlySig>>().toEqualTypeOf<{
     };
   };
 }>();
-expectTypeOf<ComponentSignatureElement<BlockOnlySig>>().toEqualTypeOf<null>();
+expectTypeOf<ComponentSignatureElement<BlockOnlySig>>().toEqualTypeOf<unknown>();
 
 interface ArgsAndBlocks {
   Args: LegacyArgs;
@@ -97,7 +97,7 @@ expectTypeOf<ComponentSignatureBlocks<ArgsAndBlocks>>().toEqualTypeOf<{
     };
   };
 }>();
-expectTypeOf<ComponentSignatureElement<ArgsAndBlocks>>().toEqualTypeOf<null>();
+expectTypeOf<ComponentSignatureElement<ArgsAndBlocks>>().toEqualTypeOf<unknown>();
 
 interface ArgsAndEl {
   Args: LegacyArgs;

--- a/packages/template/__tests__/signature-test.test.ts
+++ b/packages/template/__tests__/signature-test.test.ts
@@ -1,5 +1,4 @@
 import { expectTypeOf } from 'expect-type';
-import { EmptyObject } from '../-private/integration';
 import {
   ComponentSignatureArgs,
   ComponentSignatureBlocks,
@@ -14,8 +13,8 @@ expectTypeOf<ComponentSignatureArgs<LegacyArgs>>().toEqualTypeOf<{
   Named: LegacyArgs;
   Positional: [];
 }>();
-expectTypeOf<ComponentSignatureBlocks<LegacyArgs>>().toEqualTypeOf<EmptyObject>();
 expectTypeOf<ComponentSignatureElement<LegacyArgs>>().toEqualTypeOf<null>();
+expectTypeOf<ComponentSignatureBlocks<LegacyArgs>>().toEqualTypeOf<{}>();
 
 // Here, we are testing that the types propertly distribute over union types,
 // generics which extend other types, etc.
@@ -25,8 +24,8 @@ expectTypeOf<ComponentSignatureArgs<LegacyArgsDistributive>>().toEqualTypeOf<
   | { Named: { foo: number }; Positional: [] }
   | { Named: { bar: string; baz: boolean }; Positional: [] }
 >();
-expectTypeOf<ComponentSignatureBlocks<LegacyArgsDistributive>>().toEqualTypeOf<EmptyObject>();
 expectTypeOf<ComponentSignatureElement<LegacyArgsDistributive>>().toEqualTypeOf<null>();
+expectTypeOf<ComponentSignatureBlocks<LegacyArgsDistributive>>().toEqualTypeOf<{}>();
 
 interface ArgsOnly {
   Args: LegacyArgs;
@@ -36,18 +35,18 @@ expectTypeOf<ComponentSignatureArgs<ArgsOnly>>().toEqualTypeOf<{
   Named: LegacyArgs;
   Positional: [];
 }>();
-expectTypeOf<ComponentSignatureBlocks<ArgsOnly>>().toEqualTypeOf<EmptyObject>();
 expectTypeOf<ComponentSignatureElement<ArgsOnly>>().toEqualTypeOf<null>();
+expectTypeOf<ComponentSignatureBlocks<ArgsOnly>>().toEqualTypeOf<{}>();
 
 interface ElementOnly {
   Element: HTMLParagraphElement;
 }
 
 expectTypeOf<ComponentSignatureArgs<ElementOnly>>().toEqualTypeOf<{
-  Named: EmptyObject;
+  Named: {};
   Positional: [];
 }>();
-expectTypeOf<ComponentSignatureBlocks<ElementOnly>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureBlocks<ElementOnly>>().toEqualTypeOf<{}>();
 expectTypeOf<ComponentSignatureElement<ElementOnly>>().toEqualTypeOf<HTMLParagraphElement>();
 
 interface Blocks {
@@ -60,7 +59,7 @@ interface BlockOnlySig {
 }
 
 expectTypeOf<ComponentSignatureArgs<BlockOnlySig>>().toEqualTypeOf<{
-  Named: EmptyObject;
+  Named: {};
   Positional: [];
 }>();
 expectTypeOf<ComponentSignatureBlocks<BlockOnlySig>>().toEqualTypeOf<{
@@ -109,7 +108,7 @@ expectTypeOf<ComponentSignatureArgs<ArgsAndEl>>().toEqualTypeOf<{
   Named: LegacyArgs;
   Positional: [];
 }>();
-expectTypeOf<ComponentSignatureBlocks<ArgsAndEl>>().toEqualTypeOf<EmptyObject>();
+expectTypeOf<ComponentSignatureBlocks<ArgsAndEl>>().toEqualTypeOf<{}>();
 expectTypeOf<ComponentSignatureElement<ArgsAndEl>>().toEqualTypeOf<HTMLParagraphElement>();
 
 interface FullShortSig {

--- a/packages/template/__tests__/test-component.ts
+++ b/packages/template/__tests__/test-component.ts
@@ -3,7 +3,7 @@
 // well as simple examples of a helper and modifier.
 
 import { ComponentLike, ModifierLike } from '../-private/index';
-import { Context, EmptyObject, TemplateContext } from '../-private/integration';
+import { Context, TemplateContext } from '../-private/integration';
 import { LetKeyword } from '../-private/keywords';
 
 export default TestComponent;
@@ -19,7 +19,7 @@ export declare const globals: {
   >;
 };
 
-type Get<T, K, Otherwise = EmptyObject> = K extends keyof T ? Exclude<T[K], undefined> : Otherwise;
+type Get<T, K, Otherwise = {}> = K extends keyof T ? Exclude<T[K], undefined> : Otherwise;
 
 interface TestComponent<T = {}> extends InstanceType<ComponentLike<T>> {}
 declare class TestComponent<T = {}> {

--- a/test-packages/ts-ember-app/tests/integration/types/empty-signature-test.ts
+++ b/test-packages/ts-ember-app/tests/integration/types/empty-signature-test.ts
@@ -27,8 +27,8 @@ module('Integration | Types | empty object signature members', function (hooks) 
         <:named></:named>
       </this.component>
 
-       <this.component
-        {{! @glint-expect-error: shouldn't accept args }}
+      {{! @glint-expect-error: shouldn't accept args }}
+      <this.component
         @foo="hi"
       />
     `);


### PR DESCRIPTION
## Background

Now that we've [overhauled `[Invoke]`](https://github.com/typed-ember/glint/pull/447) to have a simpler internal representation, we're better positioned to ensure that various `ComponentLike` values property reflects the real-world subtyping relationship between their types.

As a concrete example, a value with the bare `ComponentLike` type represents a component that can be invoked with no args, no blocks, and no modifiers. Given a definition like this:

```ts
class MyComponent extends Component<{
  Args: { name?: string };
  Element: HTMLImageElement;
  Blocks: { default: [] };
}> {}
```

The value `MyComponent` should be assignable to `ComponentLike`, because it _is_ legal to invoke without passing any args, blocks or modifiers.

If, however, the `name` arg were _not_ optional, then `MyComponent` should no longer be assignable to `ComponentLike`, as it would no longer be legal to invoke without any arguments.

The goal of this PR is to capture this and similar intuitions about the subtyping relationship between `ComponentLike`, `HelperLike` and `ModifierLike` values in the type system, and to put tests in place to ensure we maintain those relationships moving forward.

## Details

The steps taken for this change also had a couple of side effects that were nice in their own right.

First, landing #447 meant we no longer need the `EmptyObject` type, because now when an entity accepts no named args, we just don't include a parameter for them in `[Invoke]` at all, so we no longer need to worry about triggering EPC for `{}` cases.

Removing `EmptyObject` also, in an ouroboric way, enabled us to clean up the last place where we _did_ create a parameter unnecessarily for named args in `InvokableArgs`. This site was already EPC-enabled even without `EmptyObject` because of the `NamedArgs` wrapper, but it's nice not to have the parameter at all.

These two changes together ensure that the pairwise subtyping relationship between `Args` and `Blocks` works as expected, leaving only `Element`.

Internally we've used the same `null` marker as the public signature type does to represent the element of a component that never spreads its `...attributes`. This doesn't work for assignability purposes, as we want a component that _does_ spread `...attributes` on a particular element type to be usable in a context where we aren't going to bother passing attributes or modifiers. Accordingly, we now use `unknown` internally for this scenario.