### PR TITLE
Support the `ShowIR` command for non-`.ts` files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "Debug Extension",
-      "type": "pwa-extensionHost",
+      "type": "extensionHost",
       "request": "launch",
       "preLaunchTask": "npm: build",
       "autoAttachChildProcesses": true,

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -25,6 +25,7 @@ import {
   tagsForDiagnostic,
 } from './util/protocol.js';
 import { TextEdit } from 'vscode-languageserver-textdocument';
+import { GetIRResult } from './messages.js';
 
 export interface GlintCompletionItem extends CompletionItem {
   data: {
@@ -347,12 +348,16 @@ export default class GlintLanguageServer {
     return this.calculateOriginalLocations(references);
   }
 
-  public getTransformedContents(uri: string): string | null {
+  public getTransformedContents(uri: string): GetIRResult | undefined {
     let filePath = uriToFilePath(uri);
     let source = this.findDiagnosticsSource(filePath);
-    if (source !== filePath) return null;
+    if (!source) return;
 
-    return this.transformManager.readTransformedFile(filePath) ?? null;
+    let contents = this.transformManager.readTransformedFile(source);
+    if (contents) {
+      let uri = filePathToUri(this.documents.getCanonicalDocumentPath(source));
+      return { uri, contents };
+    }
   }
 
   private calculateOriginalLocations(spans: ReadonlyArray<ts.DocumentSpan>): Array<Location> {

--- a/packages/core/src/language-server/messages.ts
+++ b/packages/core/src/language-server/messages.ts
@@ -7,10 +7,15 @@ export type Request<Name extends string, T> = {
 
 export const GetIRRequest = makeRequestType(
   'glint/getIR',
-  ProtocolRequestType<GetIRParams, string | null, void, void, void>
+  ProtocolRequestType<GetIRParams, GetIRResult | null, void, void, void>
 );
 
 export interface GetIRParams {
+  uri: string;
+}
+
+export interface GetIRResult {
+  contents: string;
   uri: string;
 }
 

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -25,7 +25,7 @@ describe('Smoke test: Ember', () => {
   });
 
   describe('debugging commands', () => {
-    test('showing IR', async () => {
+    test('showing IR in the backing file', async () => {
       let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
       let editor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
 
@@ -33,6 +33,18 @@ describe('Smoke test: Ember', () => {
       await waitUntil(() => editor.document.getText().includes('𝚪'));
 
       expect(editor.document.getText()).toMatch('𝚪.this.message');
+    });
+
+    test('showing IR from a template', async () => {
+      let templateURI = Uri.file(`${rootDir}/app/components/colocated-layout.hbs`);
+      let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
+
+      await window.showTextDocument(templateURI, { viewColumn: ViewColumn.One });
+      await commands.executeCommand('glint.show-debug-ir');
+      await waitUntil(() => window.activeTextEditor?.document.getText().includes('𝚪'));
+
+      expect(window.activeTextEditor?.document.uri.toString()).toEqual(scriptURI.toString());
+      expect(window.activeTextEditor?.document.getText()).toMatch('𝚪.this.message');
     });
   });
 

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -39,5 +39,17 @@ describe('Smoke test: ETI Environment', () => {
         },
       ]);
     });
+
+    describe('debugging commands', () => {
+      test('showing IR in a custom file type', async () => {
+        let scriptURI = Uri.file(`${rootDir}/src/Greeting.gts`);
+        let editor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
+
+        await commands.executeCommand('glint.show-debug-ir');
+        await waitUntil(() => editor.document.getText().includes('𝚪'));
+
+        expect(editor.document.getText()).toMatch('𝚪.this.message');
+      });
+    });
   });
 });


### PR DESCRIPTION
We don't document this command anywhere public and make no guarantees about its functionality (or even continued existence), but since we're bundling up breaking changes anyway, I'm taking this opportunity to tweak the message format we use for asking the language service about the transformed contents of a file. This allows the command to work in `.gts` files, and if you run it in a `.hbs` file, you'll now be taken to the backing module instead.