### PR TITLE
Add migration notes for 0.9 => 1.0

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -39,13 +39,15 @@ Glint 1.0 drops support for the `transform` configuration key, which is where `i
 earlier iteration of Glint.
 
 If you're currently relying on these keys to have Glint skip typechecking for parts of your
-codebase, consider using `@glint-nocheck` directives instead. You can automate the process of
-adding those directives to templates that have type errors using the [`glint-auto-nocheck`] script.
+codebase, consider using [`@glint-nocheck` directives][nocheck] instead. You can automate the
+process of adding those directives to templates that have type errors using the
+[`glint-auto-nocheck`] script.
 
 Note that templates with a `@glint-nocheck` directive will benefit from best-effort editor support
 for features such as hover information, go-to-definition, etc. even if they aren't typesafe,
 which is a meaningful advantage over templates that were ignored via `include`/`exclude`.
 
+[nocheck]: ../docs/directives.md#glint-nocheck
 [`glint-auto-nocheck`]: https://github.com/typed-ember/glint/tree/main/packages/scripts#auto-glint-nocheck
 
 ### Tagged Strings in `ember-template-imports`

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,5 +1,82 @@
 # Migrating
 
+## Glint 0.9.x to 1.0
+
+{% hint style="warning" %}
+
+Glint 1.0 is currently in a beta period. We encourage you to try out the beta and report any
+issues you run into. While we don't anticipate landing any further breaking changes during the beta
+cycle, be aware that it's still possible we'll do so in response to bugs or other early feedback.
+
+{% endhint %}
+
+Most of the changes in Glint 1.0 should appear as bugfixes and improvements to the majority of 
+users migrating from 0.9.x.
+
+The main change to be aware of is that **`@glint/template` should now be explicitly added to your
+project's `devDependencies`** when you upgrade Glint. Note also that support for `include` and
+`exclude` globs has been removed.
+
+More details about these and other breaking changes are laid out below.
+
+### `@glint/template` Peer
+
+For Glint to work properly, there must be exactly one common copy of `@glint/template` present
+in your dependency hierarchy. This has been true throughout our 0.x releases, but as of 1.0
+we're making that explicit by marking `@glint/template` as a `peerDependency` of our environment
+packages rather than a hard `dependency`.
+
+Accordingly, you will need to add `@glint/template` to your project's own dependencies list
+alongside `@glint/core` and your environment package(s).
+
+Note also that if you publish an addon that depends on types from `@glint/template`, that addon
+should likewise declare a `peerDependency` on `@glint/template` and **not** a regular `dependency`.
+
+### `include`/`exclude` Configuration
+
+Glint 1.0 drops support for the `transform` configuration key, which is where `include` and
+`exclude` globs were previously specified. These options were a blunt instrument left over from an
+earlier iteration of Glint.
+
+If you're currently relying on these keys to have Glint skip typechecking for parts of your
+codebase, consider using `@glint-nocheck` directives instead. You can automate the process of
+adding those directives to templates that have type errors using the [`glint-auto-nocheck`] script.
+
+Note that templates with a `@glint-nocheck` directive will benefit from best-effort editor support
+for features such as hover information, go-to-definition, etc. even if they aren't typesafe,
+which is a meaningful advantage over templates that were ignored via `include`/`exclude`.
+
+[`glint-auto-nocheck`]: https://github.com/typed-ember/glint/tree/main/packages/scripts#auto-glint-nocheck
+
+### Tagged Strings in `ember-template-imports`
+
+Since `<template>` [has been been selected][fccts] as the path forward for template imports (a.k.a
+strict mode) in Ember, the `hbs` string tag from `ember-template-imports` is no longer treated as
+a template marker by `@glint/environment-ember-template-imports`. This also aligns with the intent
+to [deprecate `hbs`][eti-no-more-hbs] in `ember-template-imports` itself.
+
+Projects using `ember-template-imports` will need to migrate to `<template>` in order to upgrade to
+Glint 1.0, as any remaining `hbs`-tagged templates will be treated as simple strings.
+
+[fccts]: https://rfcs.emberjs.com/id/0779-first-class-component-templates/
+[eti-no-more-hbs]: https://github.com/ember-template-imports/ember-template-imports/pull/18#issuecomment-1311185752
+
+### Internal Type Updates
+
+Between 0.9.x and 1.0, several updates landed to rework how Glint internally represents the types
+of many template entities. For end users, this should result in simpler error messages, better
+support for "plain-function" helpers, and more sensible assignability rules when working with types
+like `ComponentLike<...>`.
+
+This change also resulted in Glint (correctly!) flagging some new type errors that might previously
+have been missed. One notable case of this is with Ember's `{{on}}` modifier, which in prior
+versions would accept a callback that required a more specific `Event` subtype than was actually
+appropriate based on the event being listened to.
+
+Finally, note that this change is almost guaranteed to break most usage of private Glint types
+from the template layer. If you've been using private APIs in 0.9.x, you'll likely need to update
+that usage to be compatible with 1.0.
+
 ## Glint 0.8.x to 0.9.x
 
 Glint 0.9 removes support for the `.glintrc.yml` file, moving configuration into your project's `tsconfig.json` or

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
     "release-it": "^15.5.0",
     "typescript": "^4.7.4"
   },
+  "resolutions:notes": {
+    "@types/yargs": "Locking temporarily to avoid an issue with the ESM types in 17.0.14; see DT#63373"
+  },
   "resolutions": {
+    "@types/yargs": "17.0.13",
     "ember-cli-htmlbars": "^6.0.1"
   },
   "version": "0.9.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,14 +2737,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
-"@types/yargs@^15.0.0":
-  version "15.0.14"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
-  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^17.0.10":
+"@types/yargs@17.0.13", "@types/yargs@^15.0.0", "@types/yargs@^17.0.10":
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.13.tgz#34cced675ca1b1d51fcf4d34c3c6f0fa142a5c76"
   integrity sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==


### PR DESCRIPTION
I'll plan to link to this page from the `1.0.0-beta.1` release note. We can update with any further changes as needed during the beta cycle, and then I'll drop the beta disclaimer when we release `1.0.0` stable!