### PR TITLE
Disable anti-classic ESLint rules for `ts-ember-preview-types` test package

### DIFF
--- a/test-packages/ts-ember-preview-types/.eslintrc.js
+++ b/test-packages/ts-ember-preview-types/.eslintrc.js
@@ -22,6 +22,8 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/no-empty-interface': 'off',
+    'ember/no-classic-components': 'off',
+    'ember/require-tagless-components': 'off',
   },
   overrides: [
     // node files

--- a/test-packages/ts-ember-preview-types/app/components/bar/index.ts
+++ b/test-packages/ts-ember-preview-types/app/components/bar/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line ember/no-classic-components
 import Component from '@ember/component';
 
 export interface BarSignature {
@@ -7,7 +6,6 @@ export interface BarSignature {
   };
 }
 
-// eslint-disable-next-line ember/require-tagless-components
 export default class Bar extends Component<BarSignature> {
   name = 'BAR';
 }

--- a/test-packages/ts-ember-preview-types/app/components/ember-component.ts
+++ b/test-packages/ts-ember-preview-types/app/components/ember-component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from '@ember/component';
 
 export interface EmberComponentArgs {

--- a/test-packages/ts-ember-preview-types/app/components/foo.ts
+++ b/test-packages/ts-ember-preview-types/app/components/foo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from '@ember/component';
 import { ComponentLike } from '@glint/template';
 

--- a/test-packages/ts-ember-preview-types/app/components/qux.ts
+++ b/test-packages/ts-ember-preview-types/app/components/qux.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from '@ember/component';
 
 export default class Qux extends Component {

--- a/test-packages/ts-ember-preview-types/app/components/test-cases/subclassing/parent.ts
+++ b/test-packages/ts-ember-preview-types/app/components/test-cases/subclassing/parent.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-classic-components
 import Component from '@ember/component';
 
-// eslint-disable-next-line ember/require-tagless-components
 export default class ParentClass extends Component {}

--- a/test-packages/ts-ember-preview-types/app/components/wrapper-component.ts
+++ b/test-packages/ts-ember-preview-types/app/components/wrapper-component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import { ComponentLike, WithBoundArgs } from '@glint/template';
 import Component from '@ember/component';
 import EmberComponent from './ember-component';

--- a/test-packages/ts-ember-preview-types/app/pods/components/baz/component.ts
+++ b/test-packages/ts-ember-preview-types/app/pods/components/baz/component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from '@ember/component';
 
 export interface BazSignature {


### PR DESCRIPTION
The `ts-ember-preview-types` test package intentionally tests classic, non-tagless components, so we should just disable the ESLint rules that complain about them "globally" for the whole package.