### PR TITLE
docs: move registry interface inside registry ambient module

### DIFF
--- a/docs/ember/template-registry.md
+++ b/docs/ember/template-registry.md
@@ -32,9 +32,12 @@ If you've nested your component inside folder(s), you'll need to add the full "s
 
 ```typescript
 export default class MyComponent extends Component {}
-export default interface Registry {
-  'Grouping::MyComponent': typeof MyComponent;
-  'grouping/my-component': typeof MyComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Grouping::MyComponent': typeof MyComponent;
+    'grouping/my-component': typeof MyComponent;
+  }
 }
 ```
 


### PR DESCRIPTION
This example is confusing (and incorrect) because the registry augmentation is not within the registry ambient module.