### PR TITLE
Update minimum supported TS version to 4.8

### DIFF
--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -44,7 +44,7 @@ Because Glint uses your project-local copy of TypeScript and the packages whose 
 
 | Package                   | Minimum Version |
 | ------------------------- | --------------- |
-| `typescript`              | 4.7.0           |
+| `typescript`              | 4.8.0           |
 | `@types/ember__component` | 4.0.8           |
 | `@glimmer/component`      | 1.1.2           |
 | `ember-modifier`          | 3.2.7           |

--- a/docs/glimmerx/installation.md
+++ b/docs/glimmerx/installation.md
@@ -44,5 +44,5 @@ Because Glint uses your project-local copy of TypeScript and the packages whose 
 
 | Package       | Minimum Version |
 | ------------- | --------------- |
-| `typescript`  | 4.7.0           |
+| `typescript`  | 4.8.0           |
 | `@glimmerx/*` | 0.6.7           |

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -19,6 +19,10 @@ project's `devDependencies`** when you upgrade Glint. Note also that support for
 
 More details about these and other breaking changes are laid out below.
 
+### Minimum TypeScript Version
+
+Glint 1.0 requires TypeScript 4.8 or greater, dropping support for 4.7.
+
 ### `@glint/template` Peer
 
 For Glint to work properly, there must be exactly one common copy of `@glint/template` present

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint": "^8.27.0",
     "prettier": "^2.1.1",
     "release-it": "^15.5.0",
-    "typescript": "^4.7.4"
+    "typescript": "~4.8.0"
   },
   "resolutions:notes": {
     "@types/yargs": "Locking temporarily to avoid an issue with the ESM types in 17.0.14; see DT#63373"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "typescript": "^4.7.0"
+    "typescript": "^4.8.0"
   },
   "dependencies": {
     "@glimmer/syntax": "^0.84.2",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,7 +36,6 @@
     "@types/js-yaml": "^4.0.5",
     "@types/yargs": "^17.0.10",
     "json5": "^2.2.1",
-    "typescript": "^4.7.4",
     "vitest": "^0.22.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15602,7 +15602,7 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
-typescript@^4.7.4:
+typescript@~4.8.0:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
TypeScript deprecated certain signatures of their AST builder API based on changes they made to their node structure in anticipation of ES decorators (see https://github.com/typed-ember/glint/commit/ce5a668fd134f84a4bd6e23999cac7f100e7d577). The non-deprecated signatures are only available starting in TS 4.8, and it turns out we weren't testing against 4.7 despite claiming to support it.

This updates our docs to reflect the new minimum version and also makes the constraint explicit in our root `package.json`.