### PR TITLE
Fix up a couple ESM oddities in the CLI

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,4 +1,4 @@
-import yargs = require('yargs');
+import yargs from 'yargs';
 import { findTypeScript, loadConfig } from '../config/index.js';
 import { performWatch } from './perform-watch.js';
 import { performCheck } from './perform-check.js';
@@ -7,7 +7,7 @@ import { performBuild } from './perform-build.js';
 import type * as TS from 'typescript';
 import { performBuildWatch } from './perform-build-watch.js';
 
-const argv = yargs
+const argv = yargs(process.argv.slice(2))
   .scriptName('glint')
   .usage('$0 [options]')
   .option('project', {

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import yargs from 'yargs';
 import { findTypeScript, loadConfig } from '../config/index.js';
 import { performWatch } from './perform-watch.js';
@@ -6,6 +7,9 @@ import { determineOptionsToExtend } from './options.js';
 import { performBuild } from './perform-build.js';
 import type * as TS from 'typescript';
 import { performBuildWatch } from './perform-build-watch.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json');
 
 const argv = yargs(process.argv.slice(2))
   .scriptName('glint')
@@ -58,6 +62,7 @@ const argv = yargs(process.argv.slice(2))
     boolean: false,
     description: `When true, writes out a Glint's internal intermediate representation of each file within a GLINT_DEBUG subdirectory of the current working directory. This is intended for debugging Glint itself.`,
   })
+  .version(pkg.version)
   .wrap(100)
   .strict()
   .parseSync();


### PR DESCRIPTION
This fixes a couple oddities relating to our conversion to ESM in the CLI, namely that `--version` and `--debug-intermediate-representation` were broken.

The former is fixed by reading our own `package.json` and manually specifying the version for `yargs`. The latter is incidentally also fixed by that, as we were using `require` to pull in a few additional modules for setting up the IR emit, and that isn't defined by default in a `type: 'module'` file in Node.