### PR TITLE
Ensure `link-to` can still be invoked with only named args

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
@@ -1,4 +1,5 @@
 import { ComponentLike } from '@glint/template';
+import { ComponentReturn, DirectInvokable, NamedArgs } from '@glint/template/-private/integration';
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
   {
@@ -20,12 +21,14 @@ type LinkToArgs = RequireAtLeastOne<
   'route' | 'model' | 'models' | 'query'
 >;
 
-export type LinkToKeyword = ComponentLike<{
-  Args: {
-    Positional: [route: string, ...params: unknown[], ...named: [named?: Partial<LinkToArgs>]];
-  };
-  Element: HTMLAnchorElement;
-  Blocks: { default: [] };
+type LinkToReturn = ComponentReturn<{ default: [] }, HTMLAnchorElement>;
+
+export type LinkToKeyword = DirectInvokable<{
+  // `{{link-to}}` classic invocation
+  (route: string, ...params: Array<unknown>): LinkToReturn;
+
+  // `<LinkTo>` invocation, but accessed via `'link-to'` e.g. with `{{component}}`
+  (named: NamedArgs<LinkToArgs>): LinkToReturn;
 }>;
 
 export type LinkToComponent = ComponentLike<{

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/link-to.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/link-to.test.ts
@@ -47,6 +47,16 @@ linkTo({}, 123);
   expectTypeOf(component.blockParams.default).toEqualTypeOf<[]>();
 }
 
+{
+  // Ensure it's also usable with only named args like `<LinkTo>`
+  emitComponent(linkTo({ route: 'index', ...NamedArgsMarker }));
+  emitComponent(linkTo({ model: {}, ...NamedArgsMarker }));
+  emitComponent(linkTo({ route: 'index', model: {}, ...NamedArgsMarker }));
+
+  // @ts-expect-error: requires at least one arg, either named or positional
+  linkTo();
+}
+
 // <LinkTo>
 
 {


### PR DESCRIPTION
This one is pretty much just what it says on the tin. Fixes #480.