### PR TITLE
Add an option to the Code extension for where to look for @glint/core

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -10,7 +10,4 @@ In addition, the [template registry](ember/template-registry.md) must currently 
 
 ### Tooling
 
-The CLI and language server currently have a few known limitations:
-
-- The language server requires that `@glint/core` be resolvable from the root directory that you've opened your editor in.
-- In VS Code, you will see diagnostics from both TypeScript and Glint in many files, as well as false 'unused symbol' positives for things only referenced in templates. See [the VS Code extension README](../packages/vscode) for details on dealing with this.
+In VS Code, you will see diagnostics from both TypeScript and Glint in many files, as well as false 'unused symbol' positives for things only referenced in templates. See [the VS Code extension README](../packages/vscode) for details on dealing with this.

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -16,6 +16,11 @@ See the [Glint home page] for a more detailed Getting Started guide.
 
 [glint home page]: https://typed-ember.gitbook.io/glint
 
+If the location where `@glint/core` is installed isn't in the root of your Code workspace, you can inform the extension on a per-workspace basis where to locate the language server in the Glint extension settings.
+
+<img width="705" alt="Input for `glint.libaryPath` in the VS Code configuration editor." src="https://user-images.githubusercontent.com/108688/206561138-aca2bb80-04f6-44dd-a23f-032d4f163f7a.png">
+
+
 ## Usage
 
 The Glint language server incorporates Glimmer templates into TypeScript-powered tooling for a project, enabling them to participate in rich editor features such as:

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -59,6 +59,11 @@
       {
         "title": "Glint",
         "properties": {
+          "glint.libraryPath": {
+            "markdownDescription": "The path, relative to your workspace folder root, from which to resolve `@glint/core`. Defaults to `'.'`.",
+            "order": 1,
+            "type": "string"
+          },
           "glint.debug": {
             "description": "Enable debugging commands for Glint.",
             "type": "boolean",


### PR DESCRIPTION
This change adds a config option to the Code extension to customize the location from which we try to resolve `@glint/core`. This means that if, for example, your frontend and backend live in a single repository, you can open Code in the root of that repo and still tell Code where to load Glint from.