### PR TITLE
Remove unused `--build` suite tests

### DIFF
--- a/packages/core/__tests__/cli/build.test.ts
+++ b/packages/core/__tests__/cli/build.test.ts
@@ -1025,24 +1025,6 @@ describe('CLI: single-pass build mode typechecking', () => {
         });
       });
     });
-
-    describe('invalidation', () => {
-      describe('for the root', () => {
-        test.todo('when the root is invalidated');
-        test.todo('when a direct reference is invalidated');
-
-        test.todo('when a transitive reference is invalidated');
-      });
-
-      describe('for a composite subproject with a reference', () => {
-        test.todo('when the subproject is invalidated');
-        test.todo('when the other subproject referenced by the subproject is invalidated');
-      });
-
-      describe('for a composite subproject with no references', () => {
-        test.todo('when the subproject is invalidated');
-      });
-    });
   });
 });
 


### PR DESCRIPTION
I originally intended these to cover some scenarios which got covered in the regular `--build` tests, and never deleted them, and somehow we all missed them in code review, too. 🤷🏻‍♂️