### PR TITLE
Ensure we handle `@glint-nocheck` in composite projects correctly

### DIFF
--- a/packages/core/src/cli/perform-build-watch.ts
+++ b/packages/core/src/cli/perform-build-watch.ts
@@ -2,7 +2,7 @@ import type * as TS from 'typescript';
 
 import { buildDiagnosticFormatter } from './diagnostics.js';
 import { sysForCompilerHost } from './utils/sys-for-compiler-host.js';
-import { patchProgram } from './utils/patch-program.js';
+import { patchProgramBuilder } from './utils/patch-program.js';
 import TransformManagerPool from './utils/transform-manager-pool.js';
 
 export function performBuildWatch(
@@ -12,14 +12,11 @@ export function performBuildWatch(
 ): void {
   let transformManagerPool = new TransformManagerPool(ts.sys);
   let formatDiagnostic = buildDiagnosticFormatter(ts);
+  let buildProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram;
 
   let host = ts.createSolutionBuilderWithWatchHost(
     sysForCompilerHost(ts, transformManagerPool),
-    (...args) => {
-      const program = ts.createEmitAndSemanticDiagnosticsBuilderProgram(...args);
-      patchProgram(program, transformManagerPool);
-      return program;
-    },
+    patchProgramBuilder(ts, transformManagerPool, buildProgram),
     (diagnostic) => console.error(formatDiagnostic(diagnostic))
   );
 

--- a/packages/core/src/cli/utils/patch-program.ts
+++ b/packages/core/src/cli/utils/patch-program.ts
@@ -3,7 +3,7 @@ import type TransformManager from '../../common/transform-manager.js';
 import { assert } from './assert.js';
 import type TransformManagerPool from './transform-manager-pool.js';
 
-type Program = TS.SemanticDiagnosticsBuilderProgram;
+type Program = TS.Program | TS.SemanticDiagnosticsBuilderProgram;
 
 export function patchProgram(
   program: Program,
@@ -38,6 +38,12 @@ export function patchProgram(
       manager?.rewriteDiagnostics(diagnostics, sourceFile?.fileName) ?? diagnostics;
     return rewrittenDiagnostics;
   };
+
+  // We want to patch these methods on both the outer "builder" program and, if
+  // applicable, its inner program representation.
+  if ('getProgram' in program) {
+    patchProgram(ts, program.getProgram(), transformManagerOrPool);
+  }
 }
 
 function isPool(manager: TransformManager | TransformManagerPool): manager is TransformManagerPool {

--- a/test-packages/test-utils/src/composite-project.ts
+++ b/test-packages/test-utils/src/composite-project.ts
@@ -24,6 +24,7 @@ export const BASE_TS_CONFIG = {
     emitDeclarationOnly: true,
     incremental: true,
     noEmit: false,
+    noEmitOnError: true,
     outDir: OUT_DIR,
   },
   include: [INPUT_DIR],


### PR DESCRIPTION
Because TypeScript's `--build` mode is primarily driven off of `emit()` calls to the underlying `Program` instances that make up the project, it's not always guaranteed to pull its diagnostics via the outer `BuilderProgram` diagnostic methods that we override in `patchProgram`.

If we silence diagnostics in those methods and TS subsequently sees the untransformed version of those diagnostics later, it will print those diagnostics for the user. Also troublingly, the presence of those diagnostics in combination with `noEmitOnError` will cause corresponding `.d.ts` files _not_ to be emitted for files that are suppressing template type errors with `@glint-nocheck`.

This change ensures that when we patch the outer program's diagnostic methods, we also patch the _inner_ program's corresponding methods, which is where `emit()` calls draw their diagnostics from. Note that it's not sufficient to _only_ patch the inner program, as the outer one doesn't simply call through, but (for reasons that are beyond me) has its own similar-but-not-the-same implementation using other TS internals.

I also added a call to `ts.sortAndDeduplicateDiagnostics` in locations where we inject our transformation diagnostics to avoid scenarios where they wind up injected twice—this also has the side effect of ensuring that all diagnostics for a given source file are grouped together, which they previously might not have been.