### PR TITLE
Update publish configuration for `@glint/type-test`

### DIFF
--- a/packages/type-test/package.json
+++ b/packages/type-test/package.json
@@ -10,6 +10,10 @@
   "exports": {
     ".": "./lib/index.js"
   },
+  "files": [
+    "README.md",
+    "lib"
+  ],
   "scripts": {
     "test": "glint -p __tests__"
   },
@@ -18,5 +22,8 @@
   },
   "peerDependencies": {
     "@glint/template": "^1.0.0-beta.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Without this, we'd include our tests and `tsconfig.json` when we  publish `@glint/type-test`, and npm would default to assuming we want this scoped package to be private and then 💥.