### PR TITLE
Widen supported range for ember-modifier to include v4

### DIFF
--- a/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts
@@ -64,9 +64,9 @@ declare module '@ember/component/helper' {
 //////////////////////////////////////////////////////////////////////
 // Modifiers
 
-import 'ember-modifier/-private/class/modifier';
+import 'ember-modifier';
 
-declare module 'ember-modifier/-private/class/modifier' {
+declare module 'ember-modifier' {
   export default interface ClassBasedModifier<S> extends InstanceType<ModifierLike<S>> {}
 }
 

--- a/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
@@ -56,9 +56,6 @@ import type Owner from '@ember/owner';
     'hello'
   );
 
-  type InferSignature<T> = T extends Modifier<infer Signature> ? Signature : never;
-  expectTypeOf<InferSignature<NeatModifier>>().toEqualTypeOf<NeatModifierSignature>();
-
   // @ts-expect-error: missing required positional arg
   neat(img);
 

--- a/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/modifier.test.ts
@@ -1,8 +1,10 @@
-import Modifier, { modifier } from 'ember-modifier';
+import Modifier, { modifier, type ArgsFor } from 'ember-modifier';
 import { NamedArgsMarker, resolve } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { ModifierReturn } from '@glint/template/-private/integration';
 import { ModifierLike } from '@glint/template';
+import { registerDestructor } from '@ember/destroyable';
+import type Owner from '@ember/owner';
 
 // Class-based modifier
 {
@@ -16,29 +18,27 @@ import { ModifierLike } from '@glint/template';
 
   class NeatModifier extends Modifier<NeatModifierSignature> {
     private interval?: number;
+    private multiplier?: number;
 
-    get lengthOfInput(): number {
-      return this.args.positional[0].length;
+    constructor(owner: Owner, args: ArgsFor<NeatModifierSignature>) {
+      super(owner, args);
+
+      registerDestructor(this, () => window.clearInterval(this.interval));
     }
 
-    get multiplier(): number {
-      if (this.args.named.multiplier === undefined) {
-        return 1000;
-      }
+    override modify(
+      element: HTMLImageElement,
+      [input]: NeatModifierSignature['Args']['Positional'],
+      { multiplier }: NeatModifierSignature['Args']['Named']
+    ): void {
+      // expectTypeOf(element).toEqualTypeOf<HTMLImageElement>();
+      this.multiplier = multiplier ?? 1000;
+      const lengthOfInput = input.length;
 
-      return this.args.named.multiplier;
-    }
-
-    override didReceiveArguments(): void {
-      expectTypeOf(this.element).toEqualTypeOf<HTMLImageElement>();
-
+      window.clearInterval(this.interval);
       this.interval = window.setInterval(() => {
         alert('this is a typesafe modifier!');
-      }, this.multiplier * this.lengthOfInput);
-    }
-
-    override willDestroy(): void {
-      window.clearInterval(this.interval);
+      }, this.multiplier * lengthOfInput);
     }
   }
 
@@ -142,7 +142,7 @@ import { ModifierLike } from '@glint/template';
   }
 
   class MyModifier extends Modifier<TestSignature> {}
-  const myModifier = modifier<TestSignature>(() => {}, { eager: false });
+  const myModifier = modifier<TestSignature>(() => {});
 
   expectTypeOf(MyModifier).toMatchTypeOf<ModifierLike<TestSignature>>();
   expectTypeOf(myModifier).toMatchTypeOf<ModifierLike<TestSignature>>();

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -36,7 +36,7 @@
     "@types/ember__object": "^4.0.4",
     "@types/ember__routing": "^4.0.11",
     "ember-cli-htmlbars": "^6.0.1",
-    "ember-modifier": "^3.2.7"
+    "ember-modifier": "^3.2.7 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@types/ember__array": {
@@ -68,7 +68,7 @@
     "@types/ember__controller": "^4.0.2",
     "@types/ember__object": "^4.0.4",
     "@types/ember__routing": "^4.0.11",
-    "ember-modifier": "^3.2.7",
+    "ember-modifier": "^3.2.7 || ^4.0.0",
     "expect-type": "^0.15.0",
     "vitest": "^0.22.0"
   },

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -66,6 +66,7 @@
     "@types/ember__array": "^4.0.2",
     "@types/ember__component": "^4.0.10",
     "@types/ember__controller": "^4.0.2",
+    "@types/ember__destroyable": "^4.0.1",
     "@types/ember__object": "^4.0.4",
     "@types/ember__routing": "^4.0.11",
     "ember-modifier": "^3.2.7 || ^4.0.0",

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -42,7 +42,7 @@
     "ember-cli-typescript": "^4.0.0",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-modifier": "^3.2.7",
+    "ember-modifier": "^3.2.7 || ^4.0.0",
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.1.1",

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -42,7 +42,7 @@
     "ember-cli-typescript": "^4.0.0",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
-    "ember-modifier": "^3.2.7 || ^4.0.0",
+    "ember-modifier": "^4.0.0",
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6597,7 +6597,7 @@ ember-load-initializers@^2.1.2:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
 
-"ember-modifier@^3.2.7 || ^4.0.0":
+"ember-modifier@^3.2.7 || ^4.0.0", ember-modifier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-4.0.0.tgz#0bb3fae11435fcbe0d3dfa852ce224d81d75ddb2"
   integrity sha512-OdconmrqKP2haK4kBwNmtnA2NiC2MFmIJC3LgJ1WhwZ49GaktM+bRIuFxF/S5W0oaegzKs1qH2ZDlqMeO2L3nw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,15 @@
     "@embroider/shared-internals" "^1.8.3"
     semver "^7.3.5"
 
+"@embroider/addon-shim@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@embroider/addon-shim/-/addon-shim-1.8.4.tgz#0e7f32c5506bf0f3eb0840506e31c36c7053763c"
+  integrity sha512-sFhfWC0vI18KxVenmswQ/ShIvBg4juL8ubI+Q3NTSdkCTeaPQ/DIOUF6oR5DCQ8eO/TkIaw+kdG3FkTY6yNJqA==
+  dependencies:
+    "@embroider/shared-internals" "^2.0.0"
+    broccoli-funnel "^3.0.8"
+    semver "^7.3.8"
+
 "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.9.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.10.0.tgz#af3844d5db48f001b85cfb096c76727c72ad6c1e"
@@ -2323,6 +2332,11 @@
     "@types/ember__debug" "*"
     "@types/ember__object" "*"
     "@types/ember__owner" "*"
+
+"@types/ember__destroyable@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ember__destroyable/-/ember__destroyable-4.0.1.tgz#6b5d5cd52a6a38ec74ea6b19804a8b4618c8810f"
+  integrity sha512-U497H5zW2bfdwmX1rktaSe+IsOrcqLn7jtrHI2dNnf9le38e1Wcnes8amA9PCv4lOhH+Mc3nkNIdQx38DwflXA==
 
 "@types/ember__engine@*":
   version "4.0.4"
@@ -6535,7 +6549,7 @@ ember-cli@~4.4.0:
     workerpool "^6.2.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
   integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
@@ -6583,16 +6597,14 @@ ember-load-initializers@^2.1.2:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
 
-ember-modifier@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
-  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
+"ember-modifier@^3.2.7 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-4.0.0.tgz#0bb3fae11435fcbe0d3dfa852ce224d81d75ddb2"
+  integrity sha512-OdconmrqKP2haK4kBwNmtnA2NiC2MFmIJC3LgJ1WhwZ49GaktM+bRIuFxF/S5W0oaegzKs1qH2ZDlqMeO2L3nw==
   dependencies:
-    ember-cli-babel "^7.26.6"
+    "@embroider/addon-shim" "^1.8.4"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^5.0.0"
-    ember-compatibility-helpers "^1.2.5"
 
 ember-named-blocks-polyfill@^0.2.4:
   version "0.2.5"
@@ -13931,7 +13943,7 @@ semver@7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==


### PR DESCRIPTION
with https://github.com/ember-modifier/ember-modifier/releases/tag/v4.0.0, we can't bump `ember-modifier` to v4.0.0 in the project due to `peerDependencies` range including only v3