### PR TITLE
Introduce CodeActions

### DIFF
--- a/packages/core/__tests__/language-server/custom-extensions.test.ts
+++ b/packages/core/__tests__/language-server/custom-extensions.test.ts
@@ -24,6 +24,7 @@ describe('Language Server: custom file extensions', () => {
     expect(server.getDiagnostics(project.fileURI('index.gts'))).toMatchInlineSnapshot(`
       [
         {
+          "code": 2322,
           "message": "Type 'number' is not assignable to type 'string'.",
           "range": {
             "end": {
@@ -47,6 +48,7 @@ describe('Language Server: custom file extensions', () => {
     expect(server.getDiagnostics(project.fileURI('index.gts'))).toMatchInlineSnapshot(`
       [
         {
+          "code": 2322,
           "message": "Type 'number' is not assignable to type 'string'.",
           "range": {
             "end": {

--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -55,6 +55,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 2554,
           "message": "Expected 2 arguments, but got 1.",
           "range": {
             "end": {
@@ -71,6 +72,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2554,
           "message": "Expected 2 arguments, but got 3.",
           "range": {
             "end": {
@@ -87,6 +89,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2554,
           "message": "Expected 2 arguments, but got 3. Note that named args are passed together as a final argument, so they collectively increase the given arg count by 1.",
           "range": {
             "end": {
@@ -103,6 +106,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2555,
           "message": "Expected at least 1 arguments, but got 0.",
           "range": {
             "end": {
@@ -119,6 +123,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2554,
           "message": "Expected 2 arguments, but got 1.",
           "range": {
             "end": {
@@ -135,6 +140,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2554,
           "message": "Expected 2 arguments, but got 3.",
           "range": {
             "end": {
@@ -151,6 +157,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2555,
           "message": "Expected at least 1 arguments, but got 0.",
           "range": {
             "end": {
@@ -203,6 +210,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 2322,
           "message": "Only primitive values (see \`AttrValue\` in \`@glint/template\`) are assignable as HTML attributes. If you want to set an event listener, consider using the \`{{on}}\` modifier instead.
         Type '{}' is not assignable to type 'AttrValue'.",
           "range": {
@@ -220,6 +228,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "Only primitive values and certain DOM objects (see \`ContentValue\` in \`@glint/template\`) are usable as top-level template content.
         Argument of type '{}' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -237,6 +246,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "Only primitive values and certain DOM objects (see \`ContentValue\` in \`@glint/template\`) are usable as top-level template content.
         Argument of type '{}' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -254,6 +264,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "Only primitive values and certain DOM objects (see \`ContentValue\` in \`@glint/template\`) are usable as top-level template content.
         Argument of type '{}' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -271,6 +282,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2322,
           "message": "Only primitive values (see \`AttrValue\` in \`@glint/template\`) are assignable as HTML attributes. If you want to set an event listener, consider using the \`{{on}}\` modifier instead.
         Type '{}' is not assignable to type 'AttrValue'.",
           "range": {
@@ -288,6 +300,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "Only primitive values and certain DOM objects (see \`ContentValue\` in \`@glint/template\`) are usable as top-level template content.
         Argument of type '{}' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -305,6 +318,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "Only primitive values and certain DOM objects (see \`ContentValue\` in \`@glint/template\`) are usable as top-level template content.
         Argument of type '{}' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -322,6 +336,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "Only primitive values and certain DOM objects (see \`ContentValue\` in \`@glint/template\`) are usable as top-level template content.
         Argument of type '{}' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -384,6 +399,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -400,6 +416,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -416,6 +433,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -432,6 +450,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -448,6 +467,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -464,6 +484,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -480,6 +501,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -496,6 +518,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The given value does not appear to be usable as a component, modifier or helper.",
           "range": {
             "end": {
@@ -545,6 +568,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 7053,
           "message": "Unknown name 'Foo'. If this isn't a typo, you may be missing a registry entry for this value; see the Template Registry page in the Glint documentation for more details.
         Element implicitly has an 'any' type because expression of type '\\"Foo\\"' can't be used to index type 'Globals'.
           Property 'Foo' does not exist on type 'Globals'.",
@@ -563,6 +587,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 7053,
           "message": "Unknown name 'foo'. If this isn't a typo, you may be missing a registry entry for this value; see the Template Registry page in the Glint documentation for more details.
         Element implicitly has an 'any' type because expression of type '\\"foo\\"' can't be used to index type 'Globals'.
           Property 'foo' does not exist on type 'Globals'.",
@@ -581,6 +606,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 7053,
           "message": "Unknown name 'foo'. If this isn't a typo, you may be missing a registry entry for this value; see the Template Registry page in the Glint documentation for more details.
         Element implicitly has an 'any' type because expression of type '\\"foo\\"' can't be used to index type 'Globals'.
           Property 'foo' does not exist on type 'Globals'.",
@@ -599,6 +625,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 7053,
           "message": "Unknown name 'foo'. If this isn't a typo, you may be missing a registry entry for this value; see the Template Registry page in the Glint documentation for more details.
         Element implicitly has an 'any' type because expression of type '\\"foo\\"' can't be used to index type 'Globals'.
           Property 'foo' does not exist on type 'Globals'.",
@@ -617,6 +644,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 7053,
           "message": "Element implicitly has an 'any' type because expression of type '\\"bad-thing\\"' can't be used to index type '{ message: string; }'.
         Property 'bad-thing' does not exist on type '{ message: string; }'.",
           "range": {
@@ -668,6 +696,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 2769,
           "message": "Unknown component name 'foo'. If this isn't a typo, you may be missing a registry entry for this name; see the Template Registry page in the Glint documentation for more details.
         No overload matches this call.
           Overload 1 of 6, '(component: keyof Globals): void | LetKeyword | ComponentKeyword<Globals> | ConcatHelper | FnHelper | ... 19 more ... | WithKeyword', gave the following error.
@@ -689,6 +718,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The type of this expression doesn't appear to be a valid value to pass the {{component}} helper. If possible, you may need to give the expression a narrower type, for example \`'component-a' | 'component-b'\` rather than \`string\`.
         No overload matches this call.
           Overload 1 of 6, '(component: keyof Globals): void | LetKeyword | ComponentKeyword<Globals> | ConcatHelper | FnHelper | ... 19 more ... | WithKeyword', gave the following error.
@@ -710,6 +740,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2769,
           "message": "The type of this expression doesn't appear to be a valid value to pass the {{component}} helper. If possible, you may need to give the expression a narrower type, for example \`'component-a' | 'component-b'\` rather than \`string\`.
         No overload matches this call.
           Overload 1 of 6, '(component: keyof Globals): void | LetKeyword | ComponentKeyword<Globals> | ConcatHelper | FnHelper | ... 19 more ... | WithKeyword', gave the following error.
@@ -774,6 +805,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 2345,
           "message": "The {{component}} helper can't be used to directly invoke a component under Glint. Consider first binding the result to a variable, e.g. '{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as '<ComponentName @arg={{value}} />'.
         Argument of type 'typeof MyComponent' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -791,6 +823,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "The {{component}} helper can't be used to directly invoke a component under Glint. Consider first binding the result to a variable, e.g. '{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as '<ComponentName @arg={{value}} />'.
         Argument of type 'Invokable<(named?: PrebindArgs<{ message?: string | undefined; }, \\"message\\"> | undefined) => ComponentReturn<FlattenBlockParams<{ default: { Params: { Positional: []; }; }; }>, unknown>>' is not assignable to parameter of type 'ContentValue'.",
           "range": {
@@ -808,6 +841,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "The {{component}} helper can't be used to directly invoke a component under Glint. Consider first binding the result to a variable, e.g. '{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as '<ComponentName @arg={{value}}>...</ComponentName>'.
         Argument of type 'typeof MyComponent' is not assignable to parameter of type 'ComponentReturn<any, any>'.
           Type 'typeof MyComponent' is missing the following properties from type 'ComponentReturn<any, any>': [Blocks], [Element]",
@@ -826,6 +860,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
+          "code": 2345,
           "message": "The {{component}} helper can't be used to directly invoke a component under Glint. Consider first binding the result to a variable, e.g. '{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as '<ComponentName @arg={{value}}>...</ComponentName>'.
         Argument of type 'Invokable<(named?: PrebindArgs<{ message?: string | undefined; }, \\"message\\"> | undefined) => ComponentReturn<FlattenBlockParams<{ default: { Params: { Positional: []; }; }; }>, unknown>>' is not assignable to parameter of type 'ComponentReturn<any, any>'.",
           "range": {

--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -59,6 +59,7 @@ describe('Language Server: Diagnostics', () => {
       expect(templateDiagnostics).toMatchInlineSnapshot(`
         [
           {
+            "code": 2339,
             "message": "Property 'missingArg' does not exist on type '{}'.",
             "range": {
               "end": {
@@ -75,6 +76,7 @@ describe('Language Server: Diagnostics', () => {
             "tags": [],
           },
           {
+            "code": 2322,
             "message": "Type 'number' is not assignable to type 'string'.",
             "range": {
               "end": {
@@ -193,6 +195,7 @@ describe('Language Server: Diagnostics', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 6133,
           "message": "'startupTime' is declared but its value is never read.",
           "range": {
             "end": {
@@ -211,6 +214,7 @@ describe('Language Server: Diagnostics', () => {
           ],
         },
         {
+          "code": 2551,
           "message": "Property 'startupTimee' does not exist on type 'Application'. Did you mean 'startupTime'?",
           "range": {
             "end": {
@@ -264,6 +268,7 @@ describe('Language Server: Diagnostics', () => {
     expect(scriptDiagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 6133,
           "message": "'startupTime' is declared but its value is never read.",
           "range": {
             "end": {
@@ -287,6 +292,7 @@ describe('Language Server: Diagnostics', () => {
     expect(templateDiagnostics).toMatchInlineSnapshot(`
       [
         {
+          "code": 2551,
           "message": "Property 'startupTimee' does not exist on type 'Application'. Did you mean 'startupTime'?",
           "range": {
             "end": {
@@ -358,6 +364,7 @@ describe('Language Server: Diagnostics', () => {
     expect(server.getDiagnostics(project.fileURI('component-a.ts'))).toMatchInlineSnapshot(`
       [
         {
+          "code": 2339,
           "message": "Property 'version' does not exist on type '{}'.",
           "range": {
             "end": {
@@ -387,6 +394,7 @@ describe('Language Server: Diagnostics', () => {
     expect(server.getDiagnostics(project.fileURI('component-a.ts'))).toMatchInlineSnapshot(`
       [
         {
+          "code": 0,
           "message": "Unused '@glint-expect-error' directive.",
           "range": {
             "end": {

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -5,11 +5,16 @@ import {
   SymbolInformation,
   TextDocuments,
   TextDocumentSyncKind,
+  InitializeParams as BaseInitializeParams,
+  CodeActionTriggerKind,
+  CodeActionKind,
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { GlintCompletionItem } from './glint-language-server.js';
 import { LanguageServerPool } from './pool.js';
 import { GetIRRequest } from './messages.cjs';
+import { ConfigManager } from './config-manager.js';
+import type * as ts from 'typescript';
 
 export const capabilities: ServerCapabilities = {
   textDocumentSync: TextDocumentSyncKind.Full,
@@ -21,6 +26,7 @@ export const capabilities: ServerCapabilities = {
   },
   referencesProvider: true,
   hoverProvider: true,
+  codeActionProvider: true,
   definitionProvider: true,
   workspaceSymbolProvider: true,
   renameProvider: {
@@ -32,10 +38,58 @@ export type BindingArgs = {
   openDocuments: TextDocuments<TextDocument>;
   connection: Connection;
   pool: LanguageServerPool;
+  configManager: ConfigManager;
 };
 
-export function bindLanguageServerPool({ connection, pool, openDocuments }: BindingArgs): void {
-  connection.onInitialize(() => ({ capabilities }));
+interface FormattingAndPreferences {
+  format?: ts.FormatCodeSettings;
+  preferences?: ts.UserPreferences;
+}
+
+interface InitializeParams extends BaseInitializeParams {
+  initializationOptions?: {
+    typescript?: FormattingAndPreferences;
+    javascript?: FormattingAndPreferences;
+  };
+}
+
+export function bindLanguageServerPool({
+  connection,
+  pool,
+  openDocuments,
+  configManager,
+}: BindingArgs): void {
+  connection.onInitialize((config: InitializeParams) => {
+    if (config.initializationOptions?.typescript?.format) {
+      configManager.updateTsJsFormatConfig(
+        'typescript',
+        config.initializationOptions.typescript.format
+      );
+    }
+
+    if (config.initializationOptions?.typescript?.preferences) {
+      configManager.updateTsJsUserPreferences(
+        'typescript',
+        config.initializationOptions.typescript.preferences
+      );
+    }
+
+    if (config.initializationOptions?.javascript?.format) {
+      configManager.updateTsJsFormatConfig(
+        'javascript',
+        config.initializationOptions.javascript.format
+      );
+    }
+
+    if (config.initializationOptions?.javascript?.preferences) {
+      configManager.updateTsJsUserPreferences(
+        'javascript',
+        config.initializationOptions.javascript.preferences
+      );
+    }
+
+    return { capabilities };
+  });
 
   openDocuments.onDidOpen(({ document }) => {
     pool.withServerForURI(document.uri, ({ server, scheduleDiagnostics }) => {
@@ -54,6 +108,37 @@ export function bindLanguageServerPool({ connection, pool, openDocuments }: Bind
     pool.withServerForURI(document.uri, ({ server, scheduleDiagnostics }) => {
       server.updateFile(document.uri, document.getText());
       scheduleDiagnostics();
+    });
+  });
+
+  connection.onCodeAction(({ textDocument, range, context }) => {
+    return pool.withServerForURI(textDocument.uri, ({ server }) => {
+      // The user actually asked for the fix
+      // @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionTriggerKind
+      if (context.triggerKind === CodeActionTriggerKind.Invoked) {
+        let language = server.getLanguageType(textDocument.uri);
+        let formating = configManager.getFormatCodeSettingsFor(language);
+        let preferences = configManager.getUserSettingsFor(language);
+        let diagnosticCodes = context.diagnostics;
+        // "only" is only present when a user hovers over and the codefix dropdown is requested. If it is missing the user has explicitly asked for codefixes
+        let type =
+          context.only === undefined
+            ? CodeActionKind.QuickFix
+            : context.only.includes(CodeActionKind.QuickFix)
+            ? CodeActionKind.QuickFix
+            : undefined;
+
+        return server.getCodeActions(
+          textDocument.uri,
+          type,
+          range,
+          diagnosticCodes,
+          formating,
+          preferences
+        );
+      }
+
+      return [];
     });
   });
 

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -26,7 +26,9 @@ export const capabilities: ServerCapabilities = {
   },
   referencesProvider: true,
   hoverProvider: true,
-  codeActionProvider: true,
+  codeActionProvider: {
+    codeActionKinds: [CodeActionKind.QuickFix],
+  },
   definitionProvider: true,
   workspaceSymbolProvider: true,
   renameProvider: {
@@ -119,20 +121,13 @@ export function bindLanguageServerPool({
         let language = server.getLanguageType(textDocument.uri);
         let formating = configManager.getFormatCodeSettingsFor(language);
         let preferences = configManager.getUserSettingsFor(language);
-        let diagnosticCodes = context.diagnostics;
-        // "only" is only present when a user hovers over and the codefix dropdown is requested. If it is missing the user has explicitly asked for codefixes
-        let type =
-          context.only === undefined
-            ? CodeActionKind.QuickFix
-            : context.only.includes(CodeActionKind.QuickFix)
-            ? CodeActionKind.QuickFix
-            : undefined;
+        let diagnostics = context.diagnostics;
 
         return server.getCodeActions(
           textDocument.uri,
-          type,
+          CodeActionKind.QuickFix,
           range,
-          diagnosticCodes,
+          diagnostics,
           formating,
           preferences
         );

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -123,9 +123,22 @@ export function bindLanguageServerPool({
         let preferences = configManager.getUserSettingsFor(language);
         let diagnostics = context.diagnostics;
 
+        let kind = '';
+
+        // QuickFix requests can have their `only` field set to `undefined`.
+        // For what we've seen this is only true about `QuickFix`
+        if (context.only === undefined) {
+          kind = CodeActionKind.QuickFix;
+        } else if (context.only.includes(CodeActionKind.QuickFix)) {
+          // Otherwise we get the kind passed in the array.
+          // Because we only solicit for `CodeFix`s this array will only have
+          // a single entry in it.
+          kind = CodeActionKind.QuickFix;
+        }
+
         return server.getCodeActions(
           textDocument.uri,
-          CodeActionKind.QuickFix,
+          kind,
           range,
           diagnostics,
           formating,

--- a/packages/core/src/language-server/config-manager.ts
+++ b/packages/core/src/language-server/config-manager.ts
@@ -1,0 +1,39 @@
+import ts from 'typescript';
+
+export type TsUserConfigLang = 'typescript' | 'javascript';
+
+// The ConfigManager holds TypeScript/JS formating and user preferences.
+// It is only needed for the vscode binding
+export class ConfigManager {
+  private formatCodeOptions: Record<TsUserConfigLang, ts.FormatCodeSettings> = {
+    javascript: ts.getDefaultFormatCodeSettings(),
+    typescript: ts.getDefaultFormatCodeSettings(),
+  };
+
+  private userPreferences: Record<TsUserConfigLang, ts.UserPreferences> = {
+    typescript: {},
+    javascript: {},
+  };
+
+  public updateTsJsFormatConfig(lang: TsUserConfigLang, config: ts.FormatCodeSettings): void {
+    this.formatCodeOptions[lang] = {
+      ...this.formatCodeOptions[lang],
+      ...config,
+    };
+  }
+
+  public updateTsJsUserPreferences(lang: TsUserConfigLang, config: ts.UserPreferences): void {
+    this.userPreferences[lang] = {
+      ...this.userPreferences[lang],
+      ...config,
+    };
+  }
+
+  public getUserSettingsFor(lang: TsUserConfigLang): ts.UserPreferences {
+    return this.userPreferences[lang];
+  }
+
+  public getFormatCodeSettingsFor(lang: TsUserConfigLang): ts.FormatCodeSettings {
+    return this.formatCodeOptions[lang];
+  }
+}

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -156,6 +156,7 @@ export default class GlintLanguageServer {
         if (!file || file.fileName !== filePath) return [];
 
         return {
+          code: diagnostic.code,
           severity: severityForDiagnostic(this.ts, diagnostic),
           message: this.ts.flattenDiagnosticMessageText(messageText, '\n'),
           source: `glint${diagnostic.code ? `:ts(${diagnostic.code})` : ''}`,
@@ -401,7 +402,7 @@ export default class GlintLanguageServer {
     formatting: ts.FormatCodeSettings = {},
     preferences: ts.UserPreferences = {}
   ): CodeAction[] {
-    let errorCodes = this.cleanDiagnosticCode(diagnostics);
+    let errorCodes = this.filterDiagnosticCodes(diagnostics);
 
     let { transformedStart, transformedEnd, transformedFileName } =
       this.getTransformedOffsetsFromPositions(
@@ -436,13 +437,11 @@ export default class GlintLanguageServer {
     );
   }
 
-  private cleanDiagnosticCode(diagnostics: Diagnostic[]): number[] {
+  private filterDiagnosticCodes(diagnostics: Diagnostic[]): number[] {
     return diagnostics
       .map((diag) => {
-        if (diag.code) {
+        if (diag.code && diag.source?.startsWith('glint')) {
           return typeof diag.code === 'string' ? parseInt(diag.code) : diag.code;
-        } else if (diag.source && diag.source.startsWith('glint:ts(')) {
-          return parseInt(diag.source.replace('glint:ts(', '').replace(')', ''));
         }
 
         return undefined;

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -374,7 +374,7 @@ export default class GlintLanguageServer {
 
   public getCodeActions(
     uri: string,
-    actionType: 'quickfix' | undefined,
+    actionType: string,
     range: Range,
     diagnosticCodes: Diagnostic[],
     formatOptions: ts.FormatCodeSettings = {},

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -374,7 +374,7 @@ export default class GlintLanguageServer {
 
   public getCodeActions(
     uri: string,
-    actionType: string,
+    actionKind: string,
     range: Range,
     diagnosticCodes: Diagnostic[],
     formatOptions: ts.FormatCodeSettings = {},
@@ -383,7 +383,7 @@ export default class GlintLanguageServer {
     // Only supports quickfixes right now but this can be expanded to support all of the
     // the different CodeActionKinds (Refactorings, Imports, etc).
     // @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
-    if (actionType === CodeActionKind.QuickFix) {
+    if (actionKind === CodeActionKind.QuickFix) {
       return this.applyCodeAction(uri, range, diagnosticCodes, formatOptions, preferences);
     }
 

--- a/packages/core/src/language-server/index.ts
+++ b/packages/core/src/language-server/index.ts
@@ -2,12 +2,14 @@ import { TextDocuments, createConnection } from 'vscode-languageserver/node.js';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { bindLanguageServerPool } from './binding.js';
 import { LanguageServerPool } from './pool.js';
+import { ConfigManager } from './config-manager.js';
 
 const connection = createConnection(process.stdin, process.stdout);
 const openDocuments = new TextDocuments(TextDocument);
+const configManager = new ConfigManager();
 const pool = new LanguageServerPool(connection, openDocuments);
 
-bindLanguageServerPool({ connection, openDocuments, pool });
+bindLanguageServerPool({ connection, openDocuments, pool, configManager });
 
 openDocuments.listen(connection);
 connection.listen();

--- a/packages/core/src/transform/template/transformed-module.ts
+++ b/packages/core/src/transform/template/transformed-module.ts
@@ -184,7 +184,7 @@ export default class TransformedModule {
     for (let span of this.correlatedSpans) {
       if (
         transformedOffset >= span.transformedStart &&
-        transformedOffset < span.transformedStart + span.transformedLength
+        transformedOffset <= span.transformedStart + span.transformedLength
       ) {
         return {
           originalOffset: transformedOffset - span.transformedStart + span.originalStart,

--- a/packages/vscode/__tests__/smoketest-js-glimmerx.test.ts
+++ b/packages/vscode/__tests__/smoketest-js-glimmerx.test.ts
@@ -1,4 +1,14 @@
-import { commands, languages, Position, ViewColumn, window, Uri, Range } from 'vscode';
+import {
+  commands,
+  languages,
+  Position,
+  ViewColumn,
+  window,
+  Uri,
+  Range,
+  CodeAction,
+  workspace,
+} from 'vscode';
 import * as path from 'path';
 import { waitUntil } from './helpers/async';
 
@@ -64,6 +74,38 @@ describe('Smoke test: js-glimmerx', () => {
           range: new Range(10, 15, 10, 18),
         },
       ]);
+    });
+
+    test('glint-ignore codeaction in JS files', async () => {
+      let scriptURI = Uri.file(`${rootDir}/src/SimpleComponent.js`);
+
+      // Open the script and the template
+      let scriptEditor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
+
+      // Ensure neither has any diagnostic messages
+      expect(languages.getDiagnostics(scriptURI)).toEqual([]);
+
+      // Comment out a property in the script that's referenced in the template
+      await scriptEditor.edit((edit) => {
+        edit.insert(new Position(11, 27), ' {{@undocumentedProperty}}');
+      });
+
+      // Wait for a diagnostic to appear in the template
+      await waitUntil(() => {
+        const diagnostics = languages.getDiagnostics(scriptURI);
+        return diagnostics.length;
+      });
+
+      const fixes = await commands.executeCommand<CodeAction[]>(
+        'vscode.executeCodeActionProvider',
+        scriptURI,
+        new Range(new Position(11, 32), new Position(11, 32))
+      );
+
+      // select ignore
+      await workspace.applyEdit(fixes![0].edit!);
+
+      await waitUntil(() => scriptEditor.document.getText().includes('glint-ignore'));
     });
   });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import {
   window,
   commands,
   workspace,
+  WorkspaceConfiguration,
 } from 'vscode';
 import { Disposable, LanguageClient, ServerOptions } from 'vscode-languageclient/node.js';
 import type { Request, GetIRRequest } from '@glint/core/lsp-messages';
@@ -107,9 +108,31 @@ async function addWorkspaceFolder(
   if (!serverPath) return;
 
   let serverOptions: ServerOptions = { module: serverPath };
+
+  const typescriptFormatOptions = getOptions(workspace.getConfiguration('typescript'), 'format');
+  const typescriptUserPreferences = getOptions(
+    workspace.getConfiguration('typescript'),
+    'preferences'
+  );
+  const javascriptFormatOptions = getOptions(workspace.getConfiguration('javascript'), 'format');
+  const javascriptUserPreferences = getOptions(
+    workspace.getConfiguration('javascript'),
+    'preferences'
+  );
+
   let client = new LanguageClient('glint', 'Glint', serverOptions, {
     workspaceFolder,
     outputChannel,
+    initializationOptions: {
+      javascript: {
+        format: javascriptFormatOptions,
+        preferences: javascriptUserPreferences,
+      },
+      typescript: {
+        format: typescriptFormatOptions,
+        preferences: typescriptUserPreferences,
+      },
+    },
     documentSelector: [{ scheme: 'file', pattern: `${folderPath}/${filePattern}` }],
     synchronize: { fileEvents: watcher },
   });
@@ -165,4 +188,15 @@ function createConfigWatcher(): Disposable {
 // `@glint/core` into the extension.
 function requestKey<R extends Request<string, unknown>>(name: R['name']): R['type'] {
   return name as unknown as R['type'];
+}
+
+// Loads the TypeScript and JavaScript formating options from the workspace and subsets them to
+// pass to the language server.
+function getOptions(config: WorkspaceConfiguration, key: string): object {
+  const formatOptions = config.get<object>(key);
+  if (formatOptions) {
+    return formatOptions;
+  }
+
+  return {};
 }


### PR DESCRIPTION
## What Does This Do?

In practice Glint is language server that translates Ember templates and concepts into TypeScript code that then is typechecked using the off shelf TypeScript typechecker. If there are errors during the checking, text offsets of those errors are translated back into the original text offsets (in Ember templates and concepts) so that the developer can resolve the type errors.

This PR starts to plumb through more capabilities for the Glint language server, specifically we're starting with CodeActions. [CodeActions Requests](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeAction) are sent from the client to server to get for fixes for problems in code including type fixes. Since Glint utilizes the underlying TypeScript infrastructure we can leverage it to ask for CodeFixes that can then be applied to Ember code. This PR addresses 3 tricky areas:

1. The TS Server does not use Language Server Protocol despite that is where LSP originated from so we must convert between `ts.CodeFix` and `lsp.CodeAction`
2. Translation of the fixes must occur before they are applied
3. We should leverage existing formatters that extension is aware of

This PR sets the ground work for these 3 areas.
