### PR TITLE
Ensure adding/removing directives busts any cached typecheck results

### DIFF
--- a/packages/core/__tests__/cli/build-watch.test.ts
+++ b/packages/core/__tests__/cli/build-watch.test.ts
@@ -208,6 +208,7 @@ describe('CLI: watched build mode typechecking', () => {
 
       await watch.terminate();
     });
+
     test('reports on errors introduced after removing a glint-nocheck directive', async () => {
       let code = stripIndent`
         import '@glint/environment-ember-template-imports';

--- a/packages/core/__tests__/cli/build-watch.test.ts
+++ b/packages/core/__tests__/cli/build-watch.test.ts
@@ -208,6 +208,41 @@ describe('CLI: watched build mode typechecking', () => {
 
       await watch.terminate();
     });
+    test('reports on errors introduced after removing a glint-nocheck directive', async () => {
+      let code = stripIndent`
+        import '@glint/environment-ember-template-imports';
+        import Component from '@glimmer/component';
+
+        type ApplicationArgs = {
+          version: string;
+        };
+
+        export default class Application extends Component<{ Args: ApplicationArgs }> {
+          private startupTime = new Date().toISOString();
+
+          <template>
+            {{! @glint-nocheck }}
+            <DoesNotExistYet />
+          </template>
+        }
+      `;
+
+      project.write(INPUT_SFC, code);
+
+      let watch = project.buildWatch({ reject: true });
+
+      let output = await watch.awaitOutput('Watching for file changes.');
+      expect(output).toMatch('Found 0 errors.');
+
+      await pauseForTSBuffering();
+
+      project.write(INPUT_SFC, code.replace('{{! @glint-nocheck }}', ''));
+
+      output = await watch.awaitOutput('Watching for file changes.');
+      expect(output).toMatch('Found 1 error.');
+
+      await watch.terminate();
+    });
   });
 
   describe('composite projects', () => {

--- a/packages/core/__tests__/transform/debug.test.ts
+++ b/packages/core/__tests__/transform/debug.test.ts
@@ -256,11 +256,11 @@ describe('Transform: Debug utilities', () => {
 
         | Mapping: TemplateEmbedding
         |  hbs(295:419): hbs\`\\\\n    <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>\\\\n  \`
-        |  ts(556:946):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }\\\\n  𝚪; χ;\\\\n})
+        |  ts(556:973):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    // @glint-expect-error\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: Template
         | |  hbs(299:418): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
-        | |  ts(736:935):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
+        | |  ts(736:962):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    // @glint-expect-error\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
         | |
         | | | Mapping: TextContent
         | | |  hbs(299:304):
@@ -268,7 +268,7 @@ describe('Transform: Debug utilities', () => {
         | | |
         | | | Mapping: ElementNode
         | | |  hbs(304:415): <p ...attributes>\\\\n      Hello, {{@foo}}!\\\\n\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\n      {{@bar}}\\\\n    </p>
-        | | |  ts(736:935):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
+        | | |  ts(736:962):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    // @glint-expect-error\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
         | | |
         | | | | Mapping: AttrNode
         | | | |  hbs(307:320): ...attributes
@@ -298,34 +298,34 @@ describe('Transform: Debug utilities', () => {
         | | | |
         | | | | Mapping: MustacheCommentStatement
         | | | |  hbs(352:391): {{! @glint-expect-error: no @bar arg }}
-        | | | |  ts(878:878):
+        | | | |  ts(878:905):  // @glint-expect-error
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(392:398):
-        | | | |  ts(878:878):
+        | | | |  ts(905:905):
         | | | |
         | | | | Mapping: MustacheStatement
         | | | |  hbs(398:406): {{@bar}}
-        | | | |  ts(878:929):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)())
+        | | | |  ts(905:956):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)())
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(400:404): @bar
-        | | | | |  ts(914:925):  𝚪.args.bar
+        | | | | |  ts(941:952):  𝚪.args.bar
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(401:404): bar
-        | | | | | |  ts(922:925):  bar
+        | | | | | |  ts(949:952):  bar
         | | | | | |
         | | | | |
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(406:411):
-        | | | |  ts(931:931):
+        | | | |  ts(958:958):
         | | | |
         | | |
         | | | Mapping: TextContent
         | | |  hbs(415:418):
-        | | |  ts(935:935):
+        | | |  ts(962:962):
         | | |
         | |
         |"
@@ -421,11 +421,11 @@ describe('Transform: Debug utilities', () => {
 
         | Mapping: TemplateEmbedding
         |  hbs(306:437): hbs\`\\\\r\\\\n    <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>\\\\r\\\\n  \`
-        |  ts(565:955):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }\\\\n  𝚪; χ;\\\\n})
+        |  ts(565:982):  ({} as typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")).templateForBackingValue(this, function(𝚪, χ: typeof import(\\"@glint/environment-glimmerx/-private/dsl\\")) {\\\\n  hbs;\\\\n  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    // @glint-expect-error\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }\\\\n  𝚪; χ;\\\\n})
         |
         | | Mapping: Template
         | |  hbs(310:436): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
-        | |  ts(745:944):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
+        | |  ts(745:971):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    // @glint-expect-error\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
         | |
         | | | Mapping: TextContent
         | | |  hbs(310:316):
@@ -433,7 +433,7 @@ describe('Transform: Debug utilities', () => {
         | | |
         | | | Mapping: ElementNode
         | | |  hbs(316:432): <p ...attributes>\\\\r\\\\n      Hello, {{@foo}}!\\\\r\\\\n\\\\r\\\\n      {{! @glint-expect-error: no @bar arg }}\\\\r\\\\n      {{@bar}}\\\\r\\\\n    </p>
-        | | |  ts(745:944):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
+        | | |  ts(745:971):  {\\\\n    const 𝛄 = χ.emitElement(\\"p\\");\\\\n    χ.applySplattributes(𝚪.element, 𝛄.element);\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.foo)());\\\\n    // @glint-expect-error\\\\n    χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)());\\\\n  }
         | | |
         | | | | Mapping: AttrNode
         | | | |  hbs(319:332): ...attributes
@@ -463,34 +463,34 @@ describe('Transform: Debug utilities', () => {
         | | | |
         | | | | Mapping: MustacheCommentStatement
         | | | |  hbs(367:406): {{! @glint-expect-error: no @bar arg }}
-        | | | |  ts(887:887):
+        | | | |  ts(887:914):  // @glint-expect-error
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(408:414):
-        | | | |  ts(887:887):
+        | | | |  ts(914:914):
         | | | |
         | | | | Mapping: MustacheStatement
         | | | |  hbs(414:422): {{@bar}}
-        | | | |  ts(887:938):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)())
+        | | | |  ts(914:965):  χ.emitContent(χ.resolveOrReturn(𝚪.args.bar)())
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(416:420): @bar
-        | | | | |  ts(923:934):  𝚪.args.bar
+        | | | | |  ts(950:961):  𝚪.args.bar
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(417:420): bar
-        | | | | | |  ts(931:934):  bar
+        | | | | | |  ts(958:961):  bar
         | | | | | |
         | | | | |
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(422:428):
-        | | | |  ts(940:940):
+        | | | |  ts(967:967):
         | | | |
         | | |
         | | | Mapping: TextContent
         | | |  hbs(432:436):
-        | | |  ts(944:944):
+        | | |  ts(971:971):
         | | |
         | |
         |"

--- a/packages/core/__tests__/transform/template-to-typescript.test.ts
+++ b/packages/core/__tests__/transform/template-to-typescript.test.ts
@@ -143,7 +143,8 @@ describe('Transform: rewriteTemplate', () => {
         },
       ]);
       expect(templateBody(template)).toMatchInlineSnapshot(`
-        "{
+        "// @glint-nocheck
+        {
           const 𝛄 = χ.emitComponent(χ.resolve(χ.Globals[\\"Foo\\"])());
           𝛄;
         }

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -134,11 +134,11 @@ export function templateToTypescript(
     }
 
     function emitComment(node: AST.MustacheCommentStatement | AST.CommentStatement): void {
-      emit.nothing(node);
-
       let text = node.value.trim();
       let match = /^@glint-([a-z-]+)/i.exec(text);
-      if (!match) return;
+      if (!match) {
+        return emit.nothing(node);
+      }
 
       let kind = match[1];
       let location = rangeForNode(node);
@@ -151,6 +151,11 @@ export function templateToTypescript(
       } else {
         record.error(`Unknown directive @glint-${kind}`, location);
       }
+
+      emit.forNode(node, () => {
+        emit.text(`// @glint-${kind}`);
+        emit.newline();
+      });
     }
 
     // Captures the context in which a given invocation (i.e. a mustache or


### PR DESCRIPTION
**Fix info from @dfreeman:**

Whether a file contains e.g. a `@glint-nocheck` directive doesn't impact what TypeScript itself sees in that module, only whether we emit errors from it or not. This means that in incremental builds, removing that directive won't produce a visible change from TypeScript's perspective, so we won't emit the now-revealed errors until the next time the `tsbuildinfo` cache is cleared.

This PR just has us emit a comment anywhere we see a `@glint` directive so that the contents of the transformed file will change if a directive comes or goes and TS will reconsider it for typechecking.

**Original writeup of the bug from @hmajoros:**

I believe I have found a bug in `glint --build --watch`, and generally, the same thing happens when running `glint --build` twice in a row.

STR: setup your project with a template ignored via the `{{! @glint-nocheck }}` flag, that would throw a type error in the absence of the nocheck directive. run a `glint --build --watch`, validate that it passes because of the nocheck directive. remove the directive, and notice that the `--build --watch` process does not pick up the fact that there is now a type error from the template.

Same issue can be reproduced running consecutive `glint --build`'s removing the nocheck directive in between runs.

Only way to fix this currently is to run `glint --build --clean` after removing the directive, then re-running `--build`

This PR adds a failing test to reproduce the behavior: after removing the nocheck directive, we would expect the output to show 1 error, instead it shows none.