### PR TITLE
Add support for logical operators (RFC 562)

### DIFF
--- a/packages/core/__tests__/transform/template-to-typescript.test.ts
+++ b/packages/core/__tests__/transform/template-to-typescript.test.ts
@@ -611,6 +611,67 @@ describe('Transform: rewriteTemplate', () => {
         `);
       });
     });
+
+    describe('{{and}}', () => {
+      test('with two arguments', () => {
+        let template = stripIndent`
+        {{log (testAnd 1 2)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testAnd'], specialForms: { testAnd: '&&' } }))
+          .toMatchInlineSnapshot(`
+        "χ.emitContent(χ.resolve(log)((1 && 2)));"
+        `);
+      });
+
+      test('with three arguments', () => {
+        let template = stripIndent`
+        {{log (testAnd 1 2 3)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testAnd'], specialForms: { testAnd: '&&' } }))
+          .toMatchInlineSnapshot(`
+        "χ.emitContent(χ.resolve(log)((1 && 2 && 3)));"
+        `);
+      });
+    });
+
+    describe('{{or}}', () => {
+      test('with two arguments', () => {
+        let template = stripIndent`
+        {{log (testOr 1 2)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testOr'], specialForms: { testOr: '||' } }))
+          .toMatchInlineSnapshot(`
+        "χ.emitContent(χ.resolve(log)((1 || 2)));"
+        `);
+      });
+
+      test('with three arguments', () => {
+        let template = stripIndent`
+        {{log (testOr 1 2 3)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testOr'], specialForms: { testOr: '||' } }))
+          .toMatchInlineSnapshot(`
+        "χ.emitContent(χ.resolve(log)((1 || 2 || 3)));"
+        `);
+      });
+    });
+
+    describe('{{not}}', () => {
+      test('with one argument', () => {
+        let template = stripIndent`
+        {{log (testNot 1)}}
+        `;
+
+        expect(templateBody(template, { globals: ['testNot'], specialForms: { testNot: '!' } }))
+          .toMatchInlineSnapshot(`
+        "χ.emitContent(χ.resolve(log)(!1));"
+        `);
+      });
+    });
   });
 
   describe('inline curlies', () => {
@@ -1361,6 +1422,90 @@ describe('Transform: rewriteTemplate', () => {
         {
           message: '{{testNeq}} requires exactly two parameters',
           location: { start: 11, end: 34 },
+        },
+      ]);
+    });
+
+    test('{{and}} with named parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testAnd 123 456 foo="bar"}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testAnd: '&&' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testAnd}} only accepts positional parameters',
+          location: { start: 11, end: 40 },
+        },
+      ]);
+    });
+
+    test('{{and}} with wrong number of parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testAnd 123}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testAnd: '&&' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testAnd}} requires at least two parameters',
+          location: { start: 11, end: 26 },
+        },
+      ]);
+    });
+
+    test('{{or}} with named parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testOr 123 456 foo="bar"}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testOr: '||' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testOr}} only accepts positional parameters',
+          location: { start: 11, end: 39 },
+        },
+      ]);
+    });
+
+    test('{{or}} with wrong number of parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testOr 123}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testOr: '||' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testOr}} requires at least two parameters',
+          location: { start: 11, end: 25 },
+        },
+      ]);
+    });
+
+    test('{{not}} with named parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testNot 123 foo="bar"}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testNot: '!' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testNot}} only accepts positional parameters',
+          location: { start: 11, end: 36 },
+        },
+      ]);
+    });
+
+    test('{{not}} with wrong number of parameters', () => {
+      let { errors } = templateToTypescript('<Foo @attr={{testNot 123 456}} />', {
+        typesModule: '@glint/template',
+        specialForms: { testNot: '!' },
+      });
+
+      expect(errors).toEqual([
+        {
+          message: '{{testNot}} requires exactly one parameter',
+          location: { start: 11, end: 30 },
         },
       ]);
     });

--- a/packages/core/src/config/types.cts
+++ b/packages/core/src/config/types.cts
@@ -48,7 +48,10 @@ export type GlintSpecialForm =
   | 'object-literal'
   | 'array-literal'
   | '==='
-  | '!==';
+  | '!=='
+  | '&&'
+  | '||'
+  | '!';
 export type GlintSpecialFormConfig = {
   globals?: { [global: string]: GlintSpecialForm };
   imports?: {


### PR DESCRIPTION
Resolves #221. With this PR merged, you should be able to fully make use of type narrowing for discriminated unions.

Note that the type effects of these operators do not strictly match the semantics specified by RFC 562, in that they express **JavaScript truthiness** instead of **Handlebars truthiness**. It's not clear to me that it is possible to express Handlebars truthiness in TypeScript in such a way that you can usefully narrow types with it in combination with logical operators.

As these helpers have not yet been merged into Ember, you can opt in by adding to your glint config:

```json
{
  "glint": {
    "environment": {
      "ember-loose": {
        "additionalSpecialForms": {
          "globals": {
            "and": "&&",
            "or": "||",
            "not": "!"
          }
        }
      },
      "ember-template-imports": {
        "additionalSpecialForms": {
          "imports": {
            "ember-truth-helpers/helpers/and": { "default": "&&" },
            "ember-truth-helpers/helpers/or": { "default": "||" },
            "ember-truth-helpers/helpers/not": { "default": "!" }
          }
        }
      }
    }
  }
}
```