### PR TITLE
Declare `@ember/test-helpers` as a peerDependency

### DIFF
--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -28,6 +28,7 @@
     "registry/**/*.{js,d.ts}"
   ],
   "peerDependencies": {
+    "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@glint/template": "^1.0.0-beta.2",
     "@types/ember__array": "^4.0.2",
@@ -62,6 +63,7 @@
     }
   },
   "devDependencies": {
+    "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@types/ember__array": "^4.0.2",
     "@types/ember__component": "^4.0.10",


### PR DESCRIPTION
Update (2023-01-17):

Demonstration of problem across all package managers: https://github.com/NullVoxPopuli/repro-v2-addon-ts-test-helpers-issue/actions/runs/3943846299

---------

Related to: https://github.com/typed-ember/glint/issues/515
I'm working on adding a thorough test for the `--typescript` flag over here: https://github.com/embroider-build/addon-blueprint/pull/89

_but_, I was getting TS errors because `@glint/environment-ember-loose` [imports a package](https://github.com/typed-ember/glint/blob/11a69e8e835329ef88dd77ee4820e85ef0b760ef/packages/environment-ember-loose/-private/dsl/integration-declarations.d.ts#L102) that it did not declare in its package.json.

<details><summary>details</summary>

after this PR: https://github.com/embroider-build/addon-blueprint/pull/96

```
 prepare$ pnpm build
. prepare: > my-addon@0.0.0 build /private/var/folders/q2/ympzs0z52tq2r4lv2gl0849w0000gn/T/v2-addon-blueprint--e4UDnn/my-addon
. prepare: > pnpm --filter my-addon build
. prepare: > my-addon@0.0.0 build /private/var/folders/q2/ympzs0z52tq2r4lv2gl0849w0000gn/T/v2-addon-blueprint--e4UDnn/my-addon/my-addon
. prepare: > rollup --config
. prepare:
. prepare:  → dist...
. prepare: (!) Generated empty chunks
. prepare: index, template-registry
. prepare: [!] (plugin Typescript) TS2688: Cannot find type definition file for 'ember__test-helpers'.
. prepare:   The file is in the program because:
. prepare:     Entry point for implicit type library 'ember__test-helpers'
. prepare: undefined
. prepare: /private/var/folders/q2/ympzs0z52tq2r4lv2gl0849w0000gn/T/v2-addon-blueprint--e4UDnn/my-addon/my-addon:
. prepare:  ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  my-addon@0.0.0 build: `rollup --config`
```

</details>

This likely wasn't caught before because we've all been using `@types/ember__test-helpers` for the longest time, and those type augmentations are global -- and is totally independent of package-manager, unlike what my commit says (I tested on yarn@1 as well)

Now that `@ember/test-helpers` actually publishes its own types (yay!!) -- as of [2.9.0](https://github.com/emberjs/ember-test-helpers/releases/tag/v2.9.0) -- I think we had a silly timing issue between the different repo's expectations.

This PR adds `@ember/test-helpers ^2.9.x` as a peerDep, so that consumers install it.
