### PR TITLE
Validate that TS meets our minimum supported version requirement

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@glimmer/syntax": "^0.84.2",
     "escape-string-regexp": "^4.0.0",
+    "semver": "^7.3.8",
     "silent-error": "^1.1.1",
     "uuid": "^8.3.2",
     "vscode-languageserver": "^8.0.1",
@@ -45,6 +46,7 @@
     "glint-monorepo-test-utils": "^1.0.0-beta.2",
     "@types/common-tags": "^1.8.0",
     "@types/node": "^18.11.5",
+    "@types/semver": "^7.3.13",
     "@types/uuid": "^8.3.4",
     "@types/yargs": "^17.0.10",
     "@vitest/ui": "^0.23.4",

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -7,6 +7,7 @@ import { determineOptionsToExtend } from './options.js';
 import { performBuild } from './perform-build.js';
 import type * as TS from 'typescript';
 import { performBuildWatch } from './perform-build-watch.js';
+import { validateTSOrExit } from '../common/typescript-compatibility.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -96,10 +97,8 @@ if (argv.build) {
   // root of a project which has no `Glint` config *at all* in its root, but
   // which must have *some* TS to be useful.
   let ts = findTypeScript(cwd);
-  if (!ts) {
-    console.error('Could not find a local TypeScript');
-    process.exit(1);
-  }
+
+  validateTSOrExit(ts);
 
   // This continues using the hack of a 'default command' to get the projects
   // specified (if any).
@@ -113,6 +112,9 @@ if (argv.build) {
 } else {
   const glintConfig = loadConfig(argv.project ?? cwd);
   const optionsToExtend = determineOptionsToExtend(argv);
+
+  validateTSOrExit(glintConfig.ts);
+
   if (argv.watch) {
     performWatch(glintConfig, optionsToExtend);
   } else {

--- a/packages/core/src/common/typescript-compatibility.ts
+++ b/packages/core/src/common/typescript-compatibility.ts
@@ -1,0 +1,38 @@
+import semver from 'semver';
+import { TSLib } from '../transform/util.js';
+
+export const MINIMUM_VERSION = '4.8.0';
+
+export type ValidationResult = { valid: true; ts: TSLib } | { valid: false; reason: string };
+
+/**
+ * Ensures that the given copy of TypeScript is a) present, and
+ * b) a supported version.
+ */
+export function validateTS(ts: TSLib | null): ValidationResult {
+  if (!ts) {
+    return { valid: false, reason: 'Unable to locate `typescript` library' };
+  }
+
+  if (!semver.gte(ts.version, MINIMUM_VERSION)) {
+    return {
+      valid: false,
+      reason: `Expected TypeScript >= ${MINIMUM_VERSION}, but found ${ts.version}`,
+    };
+  }
+
+  return { valid: true, ts };
+}
+
+/**
+ * Validates the given copy of TypeScript as with `validateTS`,
+ * logging an error message and exiting the process if validation
+ * fails.
+ */
+export function validateTSOrExit(ts: TSLib | null): asserts ts {
+  let result = validateTS(ts);
+  if (!result.valid) {
+    console.error(result.reason);
+    process.exit(1);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,7 +2644,7 @@
   resolved "https://registry.yarnpkg.com/@types/rsvp/-/rsvp-4.0.4.tgz#55e93e7054027f1ad4b4ebc1e60e59eb091e2d32"
   integrity sha512-J3Ol++HCC7/hwZhanDvggFYU/GtxHxE/e7cGRWxR04BF7Tt3TqJZ84BkzQgDxmX0uu8IagiyfmfoUlBACh2Ilg==
 
-"@types/semver@^7.3.12":
+"@types/semver@^7.3.12", "@types/semver@^7.3.13":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
@@ -13931,7 +13931,7 @@ semver@7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==


### PR DESCRIPTION
This PR expands on #504 (thanks, @NullVoxPopuli!) to enforce that we don't try to run with an older version of TS than we support. It covers both `--build` and non-`--build` invocations of the `glint` CLI, as well as the language server on a per-project basis.

Closes #504 