### PR TITLE
Don't duplicate diagnostic code information

### DIFF
--- a/packages/core/__tests__/language-server/custom-extensions.test.ts
+++ b/packages/core/__tests__/language-server/custom-extensions.test.ts
@@ -37,7 +37,7 @@ describe('Language Server: custom file extensions', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2322)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -61,7 +61,7 @@ describe('Language Server: custom file extensions', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2322)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -170,7 +170,8 @@ describe('Language Server: custom file extensions', () => {
 
     expect(diagnostics).toMatchObject([
       {
-        source: 'glint:ts(2307)',
+        source: 'glint',
+        code: 2307,
         range: {
           start: { line: 0, character: 27 },
           end: { line: 0, character: 36 },
@@ -198,7 +199,8 @@ describe('Language Server: custom file extensions', () => {
       expect(diagnostics).toMatchObject([
         {
           message: "Cannot find module './other' or its corresponding type declarations.",
-          source: 'glint:ts(2307)',
+          source: 'glint',
+          code: 2307,
         },
       ]);
 
@@ -246,7 +248,8 @@ describe('Language Server: custom file extensions', () => {
       expect(diagnostics).toMatchObject([
         {
           message: "Cannot find module './other' or its corresponding type declarations.",
-          source: 'glint:ts(2307)',
+          source: 'glint',
+          code: 2307,
         },
       ]);
     });

--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -68,7 +68,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2554)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -85,7 +85,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2554)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -102,7 +102,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2554)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -119,7 +119,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2555)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -136,7 +136,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2554)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -153,7 +153,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2554)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -170,7 +170,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2555)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -224,7 +224,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2322)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -242,7 +242,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -260,7 +260,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -278,7 +278,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -296,7 +296,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2322)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -314,7 +314,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -332,7 +332,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -350,7 +350,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -412,7 +412,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -429,7 +429,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -446,7 +446,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -463,7 +463,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -480,7 +480,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -497,7 +497,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -514,7 +514,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -531,7 +531,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -583,7 +583,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(7053)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -602,7 +602,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(7053)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -621,7 +621,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(7053)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -640,7 +640,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(7053)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -658,7 +658,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(7053)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -714,7 +714,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -736,7 +736,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -758,7 +758,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2769)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -819,7 +819,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -837,7 +837,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -856,7 +856,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -874,7 +874,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2345)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -919,7 +919,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(4111)",
+          "source": "glint",
           "tags": [],
         },
         {
@@ -936,7 +936,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(4111)",
+          "source": "glint",
           "tags": [],
         },
       ]

--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -72,7 +72,7 @@ describe('Language Server: Diagnostics', () => {
               },
             },
             "severity": 1,
-            "source": "glint:ts(2339)",
+            "source": "glint",
             "tags": [],
           },
           {
@@ -89,7 +89,7 @@ describe('Language Server: Diagnostics', () => {
               },
             },
             "severity": 1,
-            "source": "glint:ts(2322)",
+            "source": "glint",
             "tags": [],
           },
         ]
@@ -121,7 +121,8 @@ describe('Language Server: Diagnostics', () => {
       expect(diagnostics).toMatchObject([
         {
           message: "Property 'foo' does not exist on type '{}'.",
-          source: 'glint:ts(2339)',
+          source: 'glint',
+          code: 2339,
         },
       ]);
 
@@ -162,7 +163,8 @@ describe('Language Server: Diagnostics', () => {
       expect(diagnostics).toMatchObject([
         {
           message: "Property 'foo' does not exist on type '{}'.",
-          source: 'glint:ts(2339)',
+          source: 'glint',
+          code: 2339,
         },
       ]);
     });
@@ -208,7 +210,7 @@ describe('Language Server: Diagnostics', () => {
             },
           },
           "severity": 4,
-          "source": "glint:ts(6133)",
+          "source": "glint",
           "tags": [
             1,
           ],
@@ -227,7 +229,7 @@ describe('Language Server: Diagnostics', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2551)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -281,7 +283,7 @@ describe('Language Server: Diagnostics', () => {
             },
           },
           "severity": 4,
-          "source": "glint:ts(6133)",
+          "source": "glint",
           "tags": [
             1,
           ],
@@ -305,7 +307,7 @@ describe('Language Server: Diagnostics', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2551)",
+          "source": "glint",
           "tags": [],
         },
       ]
@@ -377,7 +379,7 @@ describe('Language Server: Diagnostics', () => {
             },
           },
           "severity": 1,
-          "source": "glint:ts(2339)",
+          "source": "glint",
           "tags": [],
         },
       ]

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -156,10 +156,10 @@ export default class GlintLanguageServer {
         if (!file || file.fileName !== filePath) return [];
 
         return {
+          source: 'glint',
           code: diagnostic.code,
           severity: severityForDiagnostic(this.ts, diagnostic),
           message: this.ts.flattenDiagnosticMessageText(messageText, '\n'),
-          source: `glint${diagnostic.code ? `:ts(${diagnostic.code})` : ''}`,
           tags: tagsForDiagnostic(diagnostic),
           range: {
             start: offsetToPosition(file.text, start),

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -76,7 +76,8 @@ describe('Smoke test: Ember', () => {
       expect(languages.getDiagnostics(templateURI)).toMatchObject([
         {
           message: "Property 'message' does not exist on type 'ColocatedLayoutComponent'.",
-          source: 'glint:ts(2339)',
+          source: 'glint',
+          code: 2339,
           range: new Range(0, 7, 0, 14),
         },
       ]);
@@ -100,7 +101,8 @@ describe('Smoke test: Ember', () => {
       expect(languages.getDiagnostics(scriptURI)).toMatchObject([
         {
           message: "Property 'foo' does not exist on type 'MyTestContext'.",
-          source: 'glint:ts(2339)',
+          source: 'glint',
+          code: 2339,
           range: new Range(17, 13, 17, 16),
         },
       ]);

--- a/packages/vscode/__tests__/smoketest-js-glimmerx.test.ts
+++ b/packages/vscode/__tests__/smoketest-js-glimmerx.test.ts
@@ -46,7 +46,8 @@ describe('Smoke test: js-glimmerx', () => {
       expect(languages.getDiagnostics(scriptURI)).toMatchObject([
         {
           message: "Property 'undocumentedProperty' does not exist on type '{ message: string; }'.",
-          source: 'glint:ts(2339)',
+          source: 'glint',
+          code: 2339,
           range: new Range(11, 31, 11, 51),
         },
       ]);
@@ -70,7 +71,8 @@ describe('Smoke test: js-glimmerx', () => {
       expect(languages.getDiagnostics(scriptURI)).toMatchObject([
         {
           message: "Property 'foo' does not exist on type 'TestComponent'.",
-          source: 'glint:ts(2339)',
+          source: 'glint',
+          code: 2339,
           range: new Range(10, 15, 10, 18),
         },
       ]);

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -44,7 +44,8 @@ describe('Smoke test: ETI Environment', () => {
       expect(languages.getDiagnostics(scriptURI)).toMatchObject([
         {
           message: "Type 'number' is not assignable to type 'string'.",
-          source: 'glint:ts(2322)',
+          source: 'glint',
+          code: 2322,
           range: new Range(6, 13, 6, 19),
         },
       ]);


### PR DESCRIPTION
Now that we're correctly tracking diagnostic `code` in its own field, also embedding it in `source` is redundant and can result in the editor showing a diagnostic's code twice, e.g. `glint:ts(2345)(2345)`.

This change simplifies the source to just `glint` (dropping the `ts:` part, since we don't invent our own error codes apart from TypeScript's), allowing the editor to construct the tag as e.g. `glint(2345)` itself.