### PR TITLE
Explicitly note the `Library Path` extension setting

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -16,10 +16,13 @@ See the [Glint home page] for a more detailed Getting Started guide.
 
 [glint home page]: https://typed-ember.gitbook.io/glint
 
-If the location where `@glint/core` is installed isn't in the root of your Code workspace, you can inform the extension on a per-workspace basis where to locate the language server in the Glint extension settings.
+### Monorepos and Other Non-Workspace-Root Installations
+
+If the location where `@glint/core` is installed isn't in the root of your Code workspace, you can inform the extension on a per-workspace basis where to locate the language server in the Glint extension settings under **Glint: Library Path**.
 
 <img width="705" alt="Input for `glint.libaryPath` in the VS Code configuration editor." src="https://user-images.githubusercontent.com/108688/206561138-aca2bb80-04f6-44dd-a23f-032d4f163f7a.png">
 
+For example, if your dependency on `@glint/core` were declared in `frontend/package.json` in your workspace, you could set the library path to `./frontend` in order for the extension to be able to locate it.
 
 ## Usage
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -165,7 +165,9 @@ function findLanguageServer(workspaceDir: string): string | null {
     // just bail out if we don't see `@glint/core`. If someone IS expecting Glint to run for this
     // project, though, we leave a message in our channel explaining why we didn't launch.
     outputChannel.appendLine(
-      `Unable to resolve @glint/core from ${resolutionDir} — not launching Glint for this directory.`
+      `Unable to resolve @glint/core from ${resolutionDir} — not launching Glint for this directory.\n` +
+        `If Glint is installed in a child directory, you may wish to set the 'glint.libraryPath' option ` +
+        `in your workspace settings for the Glint VS Code extension.`
     );
 
     return null;


### PR DESCRIPTION
Partially addresses #524, at least making it more explicit what's required. I'll also promote the extension from prerelease to stable when we do our next release so that folks no longer need to opt in to a beta version to have access to this piece of config.