### PR TITLE
feat: Introduce InlayHints

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,17 @@
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
         "${workspaceFolder}/test-packages"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current Test File",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "${relativeFile}"],
+      "smartStep": true,
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/packages/core/__tests__/language-server/inlay.test.ts
+++ b/packages/core/__tests__/language-server/inlay.test.ts
@@ -1,0 +1,84 @@
+import { Project } from 'glint-monorepo-test-utils';
+import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import { Position, Range } from 'vscode-languageserver';
+
+describe('Language Server: iInlays', () => {
+  let project!: Project;
+
+  beforeEach(async () => {
+    project = await Project.create();
+  });
+
+  afterEach(async () => {
+    await project.destroy();
+  });
+
+  test('it provides inlays for return types when preference is set', async () => {
+    project.setGlintConfig({ environment: 'ember-template-imports' });
+    let content = 'const bar = () => true;';
+    project.write('foo.gts', content);
+    let server = project.startLanguageServer();
+
+    const inlays = server.getInlayHints(
+      {
+        textDocument: {
+          uri: project.fileURI('foo.gts'),
+        },
+        range: Range.create(Position.create(0, 0), Position.create(0, content.length)),
+      },
+      {
+        includeInlayFunctionLikeReturnTypeHints: true,
+      }
+    );
+
+    expect(inlays.length).toBe(1);
+    expect(inlays[0].kind).toBe(1);
+    expect(inlays[0].label).toBe(': boolean');
+  });
+
+  test('it provides inlays for variable types when preference is set', async () => {
+    project.setGlintConfig({ environment: 'ember-template-imports' });
+    let content = 'const bar = globalThis.thing ?? null;';
+    project.write('foo.gts', content);
+    let server = project.startLanguageServer();
+
+    const inlays = server.getInlayHints(
+      {
+        textDocument: {
+          uri: project.fileURI('foo.gts'),
+        },
+        range: Range.create(Position.create(0, 0), Position.create(0, content.length)),
+      },
+      {
+        includeInlayVariableTypeHints: true,
+      }
+    );
+
+    expect(inlays.length).toBe(1);
+    expect(inlays[0].kind).toBe(1);
+    expect(inlays[0].label).toBe(': any');
+  });
+
+  test('it provides inlays for property types when preference is set', async () => {
+    project.setGlintConfig({ environment: 'ember-template-imports' });
+    let content = 'class Foo { date = Date.now() }';
+    project.write('foo.gts', content);
+    let server = project.startLanguageServer();
+
+    const inlays = server.getInlayHints(
+      {
+        textDocument: {
+          uri: project.fileURI('foo.gts'),
+        },
+        range: Range.create(Position.create(0, 0), Position.create(0, content.length)),
+      },
+      {
+        includeInlayPropertyDeclarationTypeHints: true,
+      }
+    );
+
+    expect(inlays.length).toBe(1);
+    expect(inlays[0].kind).toBe(1);
+    expect(inlays[0].label).toBe(': number');
+  });
+});

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -26,6 +26,7 @@ export const capabilities: ServerCapabilities = {
   },
   referencesProvider: true,
   hoverProvider: true,
+  inlayHintProvider: true,
   codeActionProvider: {
     codeActionKinds: [CodeActionKind.QuickFix],
   },
@@ -110,6 +111,13 @@ export function bindLanguageServerPool({
     pool.withServerForURI(document.uri, ({ server, scheduleDiagnostics }) => {
       server.updateFile(document.uri, document.getText());
       scheduleDiagnostics();
+    });
+  });
+
+  connection.languages.inlayHint.on((hint) => {
+    return pool.withServerForURI(hint.textDocument.uri, ({ server }) => {
+      let language = server.getLanguageType(hint.textDocument.uri);
+      return server.getInlayHints(hint, configManager.getUserSettingsFor(language));
     });
   });
 

--- a/packages/vscode/src/formatting.ts
+++ b/packages/vscode/src/formatting.ts
@@ -1,0 +1,64 @@
+import { type WorkspaceConfiguration, window } from 'vscode';
+import type * as ts from 'typescript/lib/tsserverlibrary';
+
+// vscode does not hold formatting config with the same interface as typescript
+// the following maps the vscode formatting options into what typescript expects
+// This is heavily borrowed from how the TypeScript works in vscode
+// https://github.com/microsoft/vscode/blob/c04c0b43470c3c743468a5e5e51f036123503452/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts#L133
+export function intoFormatting(
+  config: WorkspaceConfiguration
+): ts.server.protocol.FormatCodeSettings {
+  let editorOptions = window.activeTextEditor?.options;
+  let tabSize = typeof editorOptions?.tabSize === 'string' ? undefined : editorOptions?.tabSize;
+  let insertSpaces =
+    typeof editorOptions?.insertSpaces === 'string' ? undefined : editorOptions?.insertSpaces;
+
+  return {
+    tabSize,
+    indentSize: tabSize,
+    convertTabsToSpaces: insertSpaces,
+    // We can use \n here since the editor normalizes later on to its line endings.
+    newLineCharacter: '\n',
+    insertSpaceAfterCommaDelimiter: config.get<boolean>('insertSpaceAfterCommaDelimiter'),
+    insertSpaceAfterConstructor: config.get<boolean>('insertSpaceAfterConstructor'),
+    insertSpaceAfterSemicolonInForStatements: config.get<boolean>(
+      'insertSpaceAfterSemicolonInForStatements'
+    ),
+    insertSpaceBeforeAndAfterBinaryOperators: config.get<boolean>(
+      'insertSpaceBeforeAndAfterBinaryOperators'
+    ),
+    insertSpaceAfterKeywordsInControlFlowStatements: config.get<boolean>(
+      'insertSpaceAfterKeywordsInControlFlowStatements'
+    ),
+    insertSpaceAfterFunctionKeywordForAnonymousFunctions: config.get<boolean>(
+      'insertSpaceAfterFunctionKeywordForAnonymousFunctions'
+    ),
+    insertSpaceBeforeFunctionParenthesis: config.get<boolean>(
+      'insertSpaceBeforeFunctionParenthesis'
+    ),
+    insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: config.get<boolean>(
+      'insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis'
+    ),
+    insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: config.get<boolean>(
+      'insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets'
+    ),
+    insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: config.get<boolean>(
+      'insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces'
+    ),
+    insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: config.get<boolean>(
+      'insertSpaceAfterOpeningAndBeforeClosingEmptyBraces'
+    ),
+    insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: config.get<boolean>(
+      'insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces'
+    ),
+    insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: config.get<boolean>(
+      'insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces'
+    ),
+    insertSpaceAfterTypeAssertion: config.get<boolean>('insertSpaceAfterTypeAssertion'),
+    placeOpenBraceOnNewLineForFunctions: config.get<boolean>('placeOpenBraceOnNewLineForFunctions'),
+    placeOpenBraceOnNewLineForControlBlocks: config.get<boolean>(
+      'placeOpenBraceOnNewLineForControlBlocks'
+    ),
+    semicolons: config.get<ts.server.protocol.SemicolonPreference>('semicolons'),
+  };
+}

--- a/packages/vscode/src/preferences.ts
+++ b/packages/vscode/src/preferences.ts
@@ -1,0 +1,124 @@
+import type { WorkspaceConfiguration } from 'vscode';
+import type * as ts from 'typescript/lib/tsserverlibrary';
+
+// vscode does not hold preferences with the same interface as typescript
+// the following maps the vscode typescript preferences into what typescript expects
+// This is heavily borrowed from vscode
+// https://github.com/microsoft/vscode/blob/c04c0b43470c3c743468a5e5e51f036123503452/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts#L167
+export function intoPreferences(
+  config: WorkspaceConfiguration,
+  preferences: WorkspaceConfiguration
+): ts.server.protocol.UserPreferences {
+  return {
+    quotePreference: getQuoteStylePreference(preferences),
+    importModuleSpecifierPreference: getImportModuleSpecifierPreference(preferences),
+    importModuleSpecifierEnding: getImportModuleSpecifierEndingPreference(preferences),
+    includeCompletionsWithClassMemberSnippets: config.get<boolean>(
+      'suggest.classMemberSnippets.enabled',
+      true
+    ),
+    includeCompletionsWithObjectLiteralMethodSnippets: config.get<boolean>(
+      'suggest.objectLiteralMethodSnippets.enabled',
+      true
+    ),
+    includeCompletionsWithSnippetText: true,
+    useLabelDetailsInCompletionEntries: true,
+    allowIncompleteCompletions: true,
+    displayPartsForJSDoc: true,
+    ...getInlayHintsPreferences(config),
+  };
+}
+
+function getQuoteStylePreference(config: WorkspaceConfiguration): 'single' | 'double' | 'auto' {
+  switch (config.get<string>('quoteStyle')) {
+    case 'single':
+      return 'single';
+    case 'double':
+      return 'double';
+    default:
+      return 'auto';
+  }
+}
+
+function getImportModuleSpecifierEndingPreference(
+  config: WorkspaceConfiguration
+): 'minimal' | 'index' | 'js' | 'auto' {
+  switch (config.get<string>('importModuleSpecifierEnding')) {
+    case 'minimal':
+      return 'minimal';
+    case 'index':
+      return 'index';
+    case 'js':
+      return 'js';
+    default:
+      return 'auto';
+  }
+}
+
+function getImportModuleSpecifierPreference(
+  config: WorkspaceConfiguration
+): 'project-relative' | 'relative' | 'non-relative' | undefined {
+  switch (config.get<string>('importModuleSpecifier')) {
+    case 'project-relative':
+      return 'project-relative';
+    case 'relative':
+      return 'relative';
+    case 'non-relative':
+      return 'non-relative';
+    default:
+      return undefined;
+  }
+}
+
+type InlaysPreferences<T> = T extends `includeInlay${string}` ? T : never;
+
+function getInlayHintsPreferences(
+  config: WorkspaceConfiguration
+): Pick<
+  ts.server.protocol.UserPreferences,
+  InlaysPreferences<keyof ts.server.protocol.UserPreferences>
+> {
+  return {
+    includeInlayParameterNameHints: getInlayParameterNameHintsPreference(config),
+    includeInlayParameterNameHintsWhenArgumentMatchesName: !config.get<boolean>(
+      'inlayHints.parameterNames.suppressWhenArgumentMatchesName',
+      true
+    ),
+    includeInlayFunctionParameterTypeHints: config.get<boolean>(
+      'inlayHints.parameterTypes.enabled',
+      false
+    ),
+    includeInlayVariableTypeHints: config.get<boolean>('inlayHints.variableTypes.enabled', false),
+    includeInlayVariableTypeHintsWhenTypeMatchesName: !config.get<boolean>(
+      'inlayHints.variableTypes.suppressWhenTypeMatchesName',
+      true
+    ),
+    includeInlayPropertyDeclarationTypeHints: config.get<boolean>(
+      'inlayHints.propertyDeclarationTypes.enabled',
+      false
+    ),
+    includeInlayFunctionLikeReturnTypeHints: config.get<boolean>(
+      'inlayHints.functionLikeReturnTypes.enabled',
+      false
+    ),
+    includeInlayEnumMemberValueHints: config.get<boolean>(
+      'inlayHints.enumMemberValues.enabled',
+      false
+    ),
+  } as const;
+}
+
+function getInlayParameterNameHintsPreference(
+  config: WorkspaceConfiguration
+): 'none' | 'literals' | 'all' | undefined {
+  switch (config.get<string>('inlayHints.parameterNames.enabled')) {
+    case 'none':
+      return 'none';
+    case 'literals':
+      return 'literals';
+    case 'all':
+      return 'all';
+    default:
+      return undefined;
+  }
+}


### PR DESCRIPTION
This introduces [InlayHints](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint) to the Glint language server.

As part of this I noticed that for the extension we were not massaging TypeScript and JavaScript preferences and formatting configs correctly. I have largely borrowed how vscode does this re-mapping for TypeScript.