### PR TITLE
Expose TS language service and original document contents in `ProjectAnalysis`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,6 @@ export interface ProjectAnalysis {
   glintConfig: GlintConfig;
   transformManager: TransformManager;
   languageServer: GlintLanguageServer;
-  documents: DocumentCache;
   service: ts.LanguageService;
   shutdown: () => void;
 }
@@ -39,10 +38,9 @@ export function analyzeProject(projectDirectory: string = process.cwd()): Projec
     glintConfig,
     transformManager,
     languageServer,
-    documents,
     service: languageServer.service,
     shutdown,
   };
 }
 
-export type { DocumentCache, TransformManager, GlintConfig, GlintLanguageServer };
+export type { TransformManager, GlintConfig, GlintLanguageServer };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,4 +45,4 @@ export function analyzeProject(projectDirectory: string = process.cwd()): Projec
   };
 }
 
-export { DocumentCache, TransformManager, GlintConfig, loadConfig, GlintLanguageServer };
+export type { DocumentCache, TransformManager, GlintConfig, GlintLanguageServer };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,12 +3,15 @@ import DocumentCache from './common/document-cache.js';
 import TransformManager from './common/transform-manager.js';
 import GlintLanguageServer from './language-server/glint-language-server.js';
 import * as utils from './language-server/util/index.js';
+import * as ts from 'typescript';
 
 /** @internal */
 export interface ProjectAnalysis {
   glintConfig: GlintConfig;
   transformManager: TransformManager;
   languageServer: GlintLanguageServer;
+  documents: DocumentCache;
+  service: ts.LanguageService;
   shutdown: () => void;
 }
 
@@ -32,5 +35,14 @@ export function analyzeProject(projectDirectory: string = process.cwd()): Projec
   let languageServer = new GlintLanguageServer(glintConfig, documents, transformManager);
   let shutdown = (): void => languageServer.dispose();
 
-  return { glintConfig, transformManager, languageServer, shutdown };
+  return {
+    glintConfig,
+    transformManager,
+    languageServer,
+    documents,
+    service: languageServer.service,
+    shutdown,
+  };
 }
+
+export { DocumentCache, TransformManager, GlintConfig, loadConfig, GlintLanguageServer };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,14 +3,12 @@ import DocumentCache from './common/document-cache.js';
 import TransformManager from './common/transform-manager.js';
 import GlintLanguageServer from './language-server/glint-language-server.js';
 import * as utils from './language-server/util/index.js';
-import * as ts from 'typescript';
 
 /** @internal */
 export interface ProjectAnalysis {
   glintConfig: GlintConfig;
   transformManager: TransformManager;
   languageServer: GlintLanguageServer;
-  service: ts.LanguageService;
   shutdown: () => void;
 }
 
@@ -38,7 +36,6 @@ export function analyzeProject(projectDirectory: string = process.cwd()): Projec
     glintConfig,
     transformManager,
     languageServer,
-    service: languageServer.service,
     shutdown,
   };
 }

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -369,6 +369,11 @@ export default class GlintLanguageServer {
     return this.calculateOriginalLocations(references);
   }
 
+  public getOriginalContents(uri: string): string | undefined {
+    let filePath = uriToFilePath(uri);
+    return this.documents.getDocumentContents(filePath);
+  }
+
   public getTransformedContents(uri: string): GetIRResult | undefined {
     let filePath = uriToFilePath(uri);
     let source = this.findDiagnosticsSource(filePath);

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -48,7 +48,7 @@ interface TransformedOffsets {
 }
 
 export default class GlintLanguageServer {
-  private service: ts.LanguageService;
+  readonly service: ts.LanguageService;
   private openFileNames: Set<string>;
   private rootFileNames: Set<string>;
   private ts: typeof import('typescript');


### PR DESCRIPTION
This PR updates `@glint/core` to expose a few more pieces of the language server implementation that should make it easier for Glint to be used programmatically (e.g. in https://github.com/rehearsal-js/rehearsal-js).