### PR TITLE
Switch to a maintained XVFB action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run Tests
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn test
 
@@ -99,7 +99,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run Tests
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn test
 
@@ -127,6 +127,6 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run Tests
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn test


### PR DESCRIPTION
https://github.com/GabrielBB/xvfb-action is no longer maintained and uses a deprecated Node 12 action runner. The README there recommends using https://github.com/coactions/setup-xvfb instead, which has the same interface.