### PR TITLE
Allow `each-in` to accept `key` as a named arg

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
@@ -2,7 +2,10 @@ import { ComponentLike } from '@glint/template';
 
 export type EachInKeyword = abstract new <T>() => InstanceType<
   ComponentLike<{
-    Args: { Positional: [object: T] };
+    Args: {
+      Positional: [object: T]
+      Named: { key?: string }
+    };
     Blocks: {
       default: [key: EachInKey<T>, value: Exclude<T, null | undefined>[EachInKey<T>]];
       else?: [];

--- a/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
@@ -3,8 +3,8 @@ import { ComponentLike } from '@glint/template';
 export type EachInKeyword = abstract new <T>() => InstanceType<
   ComponentLike<{
     Args: {
-      Positional: [object: T]
-      Named: { key?: string }
+      Positional: [object: T];
+      Named: { key?: string };
     };
     Blocks: {
       default: [key: EachInKey<T>, value: Exclude<T, null | undefined>[EachInKey<T>]];

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/each-in.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/each-in.test.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf } from 'expect-type';
-import { emitComponent, Globals, resolve } from '@glint/environment-ember-loose/-private/dsl';
+import {
+  emitComponent,
+  Globals,
+  NamedArgsMarker,
+  resolve
+} from '@glint/environment-ember-loose/-private/dsl';
 
 let eachIn = resolve(Globals['each-in']);
 
@@ -95,5 +100,16 @@ declare const maybeVal: { a: number; b: number } | undefined;
   {
     const [...args] = component.blockParams.else;
     expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}
+
+// Accept a `key` string
+{
+  const component = emitComponent(eachIn({ a: 5, b: 3 }, { key: 'id', ...NamedArgsMarker }));
+
+  {
+    const [key, value] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
+    expectTypeOf(value).toEqualTypeOf<number>();
   }
 }

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/each-in.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/each-in.test.ts
@@ -3,7 +3,7 @@ import {
   emitComponent,
   Globals,
   NamedArgsMarker,
-  resolve
+  resolve,
 } from '@glint/environment-ember-loose/-private/dsl';
 
 let eachIn = resolve(Globals['each-in']);


### PR DESCRIPTION
fixes #541 