### PR TITLE
Bugfixes for the beta.5 `bind-invokable` refactor

### DIFF
--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -786,18 +786,21 @@ describe('Language Server: Diagnostic Augmentation', () => {
     expect(diagnostics).toMatchInlineSnapshot(`
       [
         {
-          "code": 2769,
+          "code": 2345,
           "message": "Unable to pre-bind the given args to the given component. This likely indicates a type mismatch between its signature and the values you're passing.
-        No overload matches this call.
-          The last overload gave the following error.
-            Type 'number' is not assignable to type 'string'.",
+        Argument of type '[{ [NamedArgs]: true; foo: number; }]' is not assignable to parameter of type '[] | [NamedArgs<{ foo: string; }>]'.
+          Type '[{ [NamedArgs]: true; foo: number; }]' is not assignable to type '[NamedArgs<{ foo: string; }>]'.
+            Type '{ [NamedArgs]: true; foo: number; }' is not assignable to type 'NamedArgs<{ foo: string; }>'.
+              Type '{ [NamedArgs]: true; foo: number; }' is not assignable to type '{ foo: string; }'.
+                Types of property 'foo' are incompatible.
+                  Type 'number' is not assignable to type 'string'.",
           "range": {
             "end": {
-              "character": 23,
+              "character": 28,
               "line": 8,
             },
             "start": {
-              "character": 20,
+              "character": 4,
               "line": 8,
             },
           },
@@ -806,18 +809,21 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "code": 2769,
+          "code": 2345,
           "message": "Unable to pre-bind the given args to the given helper. This likely indicates a type mismatch between its signature and the values you're passing.
-        No overload matches this call.
-          The last overload gave the following error.
-            Type 'number' is not assignable to type 'string'.",
+        Argument of type '[{ [NamedArgs]: true; foo: number; }]' is not assignable to parameter of type '[] | [NamedArgs<{ foo: string; }>]'.
+          Type '[{ [NamedArgs]: true; foo: number; }]' is not assignable to type '[NamedArgs<{ foo: string; }>]'.
+            Type '{ [NamedArgs]: true; foo: number; }' is not assignable to type 'NamedArgs<{ foo: string; }>'.
+              Type '{ [NamedArgs]: true; foo: number; }' is not assignable to type '{ foo: string; }'.
+                Types of property 'foo' are incompatible.
+                  Type 'number' is not assignable to type 'string'.",
           "range": {
             "end": {
-              "character": 20,
+              "character": 25,
               "line": 9,
             },
             "start": {
-              "character": 17,
+              "character": 4,
               "line": 9,
             },
           },
@@ -826,18 +832,21 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "tags": [],
         },
         {
-          "code": 2769,
+          "code": 2345,
           "message": "Unable to pre-bind the given args to the given modifier. This likely indicates a type mismatch between its signature and the values you're passing.
-        No overload matches this call.
-          The last overload gave the following error.
-            Type 'number' is not assignable to type 'string'.",
+        Argument of type '[{ [NamedArgs]: true; foo: number; }]' is not assignable to parameter of type '[] | [NamedArgs<{ foo: string; }>]'.
+          Type '[{ [NamedArgs]: true; foo: number; }]' is not assignable to type '[NamedArgs<{ foo: string; }>]'.
+            Type '{ [NamedArgs]: true; foo: number; }' is not assignable to type 'NamedArgs<{ foo: string; }>'.
+              Type '{ [NamedArgs]: true; foo: number; }' is not assignable to type '{ foo: string; }'.
+                Types of property 'foo' are incompatible.
+                  Type 'number' is not assignable to type 'string'.",
           "range": {
             "end": {
-              "character": 21,
+              "character": 26,
               "line": 10,
             },
             "start": {
-              "character": 18,
+              "character": 4,
               "line": 10,
             },
           },

--- a/packages/core/src/transform/diagnostics/augmentation.ts
+++ b/packages/core/src/transform/diagnostics/augmentation.ts
@@ -59,20 +59,6 @@ function checkAssignabilityError(
         'If you want to set an event listener, consider using the `{{on}}` modifier instead.'
     );
   } else if (
-    node.type === 'BlockStatement' &&
-    node.path.type === 'PathExpression' &&
-    node.path.original === 'component'
-  ) {
-    // If it's attempted direct usage of `{{#component}}` as a curly block component,
-    // give a special note that that's not supported.
-    return addGlintDetails(
-      message,
-      `The {{component}} helper can't be used to directly invoke a component under Glint. ` +
-        `Consider first binding the result to a variable, e.g. ` +
-        `'{{#let (component 'component-name') as |ComponentName|}}' and then invoking it as ` +
-        `'<ComponentName @arg={{value}}>...</ComponentName>'.`
-    );
-  } else if (
     node.type === 'MustacheStatement' &&
     (parentNode.type === 'Template' ||
       parentNode.type === 'BlockStatement' ||

--- a/packages/core/src/transform/diagnostics/augmentation.ts
+++ b/packages/core/src/transform/diagnostics/augmentation.ts
@@ -36,6 +36,8 @@ const diagnosticHandlers: Record<number, DiagnosticHandler | undefined> = {
   7053: checkImplicitAnyError, // TS7053: Element implicitly has an 'any' type because expression of type '"X"' can't be used to index type 'Y'.
 };
 
+const bindHelpers = ['component', 'helper', 'modifier'];
+
 function checkAssignabilityError(
   message: Diagnostic,
   mapping: MappingTree
@@ -95,6 +97,21 @@ function checkAssignabilityError(
       'Only primitive values and certain DOM objects (see `ContentValue` in `@glint/template`) are ' +
         'usable as top-level template content.'
     );
+  } else if (
+    (mapping?.sourceNode.type === 'SubExpression' ||
+      mapping?.sourceNode.type === 'MustacheStatement') &&
+    mapping.sourceNode.path.type === 'PathExpression' &&
+    bindHelpers.includes(mapping.sourceNode.path.original)
+  ) {
+    // If we're looking at a binding helper subexpression like `(component ...)`, error messages
+    // may be very straightforward or may be horrendously complex when users start playing games
+    // with parametrized types, so we add a hint here.
+    let kind = mapping.sourceNode.path.original;
+    return addGlintDetails(
+      message,
+      `Unable to pre-bind the given args to the given ${kind}. This likely indicates a type ` +
+        `mismatch between its signature and the values you're passing.`
+    );
   }
 }
 
@@ -134,8 +151,6 @@ function noteNamedArgsAffectArity(
   }
 }
 
-let bindHelpers = ['component', 'helper', 'modifier'];
-
 function checkResolveError(
   diagnostic: Diagnostic,
   mapping: MappingTree
@@ -143,21 +158,6 @@ function checkResolveError(
   // The diagnostic might fall on a lone identifier or a full path; if the former,
   // we need to traverse up through the path to find the true parent.
   let sourceMapping = mapping.sourceNode.type === 'Identifier' ? mapping.parent : mapping;
-
-  if (
-    (sourceMapping?.sourceNode.type === 'SubExpression' ||
-      sourceMapping?.sourceNode.type === 'MustacheStatement') &&
-    sourceMapping.sourceNode.path.type === 'PathExpression' &&
-    bindHelpers.includes(sourceMapping.sourceNode.path.original)
-  ) {
-    let kind = sourceMapping.sourceNode.path.original;
-    return addGlintDetails(
-      diagnostic,
-      `Unable to pre-bind the given args to the given ${kind}. This likely indicates a type ` +
-        `mismatch between its signature and the values you're passing.`
-    );
-  }
-
   let parentNode = sourceMapping?.parent?.sourceNode;
 
   // If this error is on the first param to a {{component}} or other bind invocation, this means

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -252,11 +252,16 @@ export function templateToTypescript(
         // Treat the first argument to a bind-invokable expression (`{{component}}`,
         // `{{helper}}`, etc) as special: we wrap it in a `resolve` call so that the
         // type machinery for those helpers can always operate against the resolved value.
+        // We wrap the `resolveForBind` call in an IIFE to prevent "backpressure" in
+        // type inference from the subsequent arguments that are being passed: the bound
+        // invokable is the source of record for its own type and we don't want inference
+        // from the `resolveForBind` call to be affected by other (potentially incorrect)
+        // parameter types.
         emit.text('χ.resolve(');
         emitExpression(node.path);
-        emit.text(')(χ.resolveForBind(');
+        emit.text(')((() => χ.resolveForBind(');
         emitExpression(node.params[0]);
-        emit.text('), ');
+        emit.text('))(), ');
         emitArgs(node.params.slice(1), node.hash);
         emit.text(')');
       });

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -203,7 +203,7 @@ export function templateToTypescript(
           break;
 
         case 'bind-invokable':
-          emitBindInvokableExpression(formInfo, node);
+          emitBindInvokableExpression(formInfo, node, position);
           break;
 
         case '===':
@@ -232,7 +232,8 @@ export function templateToTypescript(
 
     function emitBindInvokableExpression(
       formInfo: SpecialFormInfo,
-      node: AST.MustacheStatement | AST.SubExpression
+      node: AST.MustacheStatement | AST.SubExpression,
+      position: InvokePosition
     ): void {
       emit.forNode(node, () => {
         assert(
@@ -249,6 +250,10 @@ export function templateToTypescript(
             `{{${formInfo.name} (${formInfo.name} ... posA posB) namedA=true namedB=true}}`
         );
 
+        if (position === 'top-level') {
+          emit.text('χ.emitContent(');
+        }
+
         // Treat the first argument to a bind-invokable expression (`{{component}}`,
         // `{{helper}}`, etc) as special: we wrap it in a `resolve` call so that the
         // type machinery for those helpers can always operate against the resolved value.
@@ -264,6 +269,10 @@ export function templateToTypescript(
         emit.text('))(), ');
         emitArgs(node.params.slice(1), node.hash);
         emit.text(')');
+
+        if (position === 'top-level') {
+          emit.text(')');
+        }
       });
     }
 
@@ -949,7 +958,9 @@ export function templateToTypescript(
 
         case 'bind-invokable':
           record.error(
-            `The {{${formInfo.name}}} helper can't be used directly in block form under Glint. Consider first binding the result to a variable, e.g. '{{#let (${formInfo.name} ...) as |...|}}'.`,
+            `The {{${formInfo.name}}} helper can't be used directly in block form under Glint. ` +
+              `Consider first binding the result to a variable, e.g. '{{#let (${formInfo.name} ...) as |...|}}' ` +
+              `and then using the bound value.`,
             rangeForNode(node.path)
           );
           break;

--- a/packages/environment-ember-loose/-private/dsl/index.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/index.d.ts
@@ -42,7 +42,17 @@ export declare function resolveForBind<T extends ((...params: any) => any) | nul
 // String lookups
 export declare function resolveForBind<T extends keyof Globals>(
   item: T
-): Globals[T] extends Invokable<infer F> ? F : Globals[T];
+): Globals[T] extends Invokable<infer F>
+  ? F
+  : Globals[T] extends DirectInvokable<infer F>
+  ? F
+  : Globals[T];
 export declare function resolveForBind<T extends keyof Globals>(
   item: T | null | undefined
-): (Globals[T] extends Invokable<infer F> ? F : Globals[T]) | null;
+):
+  | (Globals[T] extends Invokable<infer F>
+      ? F
+      : Globals[T] extends DirectInvokable<infer F>
+      ? F
+      : Globals[T])
+  | null;

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/component.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/component.test.ts
@@ -16,6 +16,16 @@ typeTest(
   `
 );
 
+// String-based lookups of special builtins
+typeTest(
+  {},
+  hbs`
+    {{#let (component 'link-to' route="widgets") as |Link|}}
+      <Link @models={{array 123}} />
+    {{/let}}
+  `
+);
+
 declare const formModifier: ModifierLike<{
   Element: HTMLFormElement;
 }>;

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/helper.test.ts
@@ -134,3 +134,27 @@ typeTest(
     {{/let}}
   `
 );
+
+// Prebinding args at different locations
+typeTest(
+  {
+    myriad: class MyriadPositionals extends Helper<{
+      Args: { Positional: [string, boolean, number] };
+      Return: string;
+    }> {},
+  },
+  hbs`
+    {{this.myriad "one" true 3}}
+    
+    {{(helper this.myriad "one" true 3)}}
+    {{(helper this.myriad "one" true) 3}}
+    {{(helper this.myriad "one") true 3}}
+    {{(helper this.myriad) "one" true 3}}
+
+    {{! @glint-expect-error: missing arg }}
+    {{(helper this.myriad "one" true)}}
+
+    {{! @glint-expect-error: extra arg }}
+    {{(helper this.myriad "one" true 3) "four"}}
+  `
+);

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/modifier.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/modifier.test.ts
@@ -70,3 +70,26 @@ typeTest(
     {{/let}}
   `
 );
+
+// Prebinding args at different locations
+typeTest(
+  {
+    myriad: class MyriadPositionals extends Modifier<{
+      Args: { Positional: [string, boolean, number] };
+    }> {},
+  },
+  hbs`
+    <div {{this.myriad "one" true 3}}></div>
+    
+    <div {{(modifier this.myriad "one" true 3)}}></div>
+    <div {{(modifier this.myriad "one" true) 3}}></div>
+    <div {{(modifier this.myriad "one") true 3}}></div>
+    <div {{(modifier this.myriad) "one" true 3}}></div>
+
+    {{! @glint-expect-error: missing arg }}
+    <div {{(modifier this.myriad "one" true)}}></div>
+
+    {{! @glint-expect-error: extra arg }}
+    <div {{(modifier this.myriad "one" true 3) "four"}}></div>
+  `
+);

--- a/packages/template/-private/keywords/-bind-invokable.d.ts
+++ b/packages/template/-private/keywords/-bind-invokable.d.ts
@@ -63,36 +63,32 @@ export type BindInvokableKeyword<Prefix extends number, Kind> = DirectInvokable<
   >;
   // {{bind invokable positional}}
   <
-    Named,
     Positional extends any[],
     Return extends Kind,
     GivenPositional extends PrefixOf<SliceFrom<Positional, Prefix>>
   >(
-    invokable: (...args: [...Positional, NamedArgs<Named>]) => Return,
+    invokable: (...args: [...Positional]) => Return,
     ...args: GivenPositional
   ): Invokable<
     (
       ...args: [
         ...SliceTo<Positional, Prefix>,
-        ...SliceFrom<SliceFrom<Positional, Prefix>, GivenPositional['length']>,
-        ...MaybeNamed<NamedArgs<Named>>
+        ...SliceFrom<SliceFrom<Positional, Prefix>, GivenPositional['length']>
       ]
     ) => Return
   >;
   <
-    Named,
     Positional extends any[],
     Return extends Kind,
     GivenPositional extends PrefixOf<SliceFrom<Positional, Prefix>>
   >(
-    invokable: null | undefined | ((...args: [...Positional, NamedArgs<Named>]) => Return),
+    invokable: null | undefined | ((...args: [...Positional]) => Return),
     ...args: GivenPositional
   ): null | Invokable<
     (
       ...args: [
         ...SliceTo<Positional, Prefix>,
-        ...SliceFrom<SliceFrom<Positional, Prefix>, GivenPositional['length']>,
-        ...MaybeNamed<NamedArgs<Named>>
+        ...SliceFrom<SliceFrom<Positional, Prefix>, GivenPositional['length']>
       ]
     ) => Return
   >;

--- a/packages/template/__tests__/keywords/component.test.ts
+++ b/packages/template/__tests__/keywords/component.test.ts
@@ -68,11 +68,11 @@ emitComponent(
   })
 );
 
-componentKeyword(resolveForBind(StringComponent), {
+componentKeyword(
+  resolveForBind(StringComponent),
   // @ts-expect-error: Attempting to curry an arg with the wrong type
-  value: 123,
-  ...NamedArgsMarker,
-});
+  { value: 123, ...NamedArgsMarker }
+);
 
 class ParametricComponent<T> extends TestComponent<{
   Args: { values: Array<T>; optional?: string };


### PR DESCRIPTION
The 1.0.0-beta.5 release of Glint introduced support for `{{helper}}` and `{{modifier}}` by way of a new `bind-invokable` abstraction based on the existing `{{component}}` implementation. As folks have kicked the tires on that refactor, a few bugs and inconsistencies have come to light:
 - #559: the type signature allowed for multiple arguments, but due to some strange interactions in TypeScript's context-sensitive inference, it would frequently infer a version of the signature that only accepted one positional arg. We fix this by wrapping the `resolveForBind` call in an IIFE, which acts as an opaque barrier to context propagation for inference.
 - #556: we weren't constraining the results of `bind-invokable` calls with `emitContent` as we should have when they appeared in a top-level position
 - #555: we were missing a special case for string-named `DirectInvokable`s for `environment-ember-loose`

I've run some targeted sets of tests with these changes, but will let CI tell me if other further-reaching impacts need to be accounted for somewhere in our integration/acceptance tests.