### PR TITLE
[Bugfix] Drop `allowPlainFunctionInvocation` flag

### DIFF
--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -65,29 +65,6 @@ Because Glint uses your project-local copy of TypeScript and the packages whose 
 
 It's possible to use the 4.x versions of the `@types/ember*` packages even if your project is still using an Ember 3.x LTS. Just note that any deprecated APIs you're using that were removed in 4.0 won't be available in the types, and APIs added later _will_ be present in them.
 
-## Functions as Helpers
-
-By default, `@glint/environment-ember-loose` includes support for the [default helper manager RFC](https://github.com/emberjs/rfcs/pull/756).
-
-If your project uses an older version of Ember, you can have Glint treat attempted use of functions as helpers as a type error by setting `allowPlainFunctionInvocation: false` in your environment configuration.
-
-{% code title="tsconfig.json" %}
-
-```javascript
-{
-  "compilerOptions": { /* ... */ },
-  "glint": {
-    "environment": {
-      "ember-loose": {
-        "allowPlainFunctionInvocation": false
-      }
-    }
-  }
-}
-```
-
-{% endcode %}
-
 ## Ember CLI TypeScript
 
 If you are using Glint with TypeScript and Ember, visit the [Ember CLI TypeScript documentation](https://docs.ember-cli-typescript.com/) for more information.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -109,6 +109,14 @@ which is a meaningful advantage over templates that were ignored via `include`/`
 [nocheck]: ../docs/directives.md#glint-nocheck
 [`glint-auto-nocheck`]: https://github.com/typed-ember/glint/tree/main/packages/scripts#auto-glint-nocheck
 
+### `allowPlainFunctionInvocation`
+
+The `allowPlainFunctionInvocation` flag has been dropped from `@glint/environment-ember-loose`'s
+configuration. If you are not using Ember 4.5+ with native support for functions as helpers,
+consider adopting [the functions-as-helpers polyfill][functions-as-helpers].
+
+[functions-as-helpers]: https://github.com/ember-polyfills/ember-functions-as-helper-polyfill
+
 ### Tagged Strings in `ember-template-imports`
 
 Since `<template>` [has been been selected][fccts] as the path forward for template imports (a.k.a

--- a/packages/environment-ember-loose/-private/dsl/index.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/index.d.ts
@@ -1,4 +1,4 @@
-export * from './without-function-resolution';
+import './integration-declarations';
 
 import { ResolveOrReturn } from '@glint/template/-private/dsl';
 import {
@@ -9,6 +9,9 @@ import {
   InvokeDirect,
 } from '@glint/template/-private/integration';
 import { Globals } from './globals';
+
+export * from '@glint/template/-private/dsl';
+export { Globals };
 
 // Items that can be directly invoked by value
 export declare function resolve<T extends DirectInvokable>(item: T): T[typeof InvokeDirect];

--- a/packages/environment-ember-loose/-private/dsl/without-function-resolution.d.ts
+++ b/packages/environment-ember-loose/-private/dsl/without-function-resolution.d.ts
@@ -1,4 +1,0 @@
-import './integration-declarations';
-
-export * from '@glint/template/-private/dsl';
-export { Globals } from './globals';

--- a/packages/environment-ember-loose/-private/environment/index.ts
+++ b/packages/environment-ember-loose/-private/environment/index.ts
@@ -20,10 +20,6 @@ export default function emberLooseEnvironment(
   options: Record<string, unknown>
 ): GlintEnvironmentConfig {
   let typesModule = '@glint/environment-ember-loose/-private/dsl';
-  if (options['allowPlainFunctionInvocation'] === false) {
-    typesModule += '/without-function-resolution';
-  }
-
   let additionalSpecialForms =
     typeof options['additionalSpecialForms'] === 'object'
       ? (options['additionalSpecialForms'] as GlintSpecialFormConfig)

--- a/packages/environment-ember-loose/__tests__/environment.test.ts
+++ b/packages/environment-ember-loose/__tests__/environment.test.ts
@@ -87,22 +87,4 @@ describe('Environments: Ember Loose', () => {
       '/routes/hello.js',
     ]);
   });
-
-  test('honors `allowPlainFunctionInvocation` configuration', () => {
-    let envWithNoConfig = envDefinition({});
-    let envWithPlainFunctions = envDefinition({ allowPlainFunctionInvocation: true });
-    let envWithoutPlainFunctions = envDefinition({ allowPlainFunctionInvocation: false });
-
-    expect(envWithNoConfig.tags?.['ember-cli-htmlbars']['hbs'].typesModule).toEqual(
-      '@glint/environment-ember-loose/-private/dsl'
-    );
-
-    expect(envWithPlainFunctions.tags?.['ember-cli-htmlbars']['hbs'].typesModule).toEqual(
-      '@glint/environment-ember-loose/-private/dsl'
-    );
-
-    expect(envWithoutPlainFunctions.tags?.['ember-cli-htmlbars']['hbs'].typesModule).toEqual(
-      '@glint/environment-ember-loose/-private/dsl/without-function-resolution'
-    );
-  });
 });

--- a/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/helper.test.ts
@@ -1,9 +1,5 @@
 import Helper, { helper } from '@ember/component/helper';
-import { resolve } from '@glint/environment-ember-loose/-private/dsl';
-import {
-  NamedArgsMarker,
-  resolve as resolveWithoutFunctionResolution,
-} from '@glint/environment-ember-loose/-private/dsl/without-function-resolution';
+import { resolve, NamedArgsMarker } from '@glint/environment-ember-loose/-private/dsl';
 import { expectTypeOf } from 'expect-type';
 import { HelperLike } from '@glint/template';
 import { NamedArgs } from '@glint/template/-private/integration';
@@ -214,9 +210,6 @@ import { NamedArgs } from '@glint/template/-private/integration';
 
 // Bare-function helpers
 {
-  // @ts-expect-error: the env with no support for function resolution should reject this
-  resolveWithoutFunctionResolution(() => 'hi');
-
   let positionalOnlyConcrete = resolve((a: number, b: number) => a + b);
   expectTypeOf(positionalOnlyConcrete).toEqualTypeOf<(a: number, b: number) => number>();
   expectTypeOf(positionalOnlyConcrete(1, 2)).toBeNumber();

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -10,8 +10,7 @@
     ".": "./-private/index.js",
     "./registry": "./registry/index.js",
     "./glint-environment-definition": "./-private/environment/index.js",
-    "./-private/dsl": "./-private/dsl/index.js",
-    "./-private/dsl/without-function-resolution": "./-private/dsl/without-function-resolution.js"
+    "./-private/dsl": "./-private/dsl/index.js"
   },
   "keywords": [
     "glint-environment"


### PR DESCRIPTION
This was meant to land as part of 1.0 but got lost in a stash.

Maintaining two versions of the `ember-loose` types—one that supports functions-as-helpers and one that doesn't—is a maintenance burden we don't want to carry moving forward, particularly as an increasing number of consumers have native support, and nearly every consumer of Glint is on a version that supports the polyfill.