### PR TITLE
Fix broken links on "Getting Started" page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ First, add `@glint/core`, `@glint/template` and an appropriate Glint environment
 
 Then, add a `"glint"` key in your `tsconfig.json` that tells Glint what environment you're working in and, optionally, which files it should include in its typechecking.
 
-See the [Configuration](configuration.md) page for more details about options you can specify under the `"glint"` key. For setup instructions specific to your project type, check out the links below:
+See the [Configuration](configuration/_index.md) page for more details about options you can specify under the `"glint"` key. For setup instructions specific to your project type, check out the links below:
 
 - [GlimmerX Installation](glimmerx/installation.md)
 - [Ember.js Installation](ember/installation.md)
@@ -42,6 +42,5 @@ You can also use the `glint` command locally with the `--watch` flag to monitor 
 You can install an editor extension to display Glint's diagnostics inline in your templates and provide richer editor support&mdash;typechecking, type information on hover, automated refactoring, and more&mdash;powered by `glint-language-server`:
 
 - Install the [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode).
-- Learn more about the [Glint Language Server](glint-language-server.md).
 
 ![A type error being shown inline for a template file in VS Code](https://user-images.githubusercontent.com/108688/111076679-995c2300-84ed-11eb-934a-3a29f21be89a.png)


### PR DESCRIPTION
 Fixes two broken links on "Getting Started" page.

- Removes link to docs page for `glint-language-server` that was removed in
  https://github.com/typed-ember/glint/pull/416
- Fixes broken link to "Configuration"

### Side Note

There are a few other broken links throughout the docs but I don't understand how/why they're broken and they seem to magically sometimes not be broken in different preview versions.

For example, in the current live version of the ["Getting Started" page](https://typed-ember.gitbook.io/glint/getting-started) the link to "Ember.js Installation" does not work. The path looks correct to me and the link works properly on GitHub when previewing the markdown files.

If you view the preview "revision" linked by GitBook in the checks for this PR this link is magically fixed. I'm not sure if that means that it will actually be fixed after merging this though.

Another example is the link to "Authoring Guide" on [the "Using Addons" page](https://typed-ember.gitbook.io/glint/environments/ember/using-addons). This link is broken in the live version AND the preview revision for this branch but seems to fix itself if ANY changes are made to the markdown file for page.