### PR TITLE
Don't pollute completions with globals in templates with syntax errors

### DIFF
--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -57,7 +57,7 @@ describe('Language Server: Completions', () => {
     expect(completions).toBeUndefined();
   });
 
-  test('in a template with syntax errors', () => {
+  test('in a companion template with syntax errors', () => {
     project.setGlintConfig({ environment: 'ember-loose' });
 
     let code = stripIndent`
@@ -70,6 +70,26 @@ describe('Language Server: Completions', () => {
     let completions = server.getCompletions(project.fileURI('index.hbs'), {
       line: 0,
       character: 4,
+    });
+
+    // Ensure we don't spew all ~900 completions available at the top level
+    // in module scope in a JS/TS file.
+    expect(completions).toBeUndefined();
+  });
+
+  test('in an embedded template with syntax errors', () => {
+    project.setGlintConfig({ environment: 'ember-template-imports' });
+
+    let code = stripIndent`
+      <template>Hello, {{this.target.}}!</template>
+    `;
+
+    project.write('index.gts', code);
+
+    let server = project.startLanguageServer();
+    let completions = server.getCompletions(project.fileURI('index.gts'), {
+      line: 0,
+      character: 31,
     });
 
     // Ensure we don't spew all ~900 completions available at the top level

--- a/packages/core/src/common/transform-manager.ts
+++ b/packages/core/src/common/transform-manager.ts
@@ -80,7 +80,12 @@ export default class TransformManager {
     originalFileName: string,
     originalStart: number,
     originalEnd: number
-  ): { transformedFileName: string; transformedStart: number; transformedEnd: number } {
+  ): {
+    transformedFileName: string;
+    transformedStart: number;
+    transformedEnd: number;
+    mapping?: MappingTree | undefined;
+  } {
     let transformInfo = this.findTransformInfoForOriginalFile(originalFileName);
     if (!transformInfo?.transformedModule) {
       return {
@@ -101,6 +106,7 @@ export default class TransformManager {
       transformedFileName,
       transformedStart: transformedRange.start,
       transformedEnd: transformedRange.end,
+      mapping: transformedRange.mapping,
     };
   }
 


### PR DESCRIPTION
We fixed this for many cases in #442, but had an outstanding issue with embedded templates.

The root of the problem was essentially that I didn't want to plumb a `MappingTree` through a few layers of function indirection, and so we were answering the "is this completion being requested within a template?" question in two passes. Unfortunately, in cases with template a syntax error where the template was _in the same file as the backing class_, the second pass lookup of the mapping tree would fail, because the transformed offset would fall directly on the border between the template and the real JS/TS code.

This change fixes my original sin and plumbs through the relevant `MappingTree` as part of the transformed offset lookup process.

Fixes #566 