### PR TITLE
Fix and extend ember-template-imports notes in installation.md

### DIFF
--- a/docs/ember/installation.md
+++ b/docs/ember/installation.md
@@ -32,9 +32,10 @@ npm install -D @glint/core @glint/template @glint/environment-ember-loose
   }
 }
 ```
-If you are using `ember-template-imports` in your project, also install the `@glint/environment-ember-template-imports` package and configure it in `tsconfig.json` under `glint.environment`. 
 
 {% endcode %}
+
+If you are using `ember-template-imports` in your project, you also need to install the `@glint/environment-ember-template-imports` package and configure it in `tsconfig.json` under `glint.environment`. 
 
 Note that, by default, Glint will assume you want it to analyze all templates in the codebase that are covered by your `tsconfig.json`. To ignore any type errors up front so that you can incrementally migrate your project to typesafe templates, consider using [the `auto-glint-nocheck` script](https://github.com/typed-ember/glint/tree/main/packages/scripts#auto-glint-nocheck) to add [`@glint-nocheck` comments](../directives.md#glint-nocheck) to your existing templates that would produce errors.
 
@@ -42,6 +43,12 @@ Finally, ensure you've added the following statement somewhere in your project's
 
 ```typescript
 import '@glint/environment-ember-loose';
+```
+
+If using `ember-template-imports`, add a corresponding line for that environment as well:
+
+```typescript
+import '@glint/environment-ember-template-imports';
 ```
 
 You may also choose to disable TypeScript's "unused symbol" warnings in your editor, since Glint will flag any symbols that are actually unused, while `tsserver` won't understand any symbol usage that only occurs in templates.


### PR DESCRIPTION
Just what it says on the tin. The `ember-template-imports` bit was getting lost inside a Gitbook block for the code sample. 😭 