### PR TITLE
Add missing argument to LinkTo component type

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/link-to.d.ts
@@ -16,6 +16,7 @@ type LinkToArgs = RequireAtLeastOne<
     activeClass?: string;
     'current-when'?: string | boolean;
     preventDefault?: boolean;
+    replace?: boolean;
     tagName?: string;
   },
   'route' | 'model' | 'models' | 'query'


### PR DESCRIPTION
The `replace` argument was missing from the Glint types.
  https://github.com/emberjs/ember.js/blob/v4.12.0/packages/@ember/-internals/glimmer/lib/components/link-to.ts#L468