### PR TITLE
Expose loadConfig

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,4 +40,6 @@ export function analyzeProject(projectDirectory: string = process.cwd()): Projec
   };
 }
 
+export { loadConfig };
+
 export type { TransformManager, GlintConfig, GlintLanguageServer };


### PR DESCRIPTION
Expose loadConfig for consumers

> Since we already provide access to the GlintConfig instance to consumers who run analyzeProject, it seems reasonable to offer a way to load that config without forcing a full project analysis.

Closes https://github.com/typed-ember/glint/issues/579