### PR TITLE
Use content tag

### DIFF
--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -59,6 +59,8 @@ export default class GlintLanguageServer {
     private documents: DocumentCache,
     private transformManager: TransformManager
   ) {
+    console.log('Glint starting...');
+
     let parsedConfig = this.parseTsconfig(glintConfig, transformManager);
 
     this.ts = glintConfig.ts;
@@ -94,6 +96,7 @@ export default class GlintLanguageServer {
 
     // Kickstart typechecking
     this.service.getProgram();
+    console.log('Glint started');
   }
 
   public dispose(): void {

--- a/packages/environment-ember-template-imports/-private/environment/preprocess.ts
+++ b/packages/environment-ember-template-imports/-private/environment/preprocess.ts
@@ -8,8 +8,6 @@ import { GLOBAL_TAG, PreprocessData, TemplateLocation } from './common';
 const TEMPLATE_START = `[${GLOBAL_TAG}\``;
 const TEMPLATE_END = '`]';
 
-// NOTE: This import is a lie -- We are not real ESM, and this is compiled to CJS.
-//       ESM usage would be different here, and this is the CJS version of content-tag.
 import { Preprocessor } from 'content-tag';
 const p = new Preprocessor();
 

--- a/packages/environment-ember-template-imports/-private/environment/preprocess.ts
+++ b/packages/environment-ember-template-imports/-private/environment/preprocess.ts
@@ -1,14 +1,42 @@
 import { GlintExtensionPreprocess } from '@glint/core/config-types';
-import { parseTemplates } from 'ember-template-imports';
 import { GLOBAL_TAG, PreprocessData, TemplateLocation } from './common';
-
+/**
+ * We don't need to actually generate the code that would be emitted for
+ * a real app to build, we can use placeholders, so we have less offsets
+ * to worry about (precompile, setComponentTemplate, their imports, etc)
+ */
 const TEMPLATE_START = `[${GLOBAL_TAG}\``;
 const TEMPLATE_END = '`]';
 
+// NOTE: This import is a lie -- We are not real ESM, and this is compiled to CJS.
+//       ESM usage would be different here, and this is the CJS version of content-tag.
+import { Preprocessor } from 'content-tag';
+const p = new Preprocessor();
+
+interface Parsed {
+  type: 'expression' | 'class-member';
+  tagName: 'template';
+  contents: string;
+  range: {
+    start: number;
+    end: number;
+  };
+  contentRange: {
+    start: number;
+    end: number;
+  };
+  startRange: {
+    end: number;
+    start: number;
+  };
+  endRange: {
+    start: number;
+    end: number;
+  };
+}
+
 export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, path) => {
-  let templates = parseTemplates(source, path, { templateTag: 'template' }).filter(
-    (match) => match.type === 'template-tag'
-  );
+  let templates = p.parse(source, path) as Parsed[];
 
   let templateLocations: Array<TemplateLocation> = [];
   let segments: Array<string> = [];
@@ -16,11 +44,10 @@ export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, pat
   let delta = 0;
 
   for (let template of templates) {
-    let { start, end } = template;
-    let startTagLength = template.start[0].length;
-    let endTagLength = template.end[0].length;
-    let startTagOffset = start.index ?? -1;
-    let endTagOffset = end.index ?? -1;
+    let startTagLength = template.startRange.end - template.startRange.start;
+    let endTagLength = template.endRange.end - template.endRange.start;
+    let startTagOffset = template.startRange.start;
+    let endTagOffset = template.endRange.start;
 
     if (startTagOffset === -1 || endTagOffset === -1) continue;
 

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -26,14 +26,16 @@
     "-private/**/*.{js,d.ts}",
     "globals/index.d.ts"
   ],
+  "dependencies": {
+    "content-tag": "^1.1.0"
+  },
   "peerDependencies": {
     "@glint/environment-ember-loose": "^1.2.1",
     "@glint/template": "^1.2.1",
     "@types/ember__component": "^4.0.10",
     "@types/ember__helper": "^4.0.1",
     "@types/ember__modifier": "^4.0.3",
-    "@types/ember__routing": "^4.0.12",
-    "ember-template-imports": "^3.0.0"
+    "@types/ember__routing": "^4.0.12"
   },
   "peerDependenciesMeta": {
     "@types/ember__component": {
@@ -55,7 +57,6 @@
     "@types/ember__helper": "^4.0.1",
     "@types/ember__modifier": "^4.0.3",
     "@types/ember__routing": "^4.0.12",
-    "ember-template-imports": "^3.0.0",
     "vitest": "^0.22.0"
   },
   "publishConfig": {

--- a/test-packages/ts-template-imports-app/src/index.gts
+++ b/test-packages/ts-template-imports-app/src/index.gts
@@ -1,5 +1,2 @@
-import Greeting from './Greeting';
-
-export default <template>
-  <Greeting @target="World" />
-</template>
+2=;
+export const Y = <template></template>;

--- a/test-packages/ts-template-imports-app/src/index.gts
+++ b/test-packages/ts-template-imports-app/src/index.gts
@@ -1,2 +1,5 @@
-2=;
-export const Y = <template></template>;
+import Greeting from './Greeting';
+
+export default <template>
+  <Greeting @target="World" />
+</template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5151,6 +5151,11 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
+content-tag@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/content-tag/-/content-tag-1.1.0.tgz#fcef4bdcf1850f9b67bf0b6f7aee217c6d7ea9fa"
+  integrity sha512-bktivDORs9M890KwVKrIONYvHhwshfgF4b1G/TFPrjH12Ag2GDiSdxVHqIzMxWZ297VgIRPSImURlpcOzJP/LQ==
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -6461,7 +6466,7 @@ ember-template-imports@^1.1.1:
     ember-cli-version-checker "^5.1.2"
     validate-peer-dependencies "^1.1.0"
 
-ember-template-imports@^3.0.0, ember-template-imports@^3.1.1:
+ember-template-imports@^3.1.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ember-template-imports/-/ember-template-imports-3.4.0.tgz#c40757e2d41e289ce08c0fe80671000bf216e0ef"
   integrity sha512-3Cwcj3NXA129g3ZhmrQ/nYOxksFonTmB/qxyaSNTHrLBSoc93UZys47hBz13DlcfoeSCCrNt2Qpq1j890I04PQ==


### PR DESCRIPTION
Resolves: https://github.com/typed-ember/glint/issues/609
~~Blocked by: https://github.com/embroider-build/content-tag/issues/19~~
~~Blocked by: https://github.com/embroider-build/content-tag/pull/31~~

Unblocks: https://github.com/NullVoxPopuli/polaris-starter/pull/11

Problem:
- content-tag requires syntax to be correct
- LSPs need fault-tolerant parsing to aid in intellisense, suggestions and all that

This isn't a new problem for Glint, but it does take things in the wrong direction a bit.