### PR TITLE
Support custom extensions with `allowImportingTsExtensions`

### DIFF
--- a/packages/core/src/cli/perform-build-watch.ts
+++ b/packages/core/src/cli/perform-build-watch.ts
@@ -10,7 +10,7 @@ export function performBuildWatch(
   projects: string[],
   buildOptions: TS.BuildOptions
 ): void {
-  let transformManagerPool = new TransformManagerPool(ts.sys);
+  let transformManagerPool = new TransformManagerPool(ts);
   let formatDiagnostic = buildDiagnosticFormatter(ts);
   let buildProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram;
 
@@ -19,6 +19,9 @@ export function performBuildWatch(
     patchProgramBuilder(ts, transformManagerPool, buildProgram),
     (diagnostic) => console.error(formatDiagnostic(diagnostic))
   );
+
+  // @ts-ignore: This hook was added in TS5, and is safely irrelevant in earlier versions. Once we drop support for 4.x, we can also remove this @ts-ignore comment.
+  host.resolveModuleNameLiterals = transformManagerPool.resolveModuleNameLiterals;
 
   let builder = ts.createSolutionBuilderWithWatch(host, projects, buildOptions);
   builder.build();

--- a/packages/core/src/cli/perform-build.ts
+++ b/packages/core/src/cli/perform-build.ts
@@ -13,7 +13,7 @@ interface BuildOptions extends TS.BuildOptions {
 }
 
 export function performBuild(ts: TypeScript, projects: string[], buildOptions: BuildOptions): void {
-  let transformManagerPool = new TransformManagerPool(ts.sys);
+  let transformManagerPool = new TransformManagerPool(ts);
   let formatDiagnostic = buildDiagnosticFormatter(ts);
   let buildProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram;
 
@@ -22,6 +22,9 @@ export function performBuild(ts: TypeScript, projects: string[], buildOptions: B
     patchProgramBuilder(ts, transformManagerPool, buildProgram),
     (diagnostic) => console.error(formatDiagnostic(diagnostic))
   );
+
+  // @ts-ignore: This hook was added in TS5, and is safely irrelevant in earlier versions. Once we drop support for 4.x, we can also remove this @ts-ignore comment.
+  host.resolveModuleNameLiterals = transformManagerPool.resolveModuleNameLiterals;
 
   let builder = ts.createSolutionBuilder(host, projects, buildOptions);
   let exitStatus = buildOptions.clean ? builder.clean() : builder.build();

--- a/packages/core/src/cli/perform-check.ts
+++ b/packages/core/src/cli/perform-check.ts
@@ -63,6 +63,8 @@ function createCompilerHost(
     ? ts.createIncrementalCompilerHost(options, sysForCompilerHost(ts, transformManager))
     : ts.createCompilerHost(options);
 
+  // @ts-ignore: This hook was added in TS5, and is safely irrelevant in earlier versions. Once we drop support for 4.x, we can also remove this @ts-ignore comment.
+  host.resolveModuleNameLiterals = transformManager.resolveModuleNameLiterals;
   host.fileExists = transformManager.fileExists;
   host.readFile = transformManager.readTransformedFile;
   host.readDirectory = transformManager.readDirectory;

--- a/packages/core/src/cli/perform-watch.ts
+++ b/packages/core/src/cli/perform-watch.ts
@@ -19,5 +19,8 @@ export function performWatch(glintConfig: GlintConfig, optionsToExtend: ts.Compi
     (diagnostic) => console.error(formatDiagnostic(diagnostic))
   );
 
+  // @ts-ignore: This hook was added in TS5, and is safely irrelevant in earlier versions. Once we drop support for 4.x, we can also remove this @ts-ignore comment.
+  host.resolveModuleNameLiterals = transformManager.resolveModuleNameLiterals;
+
   ts.createWatchProgram(host);
 }

--- a/test-packages/ts-ember-app/types/global.d.ts
+++ b/test-packages/ts-ember-app/types/global.d.ts
@@ -1,6 +1,0 @@
-// Types for compiled templates
-declare module 'ts-ember-app/templates/*' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
-  const tmpl: TemplateFactory;
-  export default tmpl;
-}

--- a/test-packages/ts-ember-preview-types/types/global.d.ts
+++ b/test-packages/ts-ember-preview-types/types/global.d.ts
@@ -1,6 +1,0 @@
-// Types for compiled templates
-declare module 'ts-ember-app/templates/*' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
-  const tmpl: TemplateFactory;
-  export default tmpl;
-}


### PR DESCRIPTION
This is an alternative approach to the one taken in #620, and fixes #618.

#620 attempts to support import paths with an explicit `.gts` extension by rewriting those imports during transformation, but module resolution really shouldn't be a concern of the transform layer. For example:
 - It's important that we fix #618 in a way that works correctly even in files that we aren't transforming at all (consider that vanilla `.ts` files might import from `.gts` files)
 - Glint is already required to intercept TypeScript's view of the project files in ways that the transform layer can't impact (consider that we already support imports of `.gts` files _without_ the extension)

TS has a hard-coded internal set of the extensions it considers to "be" TypeScript, and we work around this fact by presenting custom extensions like `.gjs` and `.gts` as `.js` and `.ts` files respectively. This is how such files get included during whole-project typechecking, and is also how extensionless imports of `.gts` and `.gjs` are resolved today.

This PR addresses #618 in the same manner as we handle custom extensions in general: by providing a custom hook for the compiler API to implement the behavior we want. In this instance, the hook is `resolveModuleNameLiterals` rather than the system-level `readFile` and friends, but the gist is the same: when a `.gts` file is imported, we intercept and rewrite the request to as though it had been for the corresponding `.ts` file.
