### PR TITLE
Update `vscode-uri` and match their docs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "semver": "^7.5.2",
     "silent-error": "^1.1.1",
     "uuid": "^8.3.2",
+    "vscode-uri": "^3.0.8",
     "vscode-languageserver": "^8.0.1",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-uri": "^3.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,10 +37,9 @@
     "semver": "^7.5.2",
     "silent-error": "^1.1.1",
     "uuid": "^8.3.2",
-    "vscode-uri": "^3.0.8",
     "vscode-languageserver": "^8.0.1",
     "vscode-languageserver-textdocument": "^1.0.5",
-    "vscode-uri": "^3.0.2",
+    "vscode-uri": "^3.0.8",
     "yargs": "^17.5.1"
   },
   "devDependencies": {

--- a/packages/core/src/language-server/util/index.ts
+++ b/packages/core/src/language-server/util/index.ts
@@ -1,14 +1,14 @@
 export { positionToOffset, offsetToPosition } from './position.js';
 export { scriptElementKindToCompletionItemKind } from './protocol.js';
 
-import VSCodeURI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 
 export function uriToFilePath(uri: string): string {
-  return VSCodeURI.URI.parse(uri).fsPath.replace(/\\/g, '/');
+  return URI.parse(uri).fsPath.replace(/\\/g, '/');
 }
 
 export function filePathToUri(filePath: string): string {
-  return VSCodeURI.URI.file(filePath).toString();
+  return URI.file(filePath).toString();
 }
 
 export function normalizeFilePath(filePath: string): string {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -96,7 +96,7 @@
     "@types/mocha": "^10.0.1",
     "@types/vscode": "^1.68.1",
     "@vscode/test-electron": "2.2.0",
-    "@vscode/vsce": "^2.19.0",
+    "@vscode/vsce": "^2.21.1",
     "esbuild": "^0.15.16",
     "expect": "^29.5.0",
     "mocha": "^10.2.0",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -96,7 +96,7 @@
     "@types/mocha": "^10.0.1",
     "@types/vscode": "^1.68.1",
     "@vscode/test-electron": "2.2.0",
-    "@vscode/vsce": "^2.21.1",
+    "@vscode/vsce": "^2.19.0",
     "esbuild": "^0.15.16",
     "expect": "^29.5.0",
     "mocha": "^10.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2607,14 +2607,14 @@
     unzipper "^0.10.11"
 
 "@vscode/vsce@^2.19.0":
-  version "2.21.1"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.21.1.tgz#793c78d992483b428611a3927211a9640041be14"
-  integrity sha512-f45/aT+HTubfCU2oC7IaWnH9NjOWp668ML002QiFObFRVUCoLtcwepp9mmql/ArFUy+HCHp54Xrq4koTcOD6TA==
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.19.0.tgz#342225662811245bc40d855636d000147c394b11"
+  integrity sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==
   dependencies:
     azure-devops-node-api "^11.0.1"
     chalk "^2.4.2"
     cheerio "^1.0.0-rc.9"
-    commander "^6.2.1"
+    commander "^6.1.0"
     glob "^7.0.6"
     hosted-git-info "^4.0.2"
     jsonc-parser "^3.2.0"
@@ -2624,7 +2624,7 @@
     minimatch "^3.0.3"
     parse-semver "^1.1.1"
     read "^1.0.7"
-    semver "^7.5.2"
+    semver "^5.1.0"
     tmp "^0.2.1"
     typed-rest-client "^1.8.4"
     url-join "^4.0.1"
@@ -5010,7 +5010,7 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.2.1:
+commander@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,7 +2606,7 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
-"@vscode/vsce@^2.21.1":
+"@vscode/vsce@^2.19.0":
   version "2.21.1"
   resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.21.1.tgz#793c78d992483b428611a3927211a9640041be14"
   integrity sha512-f45/aT+HTubfCU2oC7IaWnH9NjOWp668ML002QiFObFRVUCoLtcwepp9mmql/ArFUy+HCHp54Xrq4koTcOD6TA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15129,10 +15129,10 @@ vscode-languageserver@^8.0.1:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
-vscode-uri@^3.0.2:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.6.tgz#5e6e2e1a4170543af30151b561a41f71db1d6f91"
-  integrity sha512-fmL7V1eiDBFRRnu+gfRWTzyPpNIHJTc4mWnFkwBUmO9U3KPgJAmTx7oxi2bl/Rh6HLdU7+4C9wlj0k2E4AdKFQ==
+vscode-uri@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
+  integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
 
 walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.3:
   version "0.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,15 +2606,15 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
-"@vscode/vsce@^2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.19.0.tgz#342225662811245bc40d855636d000147c394b11"
-  integrity sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ==
+"@vscode/vsce@^2.21.1":
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.21.1.tgz#793c78d992483b428611a3927211a9640041be14"
+  integrity sha512-f45/aT+HTubfCU2oC7IaWnH9NjOWp668ML002QiFObFRVUCoLtcwepp9mmql/ArFUy+HCHp54Xrq4koTcOD6TA==
   dependencies:
     azure-devops-node-api "^11.0.1"
     chalk "^2.4.2"
     cheerio "^1.0.0-rc.9"
-    commander "^6.1.0"
+    commander "^6.2.1"
     glob "^7.0.6"
     hosted-git-info "^4.0.2"
     jsonc-parser "^3.2.0"
@@ -2624,7 +2624,7 @@
     minimatch "^3.0.3"
     parse-semver "^1.1.1"
     read "^1.0.7"
-    semver "^5.1.0"
+    semver "^7.5.2"
     tmp "^0.2.1"
     typed-rest-client "^1.8.4"
     url-join "^4.0.1"
@@ -5010,7 +5010,7 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.1.0:
+commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==


### PR DESCRIPTION
On projects using 1.2.0 of Glint, they'll run in to this:
```
file:///home/nvp/Development/NullVoxPopuli/polaris-starter-2/node_modules/.pnpm/@glint+core@1.2.0_typescript@5.2.2/node_modules/@glint/core/lib/language-server/util/index.js:3
import VSCodeURI from 'vscode-uri';
       ^^^^^^^^^
SyntaxError: The requested module 'vscode-uri' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
```

Which makes sense since `@glint/core` didn't declare a dep on `vscode-uri`.

Locally, when testing, I was using the 1.2.0 version of the language server, / vscode extension, so I don't know if that'll need to be published :shrug: 