### PR TITLE
Add JS/TS code folding support to language server

### DIFF
--- a/packages/core/__tests__/language-server/folding-ranges.test.ts
+++ b/packages/core/__tests__/language-server/folding-ranges.test.ts
@@ -1,0 +1,238 @@
+import { Project } from 'glint-monorepo-test-utils';
+import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import { stripIndent } from 'common-tags';
+
+describe('Language Server: Folding Ranges', () => {
+  let project!: Project;
+
+  beforeEach(async () => {
+    project = await Project.create();
+  });
+
+  afterEach(async () => {
+    await project.destroy();
+  });
+
+  test('function', () => {
+    project.write({
+      'example.ts': stripIndent`
+        function foo() {
+          return 'bar';
+        }
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 1,
+        kind: undefined,
+      },
+    ]);
+  });
+
+  test('nested function', () => {
+    project.write({
+      'example.ts': stripIndent`
+        function topLevel() {
+
+          function nested() {
+            return 'bar';
+          }
+
+          return nested();
+        }
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 6,
+        kind: undefined,
+      },
+      {
+        startLine: 2,
+        endLine: 3,
+        kind: undefined,
+      },
+    ]);
+  });
+
+  test('imports', () => {
+    project.write({
+      'example.ts': stripIndent`
+        import Component, { hbs } from '@glimmerx/component';
+        import foo from 'bar';
+        import { baz } from 'qux';
+
+        export default { foo, baz, Component };
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 2,
+        kind: 'imports',
+      },
+    ]);
+  });
+
+  test('comments', () => {
+    project.write({
+      'example.ts': stripIndent`
+        // This is
+        // a
+        // multiline
+        // comment
+
+        const foo = 'bar';
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 0,
+        endLine: 3,
+        kind: 'comment',
+      },
+    ]);
+  });
+
+  test('region', () => {
+    project.write({
+      'example.ts': stripIndent`
+        const foo = 'bar';
+
+        // #region
+
+        const bar = 'baz';
+
+        // #endregion
+
+        export default { foo, bar };
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      {
+        startLine: 2,
+        endLine: 6,
+        kind: 'region',
+      },
+    ]);
+  });
+
+  test('simple component', () => {
+    project.write({
+      'example.ts': stripIndent`
+        import Component, { hbs } from '@glimmerx/component';
+        import { tracked } from '@glimmer/tracking';
+
+        export interface EmberComponentArgs {
+          message: string;
+        }
+
+        export interface EmberComponentSignature {
+          Element: HTMLDivElement;
+          Args: EmberComponentArgs;
+        }
+
+        /**
+         * A simple component that renders a message.
+         */
+        export default class Greeting extends Component<EmberComponentSignature> {
+          @tracked message = this.args.message;
+
+          get capitalizedMessage() {
+            return this.message.toUpperCase();
+          }
+        }
+
+        declare module '@glint/environment-ember-loose/registry' {
+          export default interface Registry {
+            EmberComponent: typeof EmberComponent;
+            'ember-component': typeof EmberComponent;
+          }
+        }
+      `,
+    });
+
+    let server = project.startLanguageServer();
+    let folds = server.getFoldingRanges(project.fileURI('example.ts'));
+
+    expect(folds).toEqual([
+      // Imports
+      {
+        startLine: 0,
+        endLine: 1,
+        kind: 'imports',
+      },
+
+      // EmberComponentArgs
+      {
+        startLine: 3,
+        endLine: 4,
+        kind: undefined,
+      },
+
+      // EmberComponentSignature
+      {
+        startLine: 7,
+        endLine: 9,
+        kind: undefined,
+      },
+
+      // Code Comment
+      {
+        startLine: 12,
+        endLine: 14,
+        kind: 'comment',
+      },
+
+      // Greeting Component
+      {
+        startLine: 15,
+        endLine: 20,
+        kind: undefined,
+      },
+
+      // capitalizedMessage
+      {
+        startLine: 18,
+        endLine: 19,
+        kind: undefined,
+      },
+
+      // declare module
+      {
+        startLine: 23,
+        endLine: 27,
+        kind: undefined,
+      },
+
+      // interface Registry
+      {
+        startLine: 24,
+        endLine: 26,
+        kind: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -30,6 +30,7 @@ export const capabilities: ServerCapabilities = {
   codeActionProvider: {
     codeActionKinds: [CodeActionKind.QuickFix],
   },
+  foldingRangeProvider: true,
   definitionProvider: true,
   workspaceSymbolProvider: true,
   renameProvider: {
@@ -216,5 +217,11 @@ export function bindLanguageServerPool({ connection, pool, openDocuments }: Bind
 
       scheduleDiagnostics();
     });
+  });
+
+  connection.onFoldingRanges((params) => {
+    return pool.withServerForURI(params.textDocument.uri, ({ server }) =>
+      server.getFoldingRanges(params.textDocument.uri)
+    );
   });
 }


### PR DESCRIPTION
Part of https://github.com/typed-ember/glint/issues/626

This adds support for code folding in js & ts files. This implementation is [based on tsserver's](https://github.com/typescript-language-server/typescript-language-server/blob/651cfcbd28992ad599b00a4ae3bc30132b2a7892/src/lsp-server.ts#L1200). This does not add support for gts/gjs files.

Folding seems to work as expected, but two odd things had to be handled:
- The OutliningSpans have TextSpans with inclusive length, leading to off-by-one errors. I handled this inline, but I'm concerned that this is unintentional and may not always be the case.
- There are some additional OutliningSpans that incorrectly have a "0" starting offset and don't match any foldable code. I believe these are retrieved from the template file and are meant to represent their folding ranges. As is, these are superfluous and cause an incorrect FoldingRange on line 1 of every component file.

Any guidance on better ways to handle either of these would be appreciated!


https://github.com/camerondubas/glint/assets/6216460/b132d090-5ebb-46bb-bd65-1dd1113d9465


