### PR TITLE
Add --preserveWatchOutput flag to avoid clearing console output in watch mode

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,5 +15,6 @@ glint [--watch|-w] [--declaration|-d] [--project path/to/tsconfig.json]
 ### Flags
 
 - `--watch` If passed, `glint` will perform a watched typecheck, re-checking your project as files change.
+- `--preserveWatchOutput` Used with `--watch`. If passed, `glint` will not clear the screen each time the project is re-checked.
 - `--declaration` If passed, `glint` will emit `.d.ts` files according to the configuration in your `tsconfig.json`
 - `--project` Overrides where `glint` will look to find your project's `tsconfig.json`

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -25,6 +25,12 @@ const argv = yargs(process.argv.slice(2))
     boolean: true,
     description: 'Whether to perform an ongoing watched build',
   })
+  .option('preserveWatchOutput', {
+    implies: 'watch',
+    boolean: true,
+    description:
+      'Whether to keep outdated console output in watch mode instead of clearing the screen every time a change happened.',
+  })
   .option('declaration', {
     alias: 'd',
     boolean: true,
@@ -91,6 +97,10 @@ if (argv.build) {
 
   if ('incremental' in argv) {
     buildOptions.incremental = argv.incremental;
+  }
+
+  if ('watch' in argv) {
+    buildOptions['preserveWatchOutput'] = argv.preserveWatchOutput;
   }
 
   // Get the closest TS to us, since we have to assume that we may be in the

--- a/packages/core/src/cli/options.ts
+++ b/packages/core/src/cli/options.ts
@@ -3,11 +3,16 @@ import { type CompilerOptions } from 'typescript';
 export function determineOptionsToExtend(argv: {
   declaration?: boolean | undefined;
   incremental?: boolean | undefined;
+  preserveWatchOutput?: boolean | undefined;
 }): CompilerOptions {
   let options: CompilerOptions = {};
 
   if ('incremental' in argv) {
     options.incremental = argv.incremental;
+  }
+
+  if ('watch' in argv) {
+    options['preserveWatchOutput'] = argv['preserveWatchOutput'] as boolean;
   }
 
   if ('declaration' in argv) {


### PR DESCRIPTION
Normally, output is cleared every time a change/re-check happens.

Correspondes to the tsc flag of the same name.