### PR TITLE
docs: add TOC example to template-only-components.md

### DIFF
--- a/docs/ember/template-only-components.md
+++ b/docs/ember/template-only-components.md
@@ -28,6 +28,8 @@ Note that the runtime content of this module (effectively `export default templa
 
 Additionally, you can create a backing module using the `TOC` type, which is a convenience alias for `templateOnlyComponent`.
 
+{% code title="app/components/shout.ts" %}
+
 ```typescript
 import type { TOC } From '@ember/component/template-only';
 
@@ -42,6 +44,8 @@ interface ShoutSignature {
 declare const Shout: TOC<ShoutSignature>;
 export default Shout;
 ```
+
+{% endcode %}
 
 Due to the way TypeScript works, it's not possible to have a generic signature for template-only components:
 

--- a/docs/ember/template-only-components.md
+++ b/docs/ember/template-only-components.md
@@ -26,6 +26,23 @@ declare module '@glint/environment-ember-loose/registry' {
 
 Note that the runtime content of this module (effectively `export default templateOnlyComponent();`) is exactly what Ember generates at build time when creating a backing module for a template-only component.
 
+Additionally, you can create a backing module using the `TOC` type, which is a convenience alias for `templateOnlyComponent`.
+
+```typescript
+import type { TOC } From '@ember/component/template-only';
+
+interface ShoutSignature {
+  Element: HTMLDivElement;
+  Args: { message: string };
+  Blocks: {
+    default: [shoutedMessage: string];
+  };
+}
+
+declare const Shout: TOC<ShoutSignature>;
+export default Shout;
+```
+
 Due to the way TypeScript works, it's not possible to have a generic signature for template-only components:
 
 ```typescript


### PR DESCRIPTION
I've mostly been using the `TOC` syntax to define template-only components. However, I noticed there wasn't any official documentation for this.