### PR TITLE
Lock @types/node to avoid issues in floating-dependencies CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "typescript": "~4.8.0"
   },
   "resolutions:notes": {
-    "@types/yargs": "Locking temporarily to avoid an issue with the ESM types in 17.0.14; see DT#63373"
+    "@types/yargs": "Locking temporarily to avoid an issue with the ESM types in 17.0.14; see DT#63373",
+    "@types/node": "Locking to avoid conflicts between the declared version in packages/core and floating '*' versions when we run in CI without the lockfile"
   },
   "resolutions": {
     "@types/yargs": "17.0.13",
+    "@types/node": "^18.11.5",
     "ember-cli-htmlbars": "^6.0.1"
   },
   "version": "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,15 +2375,10 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.11.5":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.11.5", "@types/node@^9.6.0":
   version "18.11.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@^9.6.0":
-  version "9.6.61"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.61.tgz#29f124eddd41c4c74281bd0b455d689109fc2a2d"
-  integrity sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Currently in CI in the floating-dependencies job we're running into conflicts between our own `@types/node` v18 and the various `*` constraints that come in transitively via DT packages. For our purposes it should be fine to just lock to a single version.