### PR TITLE
Default to TS's `fixedPollingInterval` watcher in tests

### DIFF
--- a/test-packages/test-utils/src/project.ts
+++ b/test-packages/test-utils/src/project.ts
@@ -17,6 +17,7 @@ const ROOT = pathUtils.normalizeFilePath(path.resolve(dirname, '../../ephemeral'
 interface TsconfigWithGlint {
   extends?: string;
   compilerOptions?: Record<string, unknown>; // no appropriate types exist :sigh:
+  watchOptions?: Record<string, unknown>; // https://www.typescriptlang.org/tsconfig#watchOptions
   references?: Array<{ path: string }>;
   files?: Array<string>;
   include?: Array<string>;
@@ -69,7 +70,7 @@ export class Project {
     }
 
     let project = new Project(rootDir);
-    let tsconfig = {
+    let tsconfig: TsconfigWithGlint = {
       compilerOptions: {
         strict: true,
         target: 'es2019',
@@ -79,6 +80,11 @@ export class Project {
         allowJs: true,
         checkJs: false,
         ...config.compilerOptions,
+      },
+      watchOptions: {
+        watchFile: 'fixedPollingInterval',
+        watchDirectory: 'fixedPollingInterval',
+        synchronousWatchDirectory: true,
       },
       glint: config.glint ?? {
         environment: 'glimmerx',


### PR DESCRIPTION
In TS <= 4.8, `fixedPollingInterval` is the default watcher configuration. Starting in TS 4.9, they changed the default to `useFsEvents`. This is generally a good thing! It means that users get more efficient, more effective FS watching.

For us, though, in the Actions runner, this causes instability in our tests. Some days it's totally fine, but others it can cause any of our tests that rely on FS events triggering behavior in `glint --watch` (or `glint --build --watch`) to fail at random.

This PR sets up any test projects generated with the `glint-monorepo-test-utils` `Project` class to continue using the `fixedPollingInterval` strategy. There shouldn't be any reason end users need to switch; this is just about FS watcher stability in the Actions runners.

EDIT: Still a bit to do here