### PR TITLE
Fix organize-imports tests

### DIFF
--- a/packages/core/__tests__/language-server/organize-imports.test.ts
+++ b/packages/core/__tests__/language-server/organize-imports.test.ts
@@ -118,7 +118,7 @@ describe('Language Server: Organize Imports', () => {
 
       class List<T> extends Component {
         <template>
-          <MaybeComponent />
+          <MaybeComponent @arg="hi" />
           <ol>
             {{#each-in (hash a=1 b='hi') as |key value|}}
               <li>{{key}}: {{value}}</li>
@@ -131,7 +131,7 @@ describe('Language Server: Organize Imports', () => {
       import { ComponentLike, ModifierLike, HelperLike } from '@glint/template';
       import { TOC } from '@ember/component/template-only';
 
-      const MaybeComponent: undefined as TOC<{ Args: { arg: string } }> | undefined;
+      const MaybeComponent = undefined as TOC<{ Args: { arg: string } }> | undefined;
       declare const CanvasThing: ComponentLike<{ Args: { str: string }; Element: HTMLCanvasElement }>;
       `,
     });


### PR DESCRIPTION
I noticed on https://github.com/typed-ember/glint/pull/655, there were unrelated errors due to
- file not having correct syntax
- unrelated type error (missing arg)

This change fixes both issues


<details><summary>Nightly failures present on `main`</summary>

```

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  __tests__/cli/custom-extensions.test.ts > CLI: custom extensions > external file changes > adding a missing module
Error: Timed out waiting to see "Found 0 errors.". Instead saw: ""
 ❯ Timeout.<anonymous> ../../test-packages/test-utils/src/project.ts:229:10
    227|         detach();
    228|         reject(
    229|           new Error(
       |          ^
    230|             `Timed out waiting to see ${JSON.stringify(target)}. Instead saw: ${JSON.stringify(
    231|               output

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  __tests__/cli/custom-extensions.test.ts > CLI: custom extensions > external file changes > removing an imported module
AssertionError: expected '\u001bc5:47:35 PM - File change detec…' to include 'Cannot find module \'./other\' or its…'
 ❯ __tests__/cli/custom-extensions.test.ts:119:21
    117| 
    118|       expect(output).toMatch('Found 1 error.');
    119|       expect(output).toMatch(
       |                     ^
    120|         "Cannot find module './other' or its corresponding type declarations."
    121|       );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

Test Files  1 failed | 23 passed (24)
     Tests  2 failed | 340 passed (342)
  Start at  17:46:59
  Duration  81.12s (transform 1.00s, setup 1ms, collect 22.40s, tests 387.23s)

```


</details>