### PR TITLE
Make explicit extensions in imports work.

### DIFF
--- a/packages/core/__tests__/cli/custom-extensions.test.ts
+++ b/packages/core/__tests__/cli/custom-extensions.test.ts
@@ -167,7 +167,7 @@ describe('CLI: custom extensions', () => {
         2 export { Greeting as Greeting2 } from './re-export.gts';
                                                 ~~~~~~~~~~~~~~~~~
 
-        barrel.ts:3:21 - error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+        barrel.ts:3:21 - error TS2691: An import path cannot end with a '.ts' extension. Consider importing './vanilla.js' instead.
 
         3 export { two } from './vanilla.ts';
                               ~~~~~~~~~~~~~~

--- a/packages/core/src/cli/perform-check.ts
+++ b/packages/core/src/cli/perform-check.ts
@@ -69,6 +69,18 @@ function createCompilerHost(
   host.readFile = transformManager.readTransformedFile;
   host.readDirectory = transformManager.readDirectory;
 
+  // Postprocess .d.ts files to temporarily patch '.gts' to '.ts'
+  // https://github.com/typed-ember/glint/issues/628
+  const tsWriteFile = host.writeFile;
+  const matchGtsImport = /\.gts';/gm;
+  host.writeFile = (fileName, data, writeByteOrderMark, onError) => {
+    const isDts = fileName.endsWith('.d.ts');
+    if (isDts && matchGtsImport.test(data)) {
+      data = data.replace(matchGtsImport, ".ts';");
+    }
+    tsWriteFile(fileName, data, writeByteOrderMark, onError);
+  };
+
   return host;
 }
 


### PR DESCRIPTION
Resolves https://github.com/typed-ember/glint/issues/628

See repro repo: https://stackblitz.com/edit/stackblitz-starters-g58nhp?file=examples%2Fts-addon-node16%2Fpackage.json,examples%2Fts-addon-node16%2Fsrc%2Findex.ts
- `pnpm build`
- poke around in the `declarations` directories

Using the patch from here: https://github.com/typed-ember/glint/issues/628#issuecomment-1805416937 
(where TS would allow)

And the test from here: https://github.com/typed-ember/glint/pull/648/files#diff-a835cb215198fc0a50973a4ae3bf66eac5a4b0bc21293fa29fc70888d663f797

The downside to this approach is "what if" someone has a foo.gts.ts file (probably co-located with a foo.gts.hbs file) -- but like, realistically, this isn't a thing they can use unless they're going half-in on static component references.

Notes:
- subpath-imports: https://nodejs.org/api/packages.html#subpath-imports
  this feature can't be used because all subpath-imports must start with a `#` to differentiate from packages.
- subpath-exports: https://nodejs.org/api/packages.html#subpath-exports
  not relevant because from a library perspective, our own exports are not referenced except by consumers

## Testing locally

### The Glint Terminal

- clone this branch
- `yarn`
- `yarn build`
- delete `glint-monorepo-test-utils` from `@glint/core`s package.json's devDependencies

### Repro Terminal


- download extract and cd into the repro
- `pnpm i`
- `pnpm link ~/path/to/this/branch/of/glint`
- `pnpm build`

----------

note that after every `pnpm link`, in order to work in the glint repo again, you'll need to re-run yarn, and un-delete the `glint-monorepo-test-utils` package.