### PR TITLE
Move ember-template-imports to dependencies instead of peerDependencies

### DIFF
--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -26,14 +26,16 @@
     "-private/**/*.{js,d.ts}",
     "globals/index.d.ts"
   ],
+  "dependencies": {
+    "ember-template-imports": "^3.0.0"
+  },
   "peerDependencies": {
     "@glint/environment-ember-loose": "^1.2.1",
     "@glint/template": "^1.2.1",
     "@types/ember__component": "^4.0.10",
     "@types/ember__helper": "^4.0.1",
     "@types/ember__modifier": "^4.0.3",
-    "@types/ember__routing": "^4.0.12",
-    "ember-template-imports": "^3.0.0"
+    "@types/ember__routing": "^4.0.12"
   },
   "peerDependenciesMeta": {
     "@types/ember__component": {


### PR DESCRIPTION
While 
https://github.com/typed-ember/glint/pull/655
is being worked on, we need an interim solution for Glint.

Today, (for apps, addons, and v2 addons) it's broken out of the box for gts, because when folks install ember-template-imports, they get v4, which removed all the APIs Glint was using.

By moving ember-template-imports in Glint to be a dependency, Glint keeps those APIs, and is no longer broken-by-default.

This should be a patch-release, imo.