### PR TITLE
Add  "Organize Imports" command

### DIFF
--- a/packages/core/__tests__/language-server/organize-imports.test.ts
+++ b/packages/core/__tests__/language-server/organize-imports.test.ts
@@ -26,10 +26,16 @@ describe('Language Server: Organize Imports', () => {
       `,
     });
 
-    let server = project.startLanguageServer();
-    let formatting = ts.getDefaultFormatCodeSettings();
-    let preferences = {};
-    let edits = server.organizeImports(project.fileURI('index.ts'), formatting, preferences);
+    const server = project.startLanguageServer();
+    const formatting = ts.getDefaultFormatCodeSettings();
+    const preferences = {};
+    const skipDestructiveCodeActions = true;
+    const edits = server.organizeImports(
+      project.fileURI('index.ts'),
+      formatting,
+      preferences,
+      skipDestructiveCodeActions
+    );
 
     expect(edits).toEqual([]);
   });
@@ -62,11 +68,17 @@ describe('Language Server: Organize Imports', () => {
       `,
     });
 
-    let server = project.startLanguageServer();
+    const server = project.startLanguageServer();
 
-    let formatting = ts.getDefaultFormatCodeSettings();
-    let preferences = {};
-    let edits = server.organizeImports(project.fileURI('index.ts'), formatting, preferences);
+    const formatting = ts.getDefaultFormatCodeSettings();
+    const preferences = {};
+    const skipDestructiveCodeActions = true;
+    const edits = server.organizeImports(
+      project.fileURI('index.ts'),
+      formatting,
+      preferences,
+      skipDestructiveCodeActions
+    );
 
     expect(edits).toEqual([
       {
@@ -136,11 +148,17 @@ describe('Language Server: Organize Imports', () => {
       `,
     });
 
-    let server = project.startLanguageServer();
+    const server = project.startLanguageServer();
 
-    let formatting = ts.getDefaultFormatCodeSettings();
-    let preferences = {};
-    let edits = server.organizeImports(project.fileURI('index.gts'), formatting, preferences);
+    const formatting = ts.getDefaultFormatCodeSettings();
+    const preferences = {};
+    const skipDestructiveCodeActions = true;
+    const edits = server.organizeImports(
+      project.fileURI('index.gts'),
+      formatting,
+      preferences,
+      skipDestructiveCodeActions
+    );
 
     expect(edits).toEqual([
       {
@@ -171,6 +189,61 @@ describe('Language Server: Organize Imports', () => {
         range: {
           start: { character: 0, line: 16 },
           end: { character: 0, line: 17 },
+        },
+      },
+    ]);
+  });
+  test('gts: removes unused imports when skipDestructiveCodeActions is `false`', () => {
+    project.setGlintConfig({ environment: 'ember-template-imports' });
+    project.write({
+      'index.gts': stripIndent`
+      import Component from '@glimmer/component';
+      import { hash } from '@ember/helper';
+      import SomeUnusedImport from 'some-unused-import';
+
+      class List<T> extends Component {
+        <template>
+            {{#each-in (hash a=1 b='hi') as |key value|}}
+              <li>{{key}}: {{value}}</li>
+            {{/each-in}}
+        </template>
+      }
+      `,
+    });
+
+    const server = project.startLanguageServer();
+
+    const formatting = ts.getDefaultFormatCodeSettings();
+    const preferences = {};
+    const skipDestructiveCodeActions = false;
+    const edits = server.organizeImports(
+      project.fileURI('index.gts'),
+      formatting,
+      preferences,
+      skipDestructiveCodeActions
+    );
+
+    expect(edits).toEqual([
+      {
+        newText:
+          "import { hash } from '@ember/helper';\nimport Component from '@glimmer/component';\n",
+        range: {
+          start: { character: 0, line: 0 },
+          end: { character: 0, line: 1 },
+        },
+      },
+      {
+        newText: '',
+        range: {
+          start: { character: 0, line: 1 },
+          end: { character: 0, line: 2 },
+        },
+      },
+      {
+        newText: '',
+        range: {
+          start: { character: 0, line: 2 },
+          end: { character: 0, line: 3 },
         },
       },
     ]);

--- a/packages/core/src/language-server/binding.ts
+++ b/packages/core/src/language-server/binding.ts
@@ -12,7 +12,7 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { GlintCompletionItem } from './glint-language-server.js';
 import { LanguageServerPool } from './pool.js';
-import { GetIRRequest, SortImportsRequest } from './messages.cjs';
+import { GetIRRequest, OrganizeImportsRequest } from './messages.cjs';
 import { ConfigManager } from './config-manager.js';
 import type * as ts from 'typescript';
 
@@ -219,12 +219,12 @@ export function bindLanguageServerPool({
     return pool.withServerForURI(uri, ({ server }) => server.getTransformedContents(uri));
   });
 
-  connection.onRequest(SortImportsRequest.type, ({ uri }) => {
+  connection.onRequest(OrganizeImportsRequest.type, ({ uri, skipDestructiveCodeActions }) => {
     return pool.withServerForURI(uri, ({ server }) => {
       const language = server.getLanguageType(uri);
       const formatting = configManager.getFormatCodeSettingsFor(language);
       const preferences = configManager.getUserSettingsFor(language);
-      return server.organizeImports(uri, formatting, preferences);
+      return server.organizeImports(uri, formatting, preferences, skipDestructiveCodeActions);
     });
   });
 

--- a/packages/core/src/language-server/glint-language-server.ts
+++ b/packages/core/src/language-server/glint-language-server.ts
@@ -419,7 +419,8 @@ export default class GlintLanguageServer {
   public organizeImports(
     uri: string,
     formatOptions: ts.FormatCodeSettings = {},
-    preferences: ts.UserPreferences = {}
+    preferences: ts.UserPreferences = {},
+    skipDestructiveCodeActions: boolean
   ): TextEdit[] {
     const transformInfo = this.transformManager.findTransformInfoForOriginalFile(
       uriToFilePath(uri)
@@ -433,7 +434,7 @@ export default class GlintLanguageServer {
       {
         type: 'file',
         fileName: transformInfo.transformedFileName,
-        skipDestructiveCodeActions: true,
+        skipDestructiveCodeActions,
       },
       formatOptions,
       preferences

--- a/packages/core/src/language-server/messages.cts
+++ b/packages/core/src/language-server/messages.cts
@@ -10,9 +10,9 @@ export const GetIRRequest = makeRequestType(
   ProtocolRequestType<GetIRParams, GetIRResult | null, void, void, void>
 );
 
-export const SortImportsRequest = makeRequestType(
-  'glint/sortImports',
-  ProtocolRequestType<SortImportsParams, SortImportsResult | null, void, void, void>
+export const OrganizeImportsRequest = makeRequestType(
+  'glint/organizeImports',
+  ProtocolRequestType<OrganizeImportsParams, OrganizeImportsResult | null, void, void, void>
 );
 
 export interface GetIRParams {
@@ -24,15 +24,16 @@ export interface GetIRResult {
   uri: string;
 }
 
-export interface SortImportsParams {
+export interface OrganizeImportsParams {
   uri: string;
+  skipDestructiveCodeActions: boolean;
 }
 
-export type SortImportsResult = TextEdit[];
+export type OrganizeImportsResult = TextEdit[];
 
 // This utility allows us to encode type information to enforce that we're using
 // a valid request name along with its associated param/response types without
-// actually requring the runtime code here to be imported elsewhere.
+// actually requiring the runtime code here to be imported elsewhere.
 // See `requestKey` in the Code extension.
 function makeRequestType<Name extends string, T>(
   name: Name,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -54,12 +54,20 @@
       {
         "title": "Glint: Sort Imports",
         "command": "glint.sort-imports"
+      },
+      {
+        "title": "Glint: Organize Imports",
+        "command": "glint.organize-imports"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "glint.sort-imports",
+          "when": "editorLangId =~ /javascript|typescript|glimmer-js|glimmer-ts/"
+        },
+        {
+          "command": "glint.organize-imports",
           "when": "editorLangId =~ /javascript|typescript|glimmer-js|glimmer-ts/"
         }
       ]


### PR DESCRIPTION
As requested here https://github.com/typed-ember/glint/pull/635#issuecomment-1827566067, this adds a `Glint: Organize Imports` command. This is a destructive version of the "Sort Imports" command as it removes unused imports while also sorting.

These commands are analogous to the TS LSP's Sort/Organize commands.

This was just a matter of passing `skipDestructiveCodeActions: false` to the `organizeImports` language service method. As such, I've standardized on using organizeImports instead sortImports in the vscode extension.