### PR TITLE
[feat] improve attributes transform semantics to match hbs AST

### DIFF
--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -215,11 +215,11 @@ describe('Language Server: Diagnostic Augmentation', () => {
         Type '{}' is not assignable to type 'AttrValue'.",
           "range": {
             "end": {
-              "character": 16,
+              "character": 35,
               "line": 9,
             },
             "start": {
-              "character": 9,
+              "character": 17,
               "line": 9,
             },
           },
@@ -287,11 +287,11 @@ describe('Language Server: Diagnostic Augmentation', () => {
         Type '{}' is not assignable to type 'AttrValue'.",
           "range": {
             "end": {
-              "character": 16,
+              "character": 39,
               "line": 14,
             },
             "start": {
-              "character": 9,
+              "character": 17,
               "line": 14,
             },
           },

--- a/packages/core/__tests__/transform/template-to-typescript.test.ts
+++ b/packages/core/__tests__/transform/template-to-typescript.test.ts
@@ -756,9 +756,9 @@ describe('Transform: rewriteTemplate', () => {
           expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
             "{
               const 𝛄 = χ.emitComponent(χ.resolve(Foo)());
-              χ.applyAttributes(𝛄.element, {
-                \\"data-bar\\": χ.resolve(helper)({ param: true , ...χ.NamedArgsMarker }),
-              });
+              χ.applyAttributes(𝛄.element, [
+                [\\"data-bar\\", χ.resolve(helper)({ param: true , ...χ.NamedArgsMarker })],
+              ]);
             }"
           `);
         });
@@ -790,9 +790,9 @@ describe('Transform: rewriteTemplate', () => {
           expect(templateBody(template)).toMatchInlineSnapshot(`
             "{
               const 𝛄 = χ.emitElement(\\"div\\");
-              χ.applyAttributes(𝛄.element, {
-                \\"data-attr\\": χ.resolveOrReturn(𝚪.args.input)(),
-              });
+              χ.applyAttributes(𝛄.element, [
+                [\\"data-attr\\", χ.resolveOrReturn(𝚪.args.input)()],
+              ]);
             }"
           `);
         });
@@ -803,9 +803,9 @@ describe('Transform: rewriteTemplate', () => {
           expect(templateBody(template)).toMatchInlineSnapshot(`
             "{
               const 𝛄 = χ.emitElement(\\"div\\");
-              χ.applyAttributes(𝛄.element, {
-                \\"data-attr\\": \`\${χ.resolveOrReturn(𝚪.args.input)()}\`,
-              });
+              χ.applyAttributes(𝛄.element, [
+                [\\"data-attr\\", \`\${χ.resolveOrReturn(𝚪.args.input)()}\`],
+              ]);
             }"
           `);
         });
@@ -957,9 +957,9 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitElement(\\"div\\");
-          χ.applyAttributes(𝛄.element, {
-            \\"data-attr\\": χ.resolve(concat)(χ.resolve(foo)(1), χ.resolve(foo)(true)),
-          });
+          χ.applyAttributes(𝛄.element, [
+            [\\"data-attr\\", χ.resolve(concat)(χ.resolve(foo)(1), χ.resolve(foo)(true))],
+          ]);
         }"
       `);
     });
@@ -1058,9 +1058,9 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitElement(\\"div\\");
-          χ.applyAttributes(𝛄.element, {
-            \\"data-foo\\": χ.resolveOrReturn(𝚪.args.foo)(),
-          });
+          χ.applyAttributes(𝛄.element, [
+            [\\"data-foo\\", χ.resolveOrReturn(𝚪.args.foo)()],
+          ]);
         }"
       `);
     });
@@ -1071,9 +1071,9 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
           const 𝛄 = χ.emitElement(\\"div\\");
-          χ.applyAttributes(𝛄.element, {
-            \\"data-foo\\": \`\${χ.resolveOrReturn(𝚪.args.foo)()}\${χ.resolveOrReturn(𝚪.args.bar)()}\`,
-          });
+          χ.applyAttributes(𝛄.element, [
+            [\\"data-foo\\", \`\${χ.resolveOrReturn(𝚪.args.foo)()}\${χ.resolveOrReturn(𝚪.args.bar)()}\`],
+          ]);
         }"
       `);
     });
@@ -1251,9 +1251,9 @@ describe('Transform: rewriteTemplate', () => {
             const [NS] = 𝛄.blockParams[\\"default\\"];
             {
               const 𝛄 = χ.emitComponent(χ.resolve(NS?.Nested?.Custom)());
-              χ.applyAttributes(𝛄.element, {
-                class: \\"foo\\",
-              });
+              χ.applyAttributes(𝛄.element, [
+                [\\"class\\", \\"foo\\"],
+              ]);
             }
           }
           χ.Globals[\\"Foo\\"];

--- a/packages/core/src/transform/diagnostics/augmentation.ts
+++ b/packages/core/src/transform/diagnostics/augmentation.ts
@@ -47,7 +47,7 @@ function checkAssignabilityError(
   if (!parentNode) return;
 
   if (
-    node.type === 'Identifier' &&
+    node.type === 'MustacheStatement' &&
     parentNode.type === 'AttrNode' &&
     !/^(@|\.)/.test(parentNode.name)
   ) {

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -795,7 +795,7 @@ export function templateToTypescript(
 
       if (!attributes.length) return;
 
-      emit.text('χ.applyAttributes(𝛄.element, {');
+      emit.text('χ.applyAttributes(𝛄.element, [');
       emit.newline();
       emit.indent();
 
@@ -805,8 +805,9 @@ export function templateToTypescript(
         emit.forNode(attr, () => {
           start = template.indexOf(attr.name, start + 1);
 
-          emitHashKey(attr.name, start);
-          emit.text(': ');
+          emit.text('[');
+          emitIdentifierString(attr.name, start);
+          emit.text(', ');
 
           if (attr.value.type === 'MustacheStatement') {
             emitMustacheStatement(attr.value, 'attr');
@@ -816,13 +817,13 @@ export function templateToTypescript(
             emit.text(JSON.stringify(attr.value.chars));
           }
 
-          emit.text(',');
+          emit.text('],');
           emit.newline();
         });
       }
 
       emit.dedent();
-      emit.text('});');
+      emit.text(']);');
       emit.newline();
     }
 

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -40,7 +40,7 @@ export declare function emitContent(value: ContentValue): void;
  *
  *     emitElement('div', (𝛄) => {
  *       applySplattributes(𝚪.element, 𝛄.element);
- *       applyAttributes(𝛄.element, { class: 'hello' });
+ *       applyAttributes(𝛄.element, [[ 'class': 'hello' ]]);
  *       applyModifier(𝛄.element, resolve(on)({}, 'click', this.clicked));
  *     });
  */
@@ -133,7 +133,7 @@ export declare function applySplattributes<
  *     <div foo={{bar}}></div>
  *     <AnotherComponent foo={{bar}} />
  */
-export declare function applyAttributes(element: Element, attrs: Record<string, AttrValue>): void;
+export declare function applyAttributes(element: Element, attrs: Array<[string, AttrValue]>): void;
 
 /*
  * Applies a modifier to an element or component.

--- a/packages/template/__tests__/attributes.test.ts
+++ b/packages/template/__tests__/attributes.test.ts
@@ -61,7 +61,7 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
 {
   const component = emitComponent(resolve(MyComponent)());
   applySplattributes(new HTMLImageElement(), component.element);
-  applyAttributes(component.element, { foo: 'bar' });
+  applyAttributes(component.element, [['foo', 'bar']]);
 }
 
 /**
@@ -179,21 +179,21 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
   applyAttributes(
     // @ts-expect-error: Trying to apply attributes to a component with no root element
     component.element,
-    { foo: 'bar' }
+    [['foo', 'bar']]
   );
 }
 
 {
-  applyAttributes(document.createElement('div'), {
-    string: 'ok',
-    safeString: htmlSafe('ok'),
-    number: 123,
-    bool: false,
-    null: null,
-    undefined: undefined,
+  applyAttributes(document.createElement('div'), [
+    ['string', 'ok'],
+    ['safeString', htmlSafe('ok')],
+    ['number', 123],
+    ['bool', false],
+    ['null', null],
+    ['undefined', undefined],
     // @ts-expect-error: setting a `void` return as an attr makes no sense
-    nothing: undefined as void,
+    ['nothing', undefined as void],
     // @ts-expect-error: DOM nodes aren't valid values
-    div: document.createElement('div'),
-  });
+    ['div', document.createElement('div')],
+  ]);
 }


### PR DESCRIPTION
Handlebars AST attribute representation: (array of elements)

<img width="426" alt="image" src="https://github.com/typed-ember/glint/assets/1360552/e15eccb8-06b4-44bd-b9e5-5c3aa21e2edd">


In scope of this PR we matching attributes to hbs semantics, where it's represented as array of key-value pairs, instead of record. It gives us more flexibility in syntaxes and reduce potential fail-cases because attribute name is explicitly string.

And getting rid of `An object literal cannot have multiple properties with the same name` typescript error.

```diff
- export declare function applyAttributes(element: Element, attrs: Record<string, AttrValue>): void;
+ export declare function applyAttributes(element: Element, attrs: Array<[string, AttrValue]>): void;
```


Resolves: https://github.com/typed-ember/glint/issues/693

Note, we not getting DX worse, because template-lint has rule to warn about duplicated attributes: https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-duplicate-attributes.md

---

Sidenote:

It seems we could have autocomoplete/attibutes validation if replace
```ts
export declare function applyAttributes(element: Element, attrs: Array<[string, AttrValue]>): void;
```
With
```ts
export declare function applyAttributes<T extends Element, K extends keyof T>(element: T, attrs: Array<[K, T[K] | SafeString]>): void;
```
<img width="1141" alt="image" src="https://github.com/typed-ember/glint/assets/1360552/ee9ed4b9-2030-4036-ae74-452ab0a74915">
<img width="1258" alt="image" src="https://github.com/typed-ember/glint/assets/1360552/c649e5ff-f213-4008-b5d8-20ddcc13fe3d">

[ts playground](https://www.typescriptlang.org/play?#code/PTAECUFMDdIJwM4EsB2BzUBpSBPAagIYA2ArpACokAORkAgnHATqAEYEDGA1qAC4D2oAilD9WAK0gdeAKF44qkUJRoV+AeQlTeAHnKhIAD16QUAEwSgA2sJwAaIShwBdAHygAvKADe1rrlBUZSsABmdnAC5QAFFjJmk9Byt-e0cXVysARmdQAF8AbhkZEFAACUgiRTg+BSUBUABbeDQlYiJQKjh+Kt4kSAQAOmVagGUOOCQqXlAAFgHMgGpQOEgARxIkFbM5WtAAVRQkfhRyfgBJFBNEbSOUHT33LwAKPYNjUws00AB+UCeuKJ7ACUnnc0H4SDMoCiKBg8BBRhM5ksT3+UVQADN4KAziCPGCIWYQb8ztDQLDYHBCjtFKAGEwcKcVLQ9G8kZ8rCQUFwUPwAO4oBy2ZxWNyeYIoEgNVjwZzUmlKbD4YhkZn0RjMcX05hM6gsqwyUBG6wAckhJocJox-H4JucdkNxqsZrMFtAVptCDtMjcRXktIAwgQmkQgwhIDoRmyPpYELwJuhHqAo4iY6AAAYAEm8mOxAAVMrkALTZ3PVPMAJlypZQWPLAGZcumZL8s94ADL8+AcAjhnQF1zV7x7KhVHt9yuD7NBkNhiN5+uD5tREbU-1KBhIAjtggy9peGcVOc6E0ECYEItEXcVE2uNe7KDQcVq06aSQJJWEUgUPXqhl34owD2cMIDha4zFfLRpD4QQOGOSlpkgTgAAs+F-GDHFEKDpnXBxeGQ0xGmaOoCIaGQjCofg4Bwh9+hIIheDfbRxQOW5TguK5w2kW4dEfAD11AAARAheAIJVxXTMwRIvbM4wTNAm0KATNzEgIvDbOTUAUktvE09BFIVUB1BQOheHjCTjlk+MtKbP1dgAWRIUTWFoaJaCaS5TOs1gnP6VlU2RIzsKTbxHSsTBAhEFJ+AxZRIlAR0jSeSNXCePF3BTd5At8KwAC1IqweLyDynJch+UAKzJTIESyz5Er+FK0tBZNo2y0AixWAgzGOIgWDygrMCKkq8nKisomq8qnmKwbWs+AAxLluOOcqKXgKIpvCnIAs+aLYtKch7PbNzIA86ZflW6p1oi7bLGMrzqnOsCyUwIFXrJC6ZFyZJcBiuLCgSgSv0hJUEH82rbuC8VQqNcKCt25QhEsQ9Q17CMIoAMlAPS0FceLrvBjMrPk4siZs9NyumnIYTAwoCjs2ljtO+6kB8kxQf0G6gvfXgk0c5zXPc0xeGZ1m-P0THQLguAzB0YTRPEgAfOlzyVBxsdcACQExoGzBBvQNepCiqJohnBcuEHxUZoWRd80H9sOwSkGgK3LgAmQMUW3ploIUdepttmwfZSwXd4Bx8aDmIzeFsyJlF9mNaeCoTqFqJyCFGOECibUcB0cKHEptwQWh40Vl4Eg4BEbwyt7UAuR5fkRBrl8NGwnRs91VQ241HO8+CQa3ANz6iiN6jQDglA43JcUfZoHB-f6J5uo4KUhYGcYkJMEOnhNMwnZNIEknq51zUta1bXtI-T3PIsRP4BokA4N14zIC-jVNKTRKLFBg0gN1MgrV+ToTTHA4EQB+XA3RNXxD4XI9pQAlFYJ1LgWk2BSAICQECvJphtC7NsN+zoupmGiLAS47YkBxlMPAN0JoqB2ngWARBSFkHoFQT2DBSgPYoCWigH0QIZBAA)

