### PR TITLE
use new glimmer ElementNode sub nodes

### DIFF
--- a/packages/core/__tests__/transform/template-to-typescript.test.ts
+++ b/packages/core/__tests__/transform/template-to-typescript.test.ts
@@ -821,6 +821,9 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
         const __glintY__ = __glintDSL__.emitElement("div");
+        __glintDSL__.applyAttributes(__glintY__.element, {
+         
+        });
         __glintDSL__.applyModifier(__glintDSL__.resolve(modifier)(__glintY__.element, { foo: "bar" , ...__glintDSL__.NamedArgsMarker }));
         }"
       `);
@@ -832,6 +835,9 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
         const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(MyComponent)());
+        __glintDSL__.applyAttributes(__glintY__.element, {
+         
+        });
         __glintDSL__.applyModifier(__glintDSL__.resolve(modifier)(__glintY__.element, { foo: "bar" , ...__glintDSL__.NamedArgsMarker }));
         }"
       `);
@@ -973,6 +979,9 @@ describe('Transform: rewriteTemplate', () => {
         "{
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applySplattributes(__glintRef__.element, __glintY__.element);
+        __glintDSL__.applyAttributes(__glintY__.element, {
+         
+        });
         }"
       `);
     });
@@ -1017,6 +1026,9 @@ describe('Transform: rewriteTemplate', () => {
         "{
         const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(Foo)());
         __glintDSL__.applySplattributes(__glintRef__.element, __glintY__.element);
+        __glintDSL__.applyAttributes(__glintY__.element, {
+         
+        });
         }"
       `);
     });

--- a/packages/core/src/transform/diagnostics/augmentation.ts
+++ b/packages/core/src/transform/diagnostics/augmentation.ts
@@ -235,7 +235,7 @@ function checkImplicitAnyError(
     // This error may appear either on `<Foo />` or `{{foo}}`/`(foo)`
     let globalName =
       sourceNode.type === 'ElementNode'
-        ? sourceNode.tag.split('.')[0]
+        ? sourceNode.path.head.original
         : sourceNode.type === 'PathExpression' && sourceNode.head.type === 'VarHead'
           ? sourceNode.head.name
           : null;

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -695,7 +695,7 @@ export function templateToTypescript(
         mapper.text('const __glintY__ = __glintDSL__.emitComponent(');
 
         // Error boundary: "Expected 1 arguments, but got 0." e.g. when invoking `<ComponentThatHasArgs />`
-        mapper.forNode(node, () => {
+        mapper.forNode(node.path, () => {
           mapper.text('__glintDSL__.resolve(');
           emitPathContents(path, start, kind);
           mapper.text(')');
@@ -707,7 +707,7 @@ export function templateToTypescript(
         let dataAttrs = node.attributes.filter(({ name }) => name.startsWith('@'));
         if (dataAttrs.length) {
           // Error boundary: "Expected 0 arguments, but got 1." e.g. when invoking `<ComponentThatHasNoArgs @foo={{bar}} />`
-          mapper.forNode(node, () => {
+          mapper.forNodeWithSpan(node, node.openTag, () => {
             mapper.text('{ ');
 
             for (let attr of dataAttrs) {
@@ -883,7 +883,9 @@ export function templateToTypescript(
         mapper.indent();
 
         mapper.text('const __glintY__ = __glintDSL__.emitElement(');
-        mapper.text(JSON.stringify(node.tag));
+        mapper.forNodeWithSpan(node, node.openTag, () => {
+          mapper.text(JSON.stringify(node.tag));
+        });
         mapper.text(');');
         mapper.newline();
 
@@ -930,40 +932,48 @@ export function templateToTypescript(
         (attr) => !attr.name.startsWith('@') && attr.name !== SPLATTRIBUTES,
       );
 
-      if (!attributes.length) return;
-
       mapper.text('__glintDSL__.applyAttributes(__glintY__.element, {');
-      mapper.newline();
-      mapper.indent();
 
-      let start = template.indexOf(node.tag, rangeForNode(node).start) + node.tag.length;
+      mapper.forNodeWithSpan(node, node.openTag, () => {
+        mapper.newline();
+        mapper.indent();
 
-      for (let attr of attributes) {
-        mapper.forNode(attr, () => {
-          start = template.indexOf(attr.name, start + 1);
+        let start = template.indexOf(node.tag, rangeForNode(node).start) + node.tag.length;
 
-          emitHashKey(attr.name, start);
-          mapper.text(': ');
+        for (let attr of attributes) {
+          mapper.forNode(attr, () => {
+            start = template.indexOf(attr.name, start + 1);
 
-          if (attr.value.type === 'MustacheStatement') {
-            emitMustacheStatement(attr.value, 'attr');
-          } else if (attr.value.type === 'ConcatStatement') {
-            emitConcatStatement(attr.value);
-          } else {
-            mapper.text(JSON.stringify(attr.value.chars));
-          }
+            emitHashKey(attr.name, start);
+            mapper.text(': ');
 
-          mapper.text(',');
+            if (attr.value.type === 'MustacheStatement') {
+              emitMustacheStatement(attr.value, 'attr');
+            } else if (attr.value.type === 'ConcatStatement') {
+              emitConcatStatement(attr.value);
+            } else {
+              mapper.text(JSON.stringify(attr.value.chars));
+            }
+
+            mapper.text(',');
+            mapper.newline();
+          });
+
+          mapper.terminateDirectiveAreaOfEffect('emitPlainAttributes');
+        }
+
+        // in case there are no attributes, this would allow completions to trigger
+        if (attributes.length === 0) {
+          mapper.text(' ');
           mapper.newline();
-        });
+        }
 
-        mapper.terminateDirectiveAreaOfEffect('emitPlainAttributes');
-      }
-
-      mapper.dedent();
-      mapper.text('});');
-      mapper.newline();
+        mapper.dedent();
+        mapper.text('});');
+        mapper.newline();
+      });
     }
+
 
     function emitSplattributes(node: AST.ElementNode): void {
       let splattributes = node.attributes.find((attr) => attr.name === SPLATTRIBUTES);


### PR DESCRIPTION
there are now also following nodes:
* name node: ElementNameNode
* start tag node: ElementStartNode

example:
```js
/*
  <Foo.bar.x attr='2'></Foo.bar.x>
   ^-- Element PathExpression[0] node
       ^-- Element PathExpression[1] node
          ^- Element PathExpression[2] node
   ^-------- Element PathExpression node
  ^------------------ Element openTag span
                      ^----------- ElementEndNode
 */
```
afterwards completions/validations can be add for attributes and element tags
In #663 