### PR TITLE
feat(vscode): add jsx and tsx to the list of watched extensions

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -21,7 +21,7 @@ import type { Request, GetIRRequest, SortImportsRequest } from '@glint/core/lsp-
 
 const outputChannel = window.createOutputChannel('Glint Language Server');
 const clients = new Map<string, LanguageClient>();
-const extensions = ['.js', '.ts', '.gjs', '.gts', '.hbs'];
+const extensions = ['.js', '.ts', '.gjs', '.gts', '.hbs', '.jsx', '.tsx'];
 const filePattern = `**/*{${extensions.join(',')}}`;
 
 export function activate(context: ExtensionContext): void {


### PR DESCRIPTION
👋 I have a usecase where I'm getting types from a `.tsx` file, glint errors does show up but does not get updated when the tsx types changes. This PR adds .tsx (and .jsx for consistency(?)) to the list of extensions to watch. 

I understand this is a rather unlikely usecase in a glint codebase but I'm trying my luck 🙏 . Another alternative would be to expose the list of extensions to watch as a setting but it's a bit more work