### PR TITLE
Add `Date` to ContentValue

### DIFF
--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -26,15 +26,15 @@ import {
  * values like `null` and `undefined`; DOM nodes; and blockless curly
  * component invocations.
  */
-export type ContentValue = 
+export type ContentValue =
   | string
   | number
   | boolean
+  | Date
   | null
   | undefined
   | void
   | SafeString
-  | { toString(): string }
   | Node
   | ArglessCurlyComponent;
 

--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -30,6 +30,7 @@ export type ContentValue =
   | string
   | number
   | boolean
+  | Date
   | null
   | undefined
   | void

--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -26,15 +26,15 @@ import {
  * values like `null` and `undefined`; DOM nodes; and blockless curly
  * component invocations.
  */
-export type ContentValue =
+export type ContentValue = 
   | string
   | number
   | boolean
-  | Date
   | null
   | undefined
   | void
   | SafeString
+  | { toString(): string }
   | Node
   | ArglessCurlyComponent;
 

--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -26,7 +26,7 @@ import {
  * values like `null` and `undefined`; DOM nodes; and blockless curly
  * component invocations.
  */
-export type ContentValue = 
+export type ContentValue =
   | string
   | number
   | boolean

--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -26,7 +26,7 @@ import {
  * values like `null` and `undefined`; DOM nodes; and blockless curly
  * component invocations.
  */
-export type ContentValue =
+export type ContentValue = 
   | string
   | number
   | boolean


### PR DESCRIPTION
<details><summary>per discussion, toString won't happen</summary>

Anything with `{ toString(): string }` is renderable, including Date, boolean, etc.

We should reflect the reality of what is renderable in the `ContentValue` type.
It already has `{ toHTML(): string }` support, which is great, but `{ toString(): string }` should cover most other cases.

-----

Old Description:

</details>

Dates are renderable.

_otherwise_, you gotta cast your value to something like `x as Date & { toHtml(): string }` which is silly, and relies on secret knowledge of how SafeString works.