### PR TITLE
check if template is in heritage clause

### DIFF
--- a/packages/core/__tests__/transform/rewrite.test.ts
+++ b/packages/core/__tests__/transform/rewrite.test.ts
@@ -467,6 +467,30 @@ describe('Transform: rewriteModule', () => {
   });
 
   describe('ember-template-imports', () => {
+    test('in class extends', () => {
+      let customEnv = GlintEnvironment.load(['ember-loose', 'ember-template-imports']);
+      let script = {
+        filename: 'test.gts',
+        contents: stripIndent`
+          import Component, { hbs } from 'special/component';
+          export default class MyComponent extends Component(<template></template>) {
+            
+          }
+        `,
+      };
+
+      let transformedModule = rewriteModule(ts, { script }, customEnv);
+
+
+      expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
+        "import Component, { hbs } from 'special/component';
+        export default class MyComponent extends Component(({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {
+          𝚪; χ;
+        })) {
+          
+        }"
+      `);
+    });
     test('embedded gts templates', () => {
       let customEnv = GlintEnvironment.load(['ember-loose', 'ember-template-imports']);
       let script = {

--- a/packages/core/__tests__/transform/rewrite.test.ts
+++ b/packages/core/__tests__/transform/rewrite.test.ts
@@ -481,7 +481,6 @@ describe('Transform: rewriteModule', () => {
 
       let transformedModule = rewriteModule(ts, { script }, customEnv);
 
-
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component, { hbs } from 'special/component';
         export default class MyComponent extends Component(({} as typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")).templateExpression(function(𝚪, χ: typeof import(\\"@glint/environment-ember-template-imports/-private/dsl\\")) {

--- a/packages/core/src/transform/template/inlining/index.ts
+++ b/packages/core/src/transform/template/inlining/index.ts
@@ -21,6 +21,9 @@ export function isEmbeddedInClass(ts: TSLib, node: ts.Node): boolean {
     // TODO: this should likely actually filter on whether the template appears in a
     // static block or property definition, but just "am I in a class body" is the
     // current status quo and has been ok so far.
+    if (ts.isHeritageClause(current)) {
+      return false;
+    }
     if (ts.isClassLike(current)) {
       return true;
     }


### PR DESCRIPTION
support 
```gjs
class A extends X(<template></template>) {

}
```

currently the template part tries to have `A` as backing value