### PR TITLE
rm glint/getIR command

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -65,26 +65,12 @@ const argv = yargs(process.argv.slice(2))
       'Save .tsbuildinfo files to allow for incremental compilation of projects. Same as the TS `--incremental` flag.',
     type: 'boolean',
   })
-  .option('debug-intermediate-representation', {
-    boolean: false,
-    description: `When true, writes out a Glint's internal intermediate representation of each file within a GLINT_DEBUG subdirectory of the current working directory. This is intended for debugging Glint itself.`,
-  })
   .version(pkg.version)
   .wrap(100)
   .strict()
   .parseSync();
 
 let cwd = process.cwd();
-
-if (argv['debug-intermediate-representation']) {
-  const fs = require('fs');
-  const path = require('path');
-  (globalThis as any).GLINT_DEBUG_IR = function (filename: string, content: string) {
-    let target = path.join('GLINT_DEBUG', path.relative(cwd, filename));
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, content);
-  };
-}
 
 if (argv.build) {
   // Type signature here so we get a useful error as close to the source of the

--- a/packages/core/src/language-server/messages.cts
+++ b/packages/core/src/language-server/messages.cts
@@ -1,31 +1,4 @@
-import { ProtocolRequestType, TextEdit } from '@volar/language-server';
-
 export type Request<Name extends string, T> = {
   name: Name;
   type: T;
 };
-
-export const GetIRRequest = makeRequestType(
-  'glint/getIR',
-  ProtocolRequestType<GetIRParams, GetIRResult | null, void, void, void>,
-);
-
-export interface GetIRParams {
-  uri: string;
-}
-
-export interface GetIRResult {
-  contents: string;
-  uri: string;
-}
-
-// This utility allows us to encode type information to enforce that we're using
-// a valid request name along with its associated param/response types without
-// actually requring the runtime code here to be imported elsewhere.
-// See `requestKey` in the Code extension.
-function makeRequestType<Name extends string, T>(
-  name: Name,
-  RequestType: new (name: Name) => T,
-): Request<Name, T> {
-  return { name, type: new RequestType(name) };
-}

--- a/packages/core/src/transform/template/rewrite-module.ts
+++ b/packages/core/src/transform/template/rewrite-module.ts
@@ -49,8 +49,6 @@ export function rewriteModule(
   let sparseSpans = completeCorrelatedSpans(partialSpans);
   let { contents, correlatedSpans } = calculateTransformedSource(script, sparseSpans);
 
-  (globalThis as any).GLINT_DEBUG_IR?.(script.filename, contents);
-
   return new TransformedModule(contents, errors, directives, correlatedSpans);
 }
 

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -26,30 +26,6 @@ describe('Smoke test: Ember', () => {
     }
   });
 
-  describe('debugging commands', () => {
-    test('showing IR in the backing file', async () => {
-      let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
-      let editor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
-
-      await commands.executeCommand('glint.show-debug-ir');
-      await waitUntil(() => editor.document.getText().includes('𝚪'));
-
-      expect(editor.document.getText()).toMatch('𝚪.this.message');
-    });
-
-    test('showing IR from a template', async () => {
-      let templateURI = Uri.file(`${rootDir}/app/components/colocated-layout.hbs`);
-      let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);
-
-      await window.showTextDocument(templateURI, { viewColumn: ViewColumn.One });
-      await commands.executeCommand('glint.show-debug-ir');
-      await waitUntil(() => window.activeTextEditor?.document.getText().includes('𝚪'));
-
-      expect(window.activeTextEditor?.document.uri.toString()).toEqual(scriptURI.toString());
-      expect(window.activeTextEditor?.document.getText()).toMatch('𝚪.this.message');
-    });
-  });
-
   describe('diagnostics for errors', () => {
     test('component template', async () => {
       let scriptURI = Uri.file(`${rootDir}/app/components/colocated-layout.ts`);

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -51,18 +51,6 @@ describe('Smoke test: ETI Environment', () => {
       ]);
     });
 
-    describe('debugging commands', () => {
-      test('showing IR in a custom file type', async () => {
-        let scriptURI = Uri.file(`${rootDir}/src/Greeting.gts`);
-        let editor = await window.showTextDocument(scriptURI, { viewColumn: ViewColumn.One });
-
-        await commands.executeCommand('glint.show-debug-ir');
-        await waitUntil(() => editor.document.getText().includes('𝚪'));
-
-        expect(editor.document.getText()).toMatch('𝚪.this.message');
-      });
-    });
-
     describe('codeactions args', () => {
       test('adds missing args from template into Args type', async () => {
         let scriptURI = Uri.file(`${rootDir}/src/Greeting.gts`);

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -178,11 +178,6 @@
       {
         "title": "Glint: Restart Glint Server",
         "command": "glint.restart-language-server"
-      },
-      {
-        "title": "Glint: Show IR for Debugging",
-        "command": "glint.show-debug-ir",
-        "enablement": "config.glint.debug == true"
       }
     ],
     "menus": {
@@ -201,11 +196,6 @@
             "markdownDescription": "The path, relative to your workspace folder root, from which to resolve `@glint/core`. Defaults to `'.'`.",
             "order": 1,
             "type": "string"
-          },
-          "glint.debug": {
-            "description": "Enable debugging commands for Glint.",
-            "type": "boolean",
-            "default": false
           },
           "glint.trace.server": {
             "description": "Traces communication between VS Code and the Glint language server.",


### PR DESCRIPTION
The getIR command was a helpful debugging command for replacing your open .gts / .hbs file with the type-checkable TS representation. With Volar, you just use the Volar Labs extension on an open file to show you the IR along with a ton of other helpful debugging/diagnostic tooling.