### PR TITLE
Tests: Use clearer project testing commands

### DIFF
--- a/packages/core/__tests__/cli/build-watch.test.ts
+++ b/packages/core/__tests__/cli/build-watch.test.ts
@@ -78,7 +78,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let watch = project.buildWatch({ reject: true });
+      let watch = project.buildDeclarationWatch({ reject: true });
       let output = await watch.awaitOutput('Watching for file changes.');
       await watch.terminate();
 
@@ -107,7 +107,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let watch = project.buildWatch({ reject: false });
+      let watch = project.buildDeclarationWatch({ reject: false });
       let output = await watch.awaitOutput('Watching for file changes.');
 
       await watch.terminate();
@@ -146,7 +146,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let watch = project.buildWatch();
+      let watch = project.buildDeclarationWatch();
       let output = await watch.awaitOutput('Watching for file changes.');
 
       await watch.terminate();
@@ -187,7 +187,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let watch = project.buildWatch({ reject: true });
+      let watch = project.buildDeclarationWatch({ reject: true });
 
       let output = await watch.awaitOutput('Watching for file changes.');
       expect(output).toMatch('Found 0 errors.');
@@ -230,7 +230,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let watch = project.buildWatch({ reject: true });
+      let watch = project.buildDeclarationWatch({ reject: true });
 
       let output = await watch.awaitOutput('Watching for file changes.');
       expect(output).toMatch('Found 0 errors.');
@@ -329,7 +329,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
     });
 
     test('passes when all projects are valid', async () => {
-      let watch = projects.root.buildWatch({ reject: true });
+      let watch = projects.root.buildDeclarationWatch({ reject: true });
 
       let output = await watch.awaitOutput('Watching for file changes.');
       expect(output).toMatch('Found 0 errors.');
@@ -340,7 +340,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
     describe('reports on errors introduced and cleared during the watch', () => {
       describe('for template syntax errors', () => {
         test('in the root', async () => {
-          let watch = projects.root.buildWatch({ reject: true });
+          let watch = projects.root.buildDeclarationWatch({ reject: true });
 
           let output = await watch.awaitOutput('Watching for file changes.');
           expect(output).toMatch('Found 0 errors.');
@@ -379,7 +379,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
         });
 
         test('in a project with references referenced directly by the root', async () => {
-          let watch = projects.root.buildWatch({ reject: true });
+          let watch = projects.root.buildDeclarationWatch({ reject: true });
 
           let output = await watch.awaitOutput('Watching for file changes.');
           expect(output).toMatch('Found 0 errors.');
@@ -417,7 +417,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
         });
 
         test('in a project transitively referenced by the root', async () => {
-          let watch = projects.root.buildWatch({ reject: true });
+          let watch = projects.root.buildDeclarationWatch({ reject: true });
 
           let output = await watch.awaitOutput('Watching for file changes.');
           expect(output).toMatch('Found 0 errors.');
@@ -455,7 +455,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
 
       describe('for template type errors', () => {
         test('in the root', async () => {
-          let watch = projects.root.buildWatch({ reject: true });
+          let watch = projects.root.buildDeclarationWatch({ reject: true });
 
           let output = await watch.awaitOutput('Watching for file changes.');
           expect(output).toMatch('Found 0 errors.');
@@ -488,7 +488,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
         });
 
         test('in a project with references referenced directly by the root', async () => {
-          let watch = projects.root.buildWatch({ reject: true });
+          let watch = projects.root.buildDeclarationWatch({ reject: true });
 
           let output = await watch.awaitOutput('Watching for file changes.');
           expect(output).toMatch('Found 0 errors.');
@@ -521,7 +521,7 @@ describe.skip('CLI: watched build mode typechecking', () => {
         });
 
         test('in a project transitively referenced by the root', async () => {
-          let watch = projects.root.buildWatch({ reject: true });
+          let watch = projects.root.buildDeclarationWatch({ reject: true });
 
           let output = await watch.awaitOutput('Watching for file changes.');
           expect(output).toMatch('Found 0 errors.');

--- a/packages/core/__tests__/cli/build.test.ts
+++ b/packages/core/__tests__/cli/build.test.ts
@@ -47,13 +47,13 @@ describe('CLI: single-pass build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let checkResult = await project.build({ reject: false });
+      let checkResult = await project.buildDeclaration({ reject: false });
 
       expect(checkResult.exitCode).toBe(0);
       expect(checkResult.stdout).toEqual('');
       expect(checkResult.stderr).toEqual('');
 
-      // This tests that the `--emitDeclarationOnly` flag within project.build is working.
+      // This tests that the `--emitDeclarationOnly` flag within project.buildDeclaration is working.
       expect(existsSync(project.filePath('dist/index.gts.js'))).toBe(false);
     });
 
@@ -79,7 +79,7 @@ describe('CLI: single-pass build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let checkResult = await project.build({ reject: false });
+      let checkResult = await project.buildDeclaration({ reject: false });
 
       expect(checkResult.exitCode).toBe(1);
       expect(checkResult.stdout).toEqual('');
@@ -122,7 +122,7 @@ describe('CLI: single-pass build mode typechecking', () => {
 
       project.write(INPUT_SFC, code);
 
-      let checkResult = await project.build({ reject: false });
+      let checkResult = await project.buildDeclaration({ reject: false });
 
       expect(checkResult.exitCode).toBe(1);
       expect(stripAnsi(checkResult.stdout)).toMatchInlineSnapshot(`
@@ -1099,11 +1099,11 @@ describe.skip('CLI: --build --clean', () => {
 
     project.write(INPUT_SFC, code);
 
-    let buildResult = await project.build();
+    let buildResult = await project.buildDeclaration();
     expect(buildResult.exitCode).toBe(0);
     expect(existsSync(project.filePath(INDEX_D_TS))).toBe(true);
 
-    let buildCleanResult = await project.build({ flags: ['--clean'] });
+    let buildCleanResult = await project.buildDeclaration({ flags: ['--clean'] });
     expect(buildCleanResult.exitCode).toBe(0);
     expect(existsSync(project.filePath(INDEX_D_TS))).toBe(false);
   });
@@ -1193,13 +1193,13 @@ describe.skip('CLI: --build --force', () => {
 
     project.write(INPUT_SFC, code);
 
-    let buildResult = await project.build();
+    let buildResult = await project.buildDeclaration();
     expect(buildResult.exitCode).toBe(0);
     let indexDTs = project.filePath(INDEX_D_TS);
     expect(existsSync(indexDTs)).toBe(true);
     let firstStat = statSync(indexDTs);
 
-    let buildCleanResult = await project.build({ flags: ['--force'] });
+    let buildCleanResult = await project.buildDeclaration({ flags: ['--force'] });
     expect(buildCleanResult.exitCode).toBe(0);
     let exists = existsSync(indexDTs);
     expect(exists).toBe(true);
@@ -1309,7 +1309,7 @@ describe.skip('CLI: --build --dry', () => {
     });
 
     test('when no build has occurred', async () => {
-      let buildResult = await project.build({ flags: ['--dry'] });
+      let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
       expect(buildResult.exitCode).toBe(0);
       expect(stripAnsi(buildResult.stdout)).toMatch(
         `A non-dry build would build project '${project.filePath('tsconfig.json')}'`,
@@ -1319,11 +1319,11 @@ describe.skip('CLI: --build --dry', () => {
 
     describe('when the project has been built', () => {
       beforeEach(async () => {
-        await project.build();
+        await project.buildDeclaration();
       });
 
       test('when there are no changes', async () => {
-        let buildResult = await project.build({ flags: ['--dry'] });
+        let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
         expect(buildResult.exitCode).toBe(0);
         expect(stripAnsi(buildResult.stdout)).toMatch(
           `Project '${project.filePath('tsconfig.json')}' is up to date`,
@@ -1352,7 +1352,7 @@ describe.skip('CLI: --build --dry', () => {
 
         project.write(INPUT_SFC, code);
 
-        let buildResult = await project.build({ flags: ['--dry'] });
+        let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
         expect(buildResult.exitCode).toBe(0);
         expect(stripAnsi(buildResult.stdout)).toMatch(
           `A non-dry build would build project '${project.filePath('tsconfig.json')}'`,
@@ -1393,7 +1393,7 @@ describe.skip('CLI: --build --dry', () => {
     });
 
     test('when no build has occurred', async () => {
-      let buildResult = await project.build({ flags: ['--dry'] });
+      let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
       expect(buildResult.exitCode).toBe(0);
       expect(stripAnsi(buildResult.stdout)).toMatch(
         `A non-dry build would build project '${project.filePath('tsconfig.json')}'`,
@@ -1403,11 +1403,11 @@ describe.skip('CLI: --build --dry', () => {
 
     describe('when the project has been built', () => {
       beforeEach(async () => {
-        await project.build();
+        await project.buildDeclaration();
       });
 
       test('when there are no changes', async () => {
-        let buildResult = await project.build({ flags: ['--dry'] });
+        let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
         expect(buildResult.exitCode).toBe(0);
         expect(stripAnsi(buildResult.stdout)).toMatch(
           `Project '${project.filePath('tsconfig.json')}' is up to date`,
@@ -1431,7 +1431,7 @@ describe.skip('CLI: --build --dry', () => {
         `;
         project.write(INPUT_SCRIPT, backingClass);
 
-        let buildResult = await project.build({ flags: ['--dry'] });
+        let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
         expect(buildResult.exitCode).toBe(0);
         expect(stripAnsi(buildResult.stdout)).toMatch(
           `A non-dry build would build project '${project.filePath('tsconfig.json')}'`,
@@ -1447,7 +1447,7 @@ describe.skip('CLI: --build --dry', () => {
 
         project.write(INPUT_TEMPLATE, template);
 
-        let buildResult = await project.build({ flags: ['--dry'] });
+        let buildResult = await project.buildDeclaration({ flags: ['--dry'] });
         expect(buildResult.exitCode).toBe(0);
         expect(stripAnsi(buildResult.stdout)).toMatch(
           `A non-dry build would build project '${project.filePath('tsconfig.json')}'`,

--- a/packages/core/__tests__/cli/custom-extensions.test.ts
+++ b/packages/core/__tests__/cli/custom-extensions.test.ts
@@ -40,7 +40,7 @@ describe.skip('CLI: custom extensions', () => {
     project.setGlintConfig({ environment: 'ember-template-imports' });
     project.write('index.gts', code);
 
-    let watch = project.watch();
+    let watch = project.checkWatch();
     let output = await watch.awaitOutput('Watching for file changes.');
 
     await watch.terminate();
@@ -73,7 +73,7 @@ describe.skip('CLI: custom extensions', () => {
     });
 
     test('adding a missing module', async () => {
-      let watch = project.watch();
+      let watch = project.checkWatch();
       let output = await watch.awaitOutput('Watching for file changes.');
 
       expect(output).toMatch('Found 1 error.');
@@ -90,7 +90,7 @@ describe.skip('CLI: custom extensions', () => {
     test('changing an imported module', async () => {
       project.write('other.gjs', 'export const foo = 123;');
 
-      let watch = project.watch();
+      let watch = project.checkWatch();
       let output = await watch.awaitOutput('Watching for file changes.');
 
       expect(output).toMatch('Found 0 errors.');
@@ -107,7 +107,7 @@ describe.skip('CLI: custom extensions', () => {
     test('removing an imported module', async () => {
       project.write('other.gjs', 'export const foo = 123;');
 
-      let watch = project.watch();
+      let watch = project.checkWatch();
       let output = await watch.awaitOutput('Watching for file changes.');
 
       expect(output).toMatch('Found 0 errors.');

--- a/packages/core/__tests__/cli/watch.test.ts
+++ b/packages/core/__tests__/cli/watch.test.ts
@@ -34,7 +34,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('index.gts', code);
 
-    let watch = project.watch({ reject: true });
+    let watch = project.checkWatch({ reject: true });
     let output = await watch.awaitOutput('Watching for file changes.');
 
     await watch.terminate();
@@ -62,7 +62,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('index.gts', code);
 
-    let watch = project.watch();
+    let watch = project.checkWatch();
     let output = await watch.awaitOutput('Watching for file changes.');
 
     await watch.terminate();
@@ -105,7 +105,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('index.gts', code);
 
-    let watch = project.watch();
+    let watch = project.checkWatch();
     let output = await watch.awaitOutput('Watching for file changes.');
 
     await watch.terminate();
@@ -149,7 +149,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('index.gts', code);
 
-    let watch = project.watch({ reject: true });
+    let watch = project.checkWatch({ reject: true });
 
     let output = await watch.awaitOutput('Watching for file changes.');
     expect(output).toMatch('Found 0 errors.');
@@ -191,7 +191,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('my-component.ts', script);
 
-    let watch = project.watch({ reject: true });
+    let watch = project.checkWatch({ reject: true });
 
     let output = await watch.awaitOutput('Watching for file changes.');
     expect(output).toMatch('Found 0 errors.');
@@ -234,7 +234,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('index.gts', code);
 
-    let watch = project.watch({ reject: true });
+    let watch = project.checkWatch({ reject: true });
     let output = await watch.awaitOutput('Watching for file changes.');
     expect(output).toMatch('Found 0 errors.');
 
@@ -273,7 +273,7 @@ describe('CLI: watched typechecking', () => {
     project.write('my-component.ts', script);
     project.write('my-component.hbs', template);
 
-    let watch = project.watch();
+    let watch = project.checkWatch();
 
     let output = await watch.awaitOutput('Watching for file changes.');
     expect(output).toMatch('Found 0 errors.');
@@ -311,7 +311,7 @@ describe('CLI: watched typechecking', () => {
 
     project.write('index.gts', code);
 
-    let watch = project.watch({ flags: ['--preserveWatchOutput'], reject: true });
+    let watch = project.checkWatch({ flags: ['--preserveWatchOutput'], reject: true });
 
     let output = await watch.awaitOutput('Watching for file changes.');
     expect(output).toMatch('Found 0 errors.');

--- a/test-packages/test-utils/src/project.ts
+++ b/test-packages/test-utils/src/project.ts
@@ -306,12 +306,15 @@ export class Project {
     });
   }
 
-  public watch(options: Options & { flags?: string[] } = {}): Watch {
+  public checkWatch(options: Options & { flags?: string[] } = {}): Watch {
     let flags = ['--watch', ...(options.flags ?? [])];
     return new Watch(this.check({ ...options, flags, reject: false }));
   }
 
-  public build(options: Options & { flags?: string[] } = {}, debug = false): ExecaChildProcess {
+  public buildDeclaration(
+    options: Options & { flags?: string[] } = {},
+    debug = false,
+  ): ExecaChildProcess {
     let flags = ['--build', '--emitDeclarationOnly', '--pretty', ...(options.flags ?? [])];
     return execaNode(require.resolve('@glint/core/bin/glint'), flags, {
       cwd: this.rootDir,
@@ -320,9 +323,9 @@ export class Project {
     });
   }
 
-  public buildWatch(options: Options & { flags?: string[] } = {}): Watch {
+  public buildDeclarationWatch(options: Options & { flags?: string[] } = {}): Watch {
     let flags = ['--watch', ...(options.flags ?? [])];
-    return new Watch(this.build({ ...options, flags, reject: false }));
+    return new Watch(this.buildDeclaration({ ...options, flags, reject: false }));
   }
 }
 


### PR DESCRIPTION
We're changing some of the behaviors around the glint CLI tools, and I wanted to make it more clear what particular operation was being triggered by which test method we were invoking on the test `Project` class. This should hopefully make it more clear.