### PR TITLE
Primitives for supporting ember-loose mode (.ts + .hbs)

### DIFF
--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -176,7 +176,7 @@ describe('CLI: single-pass typechecking', () => {
     `);
   });
 
-  test.only('reports diagnostics for a companion template type error', async () => {
+  test.skip('reports diagnostics for a companion template type error', async () => {
     project.setGlintConfig({ environment: 'ember-loose' });
 
     let script = stripIndent`

--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -176,7 +176,7 @@ describe('CLI: single-pass typechecking', () => {
     `);
   });
 
-  test('reports diagnostics for a companion template type error', async () => {
+  test.only('reports diagnostics for a companion template type error', async () => {
     project.setGlintConfig({ environment: 'ember-loose' });
 
     let script = stripIndent`

--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -176,7 +176,7 @@ describe('CLI: single-pass typechecking', () => {
     `);
   });
 
-  test.skip('reports diagnostics for a companion template type error', async () => {
+  test.only('reports diagnostics for a companion template type error', async () => {
     project.setGlintConfig({ environment: 'ember-loose' });
 
     let script = stripIndent`
@@ -200,9 +200,8 @@ describe('CLI: single-pass typechecking', () => {
 
     let checkResult = await project.check({ reject: false });
 
-    expect(checkResult.exitCode).toBe(1);
-    expect(checkResult.stdout).toEqual('');
-    expect(stripAnsi(checkResult.stderr)).toMatchInlineSnapshot(`
+    expect(checkResult.exitCode).not.toBe(0);
+    expect(stripAnsi(checkResult.stdout)).toMatchInlineSnapshot(`
       "my-component.hbs:1:22 - error TS2551: Property 'targett' does not exist on type 'MyComponent'. Did you mean 'target'?
 
       1 {{@message}}, {{this.targett}}

--- a/packages/core/__tests__/cli/check.test.ts
+++ b/packages/core/__tests__/cli/check.test.ts
@@ -176,7 +176,7 @@ describe('CLI: single-pass typechecking', () => {
     `);
   });
 
-  test.only('reports diagnostics for a companion template type error', async () => {
+  test('reports diagnostics for a companion template type error', async () => {
     project.setGlintConfig({ environment: 'ember-loose' });
 
     let script = stripIndent`

--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -14,7 +14,7 @@ describe('Language Server: Completions', () => {
     await project.destroy();
   });
 
-  test('querying a standalone template', async () => {
+  test.skip('querying a standalone template', async () => {
     project.setGlintConfig({ environment: 'ember-loose' });
     project.write('index.hbs', '<LinkT />');
 

--- a/packages/core/__tests__/language-server/completions.test.ts
+++ b/packages/core/__tests__/language-server/completions.test.ts
@@ -14,21 +14,19 @@ describe('Language Server: Completions', () => {
     await project.destroy();
   });
 
-  test.skip('querying a standalone template', async () => {
+  test('querying a standalone template', async () => {
     project.setGlintConfig({ environment: 'ember-loose' });
     project.write('index.hbs', '<LinkT />');
 
     let server = await project.startLanguageServer();
-    let completions = server.getCompletions(project.fileURI('index.hbs'), {
-      line: 0,
-      character: 6,
-    });
+    const { uri } = await server.openTextDocument(project.filePath('index.hbs'), 'handlebars');
+    let completions = await server.sendCompletionRequest(uri, Position.create(0, 6));
 
-    let completion = completions?.find((item) => item.label === 'LinkTo');
+    let completion = completions?.items.find((item) => item.label === 'LinkTo');
 
     expect(completion?.kind).toEqual(CompletionItemKind.Field);
 
-    let details = server.getCompletionDetails(completion!);
+    let details = await server.sendCompletionResolveRequest(completion!);
 
     expect(details.detail).toEqual('(property) Globals.LinkTo: LinkToComponent');
   });
@@ -65,10 +63,8 @@ describe('Language Server: Completions', () => {
     project.write('index.hbs', code);
 
     let server = await project.startLanguageServer();
-    let completions = server.getCompletions(project.fileURI('index.hbs'), {
-      line: 0,
-      character: 4,
-    });
+    const { uri } = await server.openTextDocument(project.filePath('index.hbs'), 'handlebars');
+    let completions = await server.sendCompletionRequest(uri, Position.create(0, 4));
 
     // Ensure we don't spew all ~900 completions available at the top level
     // in module scope in a JS/TS file.

--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -915,7 +915,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     `);
   });
 
-  test.only('unresolved globals', async () => {
+  test.skip('unresolved globals', async () => {
     project.setGlintConfig({ environment: ['ember-loose'] });
     project.write({
       'index.ts': stripIndent`

--- a/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/packages/core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -915,7 +915,7 @@ describe('Language Server: Diagnostic Augmentation', () => {
     `);
   });
 
-  test.skip('unresolved globals', async () => {
+  test.only('unresolved globals', async () => {
     project.setGlintConfig({ environment: ['ember-loose'] });
     project.write({
       'index.ts': stripIndent`
@@ -940,7 +940,8 @@ describe('Language Server: Diagnostic Augmentation', () => {
     });
 
     let server = await project.startLanguageServer();
-    let diagnostics = server.getDiagnostics(project.fileURI('index.hbs'));
+    const { uri } = await server.openTextDocument(project.filePath('index.hbs'), 'handlebars');
+    let diagnostics = await server.sendDocumentDiagnosticRequest(uri);
 
     expect(diagnostics.items.reverse()).toMatchInlineSnapshot(`
       [

--- a/packages/core/src/cli/run-volar-tsc.ts
+++ b/packages/core/src/cli/run-volar-tsc.ts
@@ -1,5 +1,5 @@
 import { runTsc } from '@volar/typescript/lib/quickstart/runTsc.js';
-import { createGtsLanguagePlugin } from '../volar/gts-language-plugin.js';
+import { createEmberLanguagePlugin } from '../volar/ember-language-plugin.js';
 import { findConfig } from '../config/index.js';
 
 import { createRequire } from 'node:module';
@@ -29,7 +29,7 @@ export function run(): void {
       // not sure whether it's better to be lenient, but we were getting test failures
       // on environment-ember-loose's `yarn run test`.
       if (glintConfig) {
-        const gtsLanguagePlugin = createGtsLanguagePlugin(glintConfig);
+        const gtsLanguagePlugin = createEmberLanguagePlugin(glintConfig);
         return [gtsLanguagePlugin];
       } else {
         return [];

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -13,8 +13,6 @@ export class GlintConfig {
   public readonly environment: GlintEnvironment;
   public readonly checkStandaloneTemplates: boolean;
 
-  private extensions: Array<string>;
-
   public constructor(
     ts: typeof import('typescript'),
     configPath: string,
@@ -25,32 +23,6 @@ export class GlintConfig {
     this.rootDir = path.dirname(configPath);
     this.environment = GlintEnvironment.load(config.environment, { rootDir: this.rootDir });
     this.checkStandaloneTemplates = config.checkStandaloneTemplates ?? true;
-    this.extensions = this.environment.getConfiguredFileExtensions();
-  }
-
-  /**
-   * Indicates whether this configuration object applies to the file at the
-   * given path.
-   */
-  public includesFile(rawFileName: string): boolean {
-    return this.extensions.some((ext) => rawFileName.endsWith(ext));
-  }
-
-  // Given the path of a template or script (potentially with a custom extension),
-  // returns the corresponding .js or .ts path we present to the TS language service.
-  public getSynthesizedScriptPathForTS(filename: string): string {
-    let extension = path.extname(filename);
-    let filenameWithoutExtension = filename.slice(0, filename.lastIndexOf(extension));
-    switch (this.environment.getSourceKind(filename)) {
-      case 'template':
-        return `${filenameWithoutExtension}${this.checkStandaloneTemplates ? '.ts' : '.js'}`;
-      case 'typed-script':
-        return `${filenameWithoutExtension}.ts`;
-      case 'untyped-script':
-        return `${filenameWithoutExtension}.js`;
-      default:
-        return filename;
-    }
   }
 }
 

--- a/packages/core/src/transform/template/glimmer-ast-mapping-tree.ts
+++ b/packages/core/src/transform/template/glimmer-ast-mapping-tree.ts
@@ -48,13 +48,13 @@ export class TemplateEmbedding {
  * level of granularity as TS itself uses when reporting on the transformed
  * output.
  */
-export default class MappingTree {
-  public parent: MappingTree | null = null;
+export default class GlimmerASTMappingTree {
+  public parent: GlimmerASTMappingTree | null = null;
 
   public constructor(
     public transformedRange: Range,
     public originalRange: Range,
-    public children: Array<MappingTree> = [],
+    public children: Array<GlimmerASTMappingTree> = [],
     public sourceNode: MappingSource,
   ) {
     children.forEach((child) => (child.parent = this));
@@ -65,7 +65,7 @@ export default class MappingTree {
    * that contains the given range, or `null` if that range doesn't fall within
    * this mapping tree.
    */
-  public narrowestMappingForTransformedRange(range: Range): MappingTree | null {
+  public narrowestMappingForTransformedRange(range: Range): GlimmerASTMappingTree | null {
     if (range.start < this.transformedRange.start || range.end > this.transformedRange.end) {
       return null;
     }
@@ -85,7 +85,7 @@ export default class MappingTree {
    * that contains the given range, or `null` if that range doesn't fall within
    * this mapping tree.
    */
-  public narrowestMappingForOriginalRange(range: Range): MappingTree | null {
+  public narrowestMappingForOriginalRange(range: Range): GlimmerASTMappingTree | null {
     if (range.start < this.originalRange.start || range.end > this.originalRange.end) {
       return null;
     }

--- a/packages/core/src/transform/template/inlining/companion-file.ts
+++ b/packages/core/src/transform/template/inlining/companion-file.ts
@@ -50,7 +50,7 @@ export function calculateCompanionTemplateSpans(
     });
   } else {
     // TODO: when does this get called?
-    throw new Error("ALEX not class like");
+    // throw new Error("ALEX not class like");
     let backingValue: string | undefined;
     if (targetNode) {
       let moduleName = path.basename(script.filename, path.extname(script.filename));

--- a/packages/core/src/transform/template/inlining/companion-file.ts
+++ b/packages/core/src/transform/template/inlining/companion-file.ts
@@ -3,7 +3,7 @@ import type ts from 'typescript';
 import { GlintEnvironment } from '../../../config/index.js';
 import { CorrelatedSpansResult, isEmbeddedInClass, PartialCorrelatedSpan } from './index.js';
 import { RewriteResult } from '../map-template-contents.js';
-import MappingTree, { ParseError } from '../mapping-tree.js';
+import GlimmerASTMappingTree, { ParseError } from '../glimmer-ast-mapping-tree.js';
 import { templateToTypescript } from '../template-to-typescript.js';
 import { Directive, SourceFile, TransformError } from '../transformed-module.js';
 import { TSLib } from '../../util.js';
@@ -115,7 +115,7 @@ export function calculateCompanionTemplateSpans(
           originalLength: template.contents.length,
           insertionPoint: options.insertionPoint,
           transformedSource: transformedTemplate.result.code,
-          mapping: transformedTemplate.result.mapping,
+          glimmerAstMapping: transformedTemplate.result.mapping,
         },
         {
           originalFile: template,
@@ -126,7 +126,7 @@ export function calculateCompanionTemplateSpans(
         },
       );
     } else {
-      let mapping = new MappingTree(
+      let mapping = new GlimmerASTMappingTree(
         { start: 0, end: 0 },
         { start: 0, end: template.contents.length },
         [],
@@ -139,7 +139,7 @@ export function calculateCompanionTemplateSpans(
         originalLength: template.contents.length,
         insertionPoint: options.insertionPoint,
         transformedSource: '',
-        mapping,
+        glimmerAstMapping: mapping,
       });
     }
   }

--- a/packages/core/src/transform/template/inlining/companion-file.ts
+++ b/packages/core/src/transform/template/inlining/companion-file.ts
@@ -147,6 +147,10 @@ export function calculateCompanionTemplateSpans(
 
 /**
  * Find and return the TS AST node which can serve as a proper insertion point
+ * for the transformed template code, which is:
+ *
+ * - The default export class declaration
+ * - a named export that matches a class declaration
  */
 function findCompanionTemplateTarget(
   ts: TSLib,

--- a/packages/core/src/transform/template/inlining/companion-file.ts
+++ b/packages/core/src/transform/template/inlining/companion-file.ts
@@ -49,8 +49,6 @@ export function calculateCompanionTemplateSpans(
       suffix: '}\n',
     });
   } else {
-    // TODO: when does this get called?
-    // throw new Error("ALEX not class like");
     let backingValue: string | undefined;
     if (targetNode) {
       let moduleName = path.basename(script.filename, path.extname(script.filename));

--- a/packages/core/src/transform/template/inlining/companion-file.ts
+++ b/packages/core/src/transform/template/inlining/companion-file.ts
@@ -49,6 +49,8 @@ export function calculateCompanionTemplateSpans(
       suffix: '}\n',
     });
   } else {
+    // TODO: when does this get called?
+    throw new Error("ALEX not class like");
     let backingValue: string | undefined;
     if (targetNode) {
       let moduleName = path.basename(script.filename, path.extname(script.filename));
@@ -143,6 +145,9 @@ export function calculateCompanionTemplateSpans(
   }
 }
 
+/**
+ * Find and return the TS AST node which can serve as a proper insertion point
+ */
 function findCompanionTemplateTarget(
   ts: TSLib,
   sourceFile: ts.SourceFile,
@@ -155,6 +160,7 @@ function findCompanionTemplateTarget(
         mods?.some((mod) => mod.kind === ts.SyntaxKind.DefaultKeyword) &&
         mods.some((mod) => mod.kind === ts.SyntaxKind.ExportKeyword)
       ) {
+        // We've found a `export default class` statement; return it.
         return statement;
       }
 
@@ -164,6 +170,8 @@ function findCompanionTemplateTarget(
     }
   }
 
+  // We didn't find a default export, but maybe there is a named export that
+  // matches one of the class statements we found above.
   for (let statement of sourceFile.statements) {
     if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
       if (ts.isIdentifier(statement.expression) && statement.expression.text in classes) {

--- a/packages/core/src/transform/template/inlining/tagged-strings.ts
+++ b/packages/core/src/transform/template/inlining/tagged-strings.ts
@@ -106,7 +106,7 @@ export function calculateTaggedTemplateSpans(
         originalLength: templateLocation.end - templateLocation.start,
         insertionPoint: templateLocation.start,
         transformedSource: transformedTemplate.result.code,
-        mapping: transformedTemplate.result.mapping,
+        glimmerAstMapping: transformedTemplate.result.mapping,
       });
     }
   }

--- a/packages/core/src/transform/template/map-template-contents.ts
+++ b/packages/core/src/transform/template/map-template-contents.ts
@@ -121,7 +121,8 @@ export type MapTemplateContentsOptions = {
 };
 
 /**
- * Given the text of an embedded template, invokes the given callback
+ * Given the text of a handlebars template (either standalone .hbs file, or the contents
+ * of an embedded `<template>...</template>` within a .gts file), invokes the given callback
  * with a set of tools to emit mapped contents corresponding to
  * that template, tracking the text emitted in order to provide
  * a mapping of ranges in the input to ranges in the output.

--- a/packages/core/src/transform/template/map-template-contents.ts
+++ b/packages/core/src/transform/template/map-template-contents.ts
@@ -1,5 +1,8 @@
 import { AST, preprocess } from '@glimmer/syntax';
-import MappingTree, { MappingSource, TemplateEmbedding } from './mapping-tree.js';
+import GlimmerASTMappingTree, {
+  MappingSource,
+  TemplateEmbedding,
+} from './glimmer-ast-mapping-tree.js';
 import { Directive, DirectiveKind, Range } from './transformed-module.js';
 import { assert } from '../util.js';
 
@@ -101,7 +104,7 @@ export type RewriteResult = {
   result?: {
     code: string;
     directives: Array<LocalDirective>;
-    mapping: MappingTree;
+    mapping: GlimmerASTMappingTree;
   };
 };
 
@@ -163,7 +166,7 @@ export function mapTemplateContents(
   });
 
   let segmentsStack: string[][] = [[]];
-  let mappingsStack: MappingTree[][] = [[]];
+  let mappingsStack: GlimmerASTMappingTree[][] = [[]];
   let indent = '';
   let offset = 0;
   let needsIndent = false;
@@ -181,7 +184,7 @@ export function mapTemplateContents(
     callback: () => void,
   ): void => {
     let start = offset;
-    let mappings: MappingTree[] = [];
+    let mappings: GlimmerASTMappingTree[] = [];
     let segments: string[] = [];
 
     segmentsStack.unshift(segments);
@@ -202,7 +205,7 @@ export function mapTemplateContents(
       let end = offset;
       let tsRange = { start, end };
 
-      mappingsStack[0].push(new MappingTree(tsRange, hbsRange, mappings, source));
+      mappingsStack[0].push(new GlimmerASTMappingTree(tsRange, hbsRange, mappings, source));
       segmentsStack[0].push(...segments);
     }
   };
@@ -271,7 +274,7 @@ export function mapTemplateContents(
   assert(segmentsStack.length === 1);
 
   let code = segmentsStack[0].join('');
-  let mapping = new MappingTree(
+  let mapping = new GlimmerASTMappingTree(
     { start: 0, end: code.length },
     {
       start: 0,

--- a/packages/core/src/transform/template/rewrite-module.ts
+++ b/packages/core/src/transform/template/rewrite-module.ts
@@ -54,7 +54,7 @@ export function rewriteModule(
 
 /**
  * Locates any embedded templates in the given AST and returns a corresponding
- * `PartialReplacedSpan` for each, as well as any errors encountered. These
+ * `PartialCorrelatedSpan` for each, as well as any errors encountered. These
  * spans are then used in `rewriteModule` above to calculate the full set of
  * source-to-source location information as well as the final transformed source
  * string.
@@ -308,27 +308,27 @@ function calculateTransformedSource(
 /**
  * Given an array of `PartialCorrelatedSpan`s for a file, calculates
  * their `transformedLength` and `transformedStart` values, resulting
- * in full `ReplacedSpan`s.
+ * in full `CorrelatedSpan`s.
  */
 function completeCorrelatedSpans(
   partialSpans: Array<PartialCorrelatedSpan>,
 ): Array<CorrelatedSpan> {
-  let replacedSpans: Array<CorrelatedSpan> = [];
+  let correlatedSpans: Array<CorrelatedSpan> = [];
 
   for (let i = 0; i < partialSpans.length; i++) {
     let current = partialSpans[i];
     let transformedLength = current.transformedSource.length;
     let transformedStart = current.insertionPoint;
     if (i > 0) {
-      let previous = replacedSpans[i - 1];
+      let previous = correlatedSpans[i - 1];
       transformedStart =
         previous.transformedStart +
         previous.transformedSource.length +
         (current.insertionPoint - previous.insertionPoint - previous.originalLength);
     }
 
-    replacedSpans.push({ ...current, transformedStart, transformedLength });
+    correlatedSpans.push({ ...current, transformedStart, transformedLength });
   }
 
-  return replacedSpans;
+  return correlatedSpans;
 }

--- a/packages/core/src/transform/template/rewrite-module.ts
+++ b/packages/core/src/transform/template/rewrite-module.ts
@@ -106,6 +106,12 @@ function calculateCorrelatedSpans(
   ts.transform(ast, [
     (context) =>
       function visit<T extends ts.Node>(node: T): T {
+        // Here we look for ```hbs``` tagged template expressions, originally introduced
+        // in the now-removed GlimmerX environment. We can consider getting rid of this, but
+        // then again there are still some use cases in the wild (e.g. Glimmer Next / GXT)
+        // where have tagged templates closing over outer scope is desirable:
+        // https://github.com/lifeart/glimmer-next/tree/master/glint-environment-gxt
+        // https://discord.com/channels/480462759797063690/717767358743183412/1259061848632721480
         if (ts.isTaggedTemplateExpression(node)) {
           let meta = emitMetadata.get(node);
           let result = calculateTaggedTemplateSpans(ts, node, meta, script, environment);

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -3,7 +3,7 @@ import { unreachable, assert } from '../util.js';
 import { EmbeddingSyntax, mapTemplateContents, RewriteResult } from './map-template-contents.js';
 import ScopeStack from './scope-stack.js';
 import { GlintEmitMetadata, GlintSpecialForm } from '@glint/core/config-types';
-import { TextContent } from './mapping-tree.js';
+import { TextContent } from './glimmer-ast-mapping-tree.js';
 
 const SPLATTRIBUTES = '...attributes';
 

--- a/packages/core/src/transform/template/transformed-module.ts
+++ b/packages/core/src/transform/template/transformed-module.ts
@@ -237,7 +237,7 @@ export default class TransformedModule {
    * - to
    * - `[[ZEROLEN-A]]χ.emitContent(χ.resolveOrReturn([[expectsAtLeastOneArg]])());[[ZEROLEN-B]]`
    */
-  public toVolarMappings(): CodeMapping[] {
+  public toVolarMappings(filenameFilter?: string): CodeMapping[] {
     const sourceOffsets: number[] = [];
     const generatedOffsets: number[] = [];
     const lengths: number[] = [];
@@ -301,6 +301,10 @@ export default class TransformedModule {
     };
 
     this.correlatedSpans.forEach((span) => {
+      if (filenameFilter && span.originalFile.filename !== filenameFilter) {
+        return;
+      }
+
       if (span.glimmerAstMapping) {
         // this span is transformation from HBS to TS (either the replaced contents
         // within `<template>` tags in a .gts file, or the inserted and transformed

--- a/packages/core/src/transform/template/transformed-module.ts
+++ b/packages/core/src/transform/template/transformed-module.ts
@@ -5,6 +5,7 @@ import { CodeMapping } from '@volar/language-core';
 export type Range = { start: number; end: number };
 export type RangeWithMapping = Range & { mapping?: MappingTree };
 export type RangeWithMappingAndSource = RangeWithMapping & { source: SourceFile };
+
 export type CorrelatedSpan = {
   /** Where this span of content originated */
   originalFile: SourceFile;
@@ -20,7 +21,7 @@ export type CorrelatedSpan = {
   transformedStart: number;
   /** The length of this span in the transformed output */
   transformedLength: number;
-  /** A mapping of offsets within this span between its original and transformed versions */
+  /** (Glimmer/Handlebars spans only:) A mapping of offsets within this span between its original and transformed versions */
   mapping?: MappingTree;
 };
 
@@ -50,6 +51,8 @@ export type SourceFile = {
  * both the original and transformed source text of the module, as
  * well any errors encountered during transformation.
  *
+ * It is used heavily for bidirectional source mapping between the original TS/HBS code
+ * and the singular transformed TS output (aka the Intermediate Representation).
  * It can be queried with an offset or range in either the
  * original or transformed source to determine the corresponding
  * offset or range in the other.
@@ -299,11 +302,12 @@ export default class TransformedModule {
 
     this.correlatedSpans.forEach((span) => {
       if (span.mapping) {
-        // this span is transformation from embedded <template> to TS.
-
+        // this span is transformation from HBS to TS (either the replaced contents
+        // within `<template>` tags in a .gts file, or the inserted and transformed
+        // contents of a companion .hbs file in loose mode)
         recurse(span, span.mapping);
       } else {
-        // untransformed TS code (between <template> tags). Because there's no
+        // this span is untransformed TS content. Because there's no
         // transformation, we expect these to be the same length (in fact, they
         // should be the same string entirely)
 

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -39,7 +39,7 @@ export function createEmberLanguagePlugin<T extends URI | string>(
     },
 
     // When does this get called?
-    createVirtualCode(scriptId: URI | string, languageId, snapshot, codegenContext) {
+    createVirtualCode(scriptId: URI | string, languageId, snapshot /*, codegenContext */) {
       const scriptIdStr = String(scriptId);
 
       // See: https://github.com/JetBrains/intellij-plugins/blob/11a9149e20f4d4ba2c1600da9f2b81ff88bd7c97/Angular/src/angular-service/src/index.ts#L31
@@ -50,24 +50,19 @@ export function createEmberLanguagePlugin<T extends URI | string>(
       ) {
         // NOTE: scriptId might not be a path when we convert this plugin:
         // https://github.com/withastro/language-tools/blob/eb7215cc0ab3a8f614455528cd71b81ea994cf68/packages/ts-plugin/src/language.ts#L19
-        return new LooseModeBackingComponentClassVirtualCode(
-          glintConfig,
-          snapshot,
-          scriptId,
-          codegenContext,
-        );
+        // TODO: commented out for now because support for ember-loose is blocking behind converting to TS Plugin and this will just slow things down
+        // return new LooseModeBackingComponentClassVirtualCode(
+        //   glintConfig,
+        //   snapshot,
+        //   scriptId,
+        //   codegenContext,
+        // );
       }
 
       if (languageId === 'glimmer-ts' || languageId === 'glimmer-js') {
         return new VirtualGtsCode(glintConfig, snapshot, languageId);
       }
     },
-
-    // This is the default implementation; should be able to comment out
-    // updateVirtualCode(uri, virtualCode, snapshot) {
-    //   (virtualCode as VirtualGtsCode | LooseModeBackingComponentClassVirtualCode).update(snapshot);
-    //   return virtualCode;
-    // },
 
     isAssociatedFileOnly(_scriptId: string | URI, languageId: string): boolean {
       // `ember-loose` only

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -7,12 +7,12 @@ import { LooseModeBackingComponentClassVirtualCode } from './loose-mode-backing-
 export type TS = typeof ts;
 
 /**
- * Create a [Volar](https://volarjs.dev) language module to support .gts/.gjs files
- * (the `ember-template-imports` environment)
- * 
- * TODO: this should probably be renamed to something more general than Gts because it handles .ts+.handlebars loose mode as well
+ * Create a [Volar](https://volarjs.dev) language plugin to support
+ *
+ * - .gts/.gjs files (the `ember-template-imports` environment)
+ * - .ts + .hbs files (the `ember-loose` environment)
  */
-export function createGtsLanguagePlugin<T extends URI | string>(
+export function createEmberLanguagePlugin<T extends URI | string>(
   glintConfig: GlintConfig,
 ): LanguagePlugin<T> {
   return {

--- a/packages/core/src/volar/gts-language-plugin.ts
+++ b/packages/core/src/volar/gts-language-plugin.ts
@@ -43,8 +43,8 @@ export function createGtsLanguagePlugin<T extends URI | string>(
       if (
         languageId === 'typescript' &&
         !scriptId.endsWith('.d.ts') &&
-        scriptId.indexOf('/node_modules/') < 0 &&
-        scriptId.indexOf('components/') >= 0 // match anything in the components directory
+        scriptId.indexOf('/node_modules/') < 0
+        // scriptId.indexOf('components/') >= 0 // match anything in the components directory
       ) {
         // let virtualCode = ngTcbBlocks.get(scriptId);
         // if (!virtualCode) {

--- a/packages/core/src/volar/gts-language-plugin.ts
+++ b/packages/core/src/volar/gts-language-plugin.ts
@@ -11,7 +11,8 @@ import { URI } from 'vscode-uri';
 export type TS = typeof ts;
 
 /**
- * Create a [Volar](https://volarjs.dev) language module to support GTS.
+ * Create a [Volar](https://volarjs.dev) language module to support .gts/.gjs files
+ * (the `ember-template-imports` environment)
  */
 export function createGtsLanguagePlugin<T extends URI | string>(
   glintConfig: GlintConfig,
@@ -57,9 +58,9 @@ export function createGtsLanguagePlugin<T extends URI | string>(
 
     typescript: {
       extraFileExtensions: [
-        { extension: 'gts', isMixedContent: true, scriptKind: 7 },
-        { extension: 'gjs', isMixedContent: true, scriptKind: 7 },
-        { extension: 'hbs', isMixedContent: true, scriptKind: 7 },
+        { extension: 'gts', isMixedContent: true, scriptKind: 7 satisfies ts.ScriptKind.Deferred },
+        { extension: 'gjs', isMixedContent: true, scriptKind: 7 satisfies ts.ScriptKind.Deferred },
+        { extension: 'hbs', isMixedContent: true, scriptKind: 7 satisfies ts.ScriptKind.Deferred },
       ],
 
       // Allow extension-less imports, e.g. `import Foo from './Foo`.
@@ -82,21 +83,20 @@ export function createGtsLanguagePlugin<T extends URI | string>(
             return {
               code: transformedCode,
               extension: '.ts',
-              scriptKind: 3, // TS
+              scriptKind: 3 satisfies ts.ScriptKind.TS,
             };
           case 'glimmer-js':
             return {
-              // The first embeddedCode is always the TS Intermediate Representation code
               code: transformedCode,
               extension: '.js',
-              scriptKind: 1, // JS
+              scriptKind: 1 satisfies ts.ScriptKind.JS,
             };
           case 'handlebars':
             // TODO: companion file might be .js? Not sure if this is right
             return {
               code: transformedCode,
               extension: '.ts',
-              scriptKind: 3, // TS
+              scriptKind: 3 satisfies ts.ScriptKind.TS,
             };
           default:
             throw new Error(`getScript: Unexpected languageId: ${rootVirtualCode.languageId}`);

--- a/packages/core/src/volar/gts-language-plugin.ts
+++ b/packages/core/src/volar/gts-language-plugin.ts
@@ -36,6 +36,7 @@ export function createGtsLanguagePlugin<T extends URI | string>(
       }
     },
 
+    // When does this get called?
     createVirtualCode(uri, languageId, snapshot) {
       const scriptId = String(uri);
 
@@ -44,17 +45,10 @@ export function createGtsLanguagePlugin<T extends URI | string>(
         languageId === 'typescript' &&
         !scriptId.endsWith('.d.ts') &&
         scriptId.indexOf('/node_modules/') < 0
-        // scriptId.indexOf('components/') >= 0 // match anything in the components directory
       ) {
-        // let virtualCode = ngTcbBlocks.get(scriptId);
-        // if (!virtualCode) {
-        //   virtualCode = new AngularVirtualCode(scriptId, ctx, ts.sys.useCaseSensitiveFileNames);
-        //   ngTcbBlocks.set(scriptId, virtualCode);
-        // }
-        // return virtualCode.sourceFileUpdated(snapshot);
-
-        // Need a new VirtualCode LooseModeBackingComponentClassVirtualCode
-        return new LooseModeBackingComponentClassVirtualCode(glintConfig, snapshot);
+        // NOTE: scriptId might not be a path when we convert this plugin:
+        // https://github.com/withastro/language-tools/blob/eb7215cc0ab3a8f614455528cd71b81ea994cf68/packages/ts-plugin/src/language.ts#L19
+        return new LooseModeBackingComponentClassVirtualCode(glintConfig, snapshot, scriptId);
       }
 
       if (languageId === 'glimmer-ts' || languageId === 'glimmer-js') {
@@ -81,7 +75,7 @@ export function createGtsLanguagePlugin<T extends URI | string>(
       extraFileExtensions: [
         { extension: 'gts', isMixedContent: true, scriptKind: 7 satisfies ts.ScriptKind.Deferred },
         { extension: 'gjs', isMixedContent: true, scriptKind: 7 satisfies ts.ScriptKind.Deferred },
-        { extension: 'hbs', isMixedContent: true, scriptKind: 7 satisfies ts.ScriptKind.Deferred },
+        { extension: 'hbs', isMixedContent: true, scriptKind: 5 satisfies ts.ScriptKind.External },
       ],
 
       // Allow extension-less imports, e.g. `import Foo from './Foo`.

--- a/packages/core/src/volar/gts-language-plugin.ts
+++ b/packages/core/src/volar/gts-language-plugin.ts
@@ -39,14 +39,14 @@ export function createGtsLanguagePlugin<T extends URI | string>(
     },
 
     // When does this get called?
-    createVirtualCode(uri, languageId, snapshot, codegenContext) {
-      const scriptId = String(uri);
+    createVirtualCode(scriptId: URI | string, languageId, snapshot, codegenContext) {
+      const scriptIdStr = String(scriptId);
 
       // See: https://github.com/JetBrains/intellij-plugins/blob/11a9149e20f4d4ba2c1600da9f2b81ff88bd7c97/Angular/src/angular-service/src/index.ts#L31
       if (
         languageId === 'typescript' &&
-        !scriptId.endsWith('.d.ts') &&
-        scriptId.indexOf('/node_modules/') < 0
+        !scriptIdStr.endsWith('.d.ts') &&
+        scriptIdStr.indexOf('/node_modules/') < 0
       ) {
         // NOTE: scriptId might not be a path when we convert this plugin:
         // https://github.com/withastro/language-tools/blob/eb7215cc0ab3a8f614455528cd71b81ea994cf68/packages/ts-plugin/src/language.ts#L19

--- a/packages/core/src/volar/gts-virtual-code.ts
+++ b/packages/core/src/volar/gts-virtual-code.ts
@@ -99,14 +99,7 @@ export class VirtualGtsCode implements VirtualCode {
           id: 'ts',
           languageId: 'typescript',
           mappings: [
-            // The Volar mapping that maps all TS syntax of the MDX file to the virtual TS file.
-            // So I think in the case of a Single-File-Component (1 <template> tag surrounded by TS),
-            // You'll end up with 2 entries in sourceOffets, representing before the <template> and after the </template>.
             {
-              // sourceOffsets: [],
-              // generatedOffsets: [],
-              // lengths: [],
-
               // Hacked hardwired values for now.
               sourceOffsets: [0],
               generatedOffsets: [0],

--- a/packages/core/src/volar/gts-virtual-code.ts
+++ b/packages/core/src/volar/gts-virtual-code.ts
@@ -11,7 +11,8 @@ interface EmbeddedCodeWithDirectives extends VirtualCode {
 }
 
 /**
- * A Volar virtual code that contains some additional metadata for MDX files.
+ * A Volar VirtualCode representing .gts/.gjs files, which includes 0+ embedded
+ * Handlebars templates within <template> tags.
  */
 export class VirtualGtsCode implements VirtualCode {
   /**

--- a/packages/core/src/volar/handlebars-virtual-code.ts
+++ b/packages/core/src/volar/handlebars-virtual-code.ts
@@ -66,7 +66,11 @@ export class VirtualHandlebarsCode implements VirtualCode {
     // it doesn't have a companion script elsewhere.
     // We default to just `export {}` to reassure TypeScript that this is definitely a module
     // TODO: this `export {}` is falsely mapping (see in Volar Labs), not sure what impact / solution is.
-    let script = { filename: 'disregard.ts', contents: 'export {}' };
+
+    // Here we are assembling the args to pass into rewriteModule, which wants both the .ts script
+    // and the template file. For .gts template is undefined but here we need to pass in the contents.
+    // Let's see how rewriteModule attempts to transform this shit.
+    let script = { filename: 'disregard.ts', contents: 'export {}; let a = 123;' };
     let template = {
       filename: 'disregard.hbs',
       contents,

--- a/packages/core/src/volar/handlebars-virtual-code.ts
+++ b/packages/core/src/volar/handlebars-virtual-code.ts
@@ -70,7 +70,7 @@ export class VirtualHandlebarsCode implements VirtualCode {
     // Here we are assembling the args to pass into rewriteModule, which wants both the .ts script
     // and the template file. For .gts template is undefined but here we need to pass in the contents.
     // Let's see how rewriteModule attempts to transform this shit.
-    let script = { filename: 'disregard.ts', contents: 'export {}; let a = 123;' };
+    let script = { filename: 'disregard.ts', contents: 'export default class MyComponent {}' };
     let template = {
       filename: 'disregard.hbs',
       contents,

--- a/packages/core/src/volar/language-server.ts
+++ b/packages/core/src/volar/language-server.ts
@@ -9,7 +9,7 @@ import {
   createTypeScriptProject,
 } from '@volar/language-server/node.js';
 import { create as createTypeScriptServicePlugins } from 'volar-service-typescript';
-import { createGtsLanguagePlugin } from './gts-language-plugin.js';
+import { createEmberLanguagePlugin } from './ember-language-plugin.js';
 import { assert } from '../transform/util.js';
 import { ConfigLoader } from '../config/loader.js';
 import ts from 'typescript';
@@ -52,7 +52,7 @@ connection.onInitialize((parameters) => {
       // assert(glintConfig, 'Glint config is missing');
 
       if (glintConfig) {
-        languagePlugins.unshift(createGtsLanguagePlugin(glintConfig));
+        languagePlugins.unshift(createEmberLanguagePlugin(glintConfig));
       }
     }
 

--- a/packages/core/src/volar/language-server.ts
+++ b/packages/core/src/volar/language-server.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { VirtualGtsCode } from './gts-virtual-code.js';
 import { augmentDiagnostic } from '../transform/diagnostics/augmentation.js';
-import MappingTree from '../transform/template/mapping-tree.js';
+import GlimmerASTMappingTree from '../transform/template/glimmer-ast-mapping-tree.js';
 import { Directive, TransformedModule } from '../transform/index.js';
 import { Range } from '../transform/template/transformed-module.js';
 import { offsetToPosition } from '../language-server/util/position.js';
@@ -141,7 +141,7 @@ function filterAndAugmentDiagnostics(
     return cachedVirtualCode;
   };
 
-  const mappingForDiagnostic = (diagnostic: vscode.Diagnostic): MappingTree | null => {
+  const mappingForDiagnostic = (diagnostic: vscode.Diagnostic): GlimmerASTMappingTree | null => {
     const transformedModule = fetchVirtualCode()?.transformedModule;
 
     if (!transformedModule) {

--- a/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
+++ b/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
@@ -42,12 +42,6 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
     this.snapshot = snapshot;
     const length = snapshot.getLength();
 
-    // Define a single mapping for the root virtual code (the .gts file).
-    // The original MDX docs describe the root virtual code mappings are as:
-    //
-    // > The code mappings of the MDX file. There is always only one mapping.
-    //
-    // I guess it's some "identity" mapping that describes the whole file? I don't know.
     this.mappings[0] = {
       sourceOffsets: [0],
       generatedOffsets: [0],
@@ -77,56 +71,56 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
 
     this.transformedModule = transformedModule;
 
-    if (transformedModule) {
-      const mappings = transformedModule.toVolarMappings();
-      this.embeddedCodes = [
-        {
-          embeddedCodes: [],
-          id: 'ts',
-          languageId: 'typescript',
-          mappings,
-          snapshot: new ScriptSnapshot(transformedModule.transformedContents),
-          directives: transformedModule.directives,
-        },
-      ];
-    } else {
-      // Null transformed module means there's no embedded HBS templates,
-      // so just return a full "no-op" mapping from source to transformed.
-      this.embeddedCodes = [
-        {
-          embeddedCodes: [],
-          id: 'ts',
-          languageId: 'typescript',
-          mappings: [
-            // The Volar mapping that maps all TS syntax of the MDX file to the virtual TS file.
-            // So I think in the case of a Single-File-Component (1 <template> tag surrounded by TS),
-            // You'll end up with 2 entries in sourceOffets, representing before the <template> and after the </template>.
-            {
-              // sourceOffsets: [],
-              // generatedOffsets: [],
-              // lengths: [],
+    // if (transformedModule) {
+    //   const mappings = transformedModule.toVolarMappings();
+    //   this.embeddedCodes = [
+    //     {
+    //       embeddedCodes: [],
+    //       id: 'ts',
+    //       languageId: 'typescript',
+    //       mappings,
+    //       snapshot: new ScriptSnapshot(transformedModule.transformedContents),
+    //       directives: transformedModule.directives,
+    //     },
+    //   ];
+    // } else {
+    //   // Null transformed module means there's no embedded HBS templates,
+    //   // so just return a full "no-op" mapping from source to transformed.
+    //   this.embeddedCodes = [
+    //     {
+    //       embeddedCodes: [],
+    //       id: 'ts',
+    //       languageId: 'typescript',
+    //       mappings: [
+    //         // The Volar mapping that maps all TS syntax of the MDX file to the virtual TS file.
+    //         // So I think in the case of a Single-File-Component (1 <template> tag surrounded by TS),
+    //         // You'll end up with 2 entries in sourceOffets, representing before the <template> and after the </template>.
+    //         {
+    //           // sourceOffsets: [],
+    //           // generatedOffsets: [],
+    //           // lengths: [],
 
-              // Hacked hardwired values for now.
-              sourceOffsets: [0],
-              generatedOffsets: [0],
-              lengths: [length],
+    //           // Hacked hardwired values for now.
+    //           sourceOffsets: [0],
+    //           generatedOffsets: [0],
+    //           lengths: [length],
 
-              // This controls which language service features are enabled within this root virtual code.
-              // Since this is just .ts, we want all of them enabled.
-              data: {
-                completion: true,
-                format: false,
-                navigation: true,
-                semantic: true,
-                structure: true,
-                verification: true,
-              },
-            },
-          ],
-          snapshot: new ScriptSnapshot(contents),
-          directives: [],
-        },
-      ];
-    }
+    //           // This controls which language service features are enabled within this root virtual code.
+    //           // Since this is just .ts, we want all of them enabled.
+    //           data: {
+    //             completion: true,
+    //             format: false,
+    //             navigation: true,
+    //             semantic: true,
+    //             structure: true,
+    //             verification: true,
+    //           },
+    //         },
+    //       ],
+    //       snapshot: new ScriptSnapshot(contents),
+    //       directives: [],
+    //     },
+    //   ];
+    // }
   }
 }

--- a/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
+++ b/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
@@ -91,7 +91,7 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
 
     const hbsLength = hbsSourceScript.snapshot.getLength();
     const hbsContent = hbsSourceScript.snapshot.getText(0, hbsLength);
-    const sourceTsFileName = String(this.fileId)
+    const sourceTsFileName = String(this.fileId);
 
     const transformedModule = rewriteModule(
       this.glintConfig.ts,

--- a/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
+++ b/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
@@ -83,7 +83,6 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
 
     if (!hbsSourceScript) {
       // TODO: this probably shouldn't be an error; just trying to fail fast for tests for now
-      // TODO: why does this sometimes fail to find the source script? Race condition, where .ts loads before .hbs?
       let msg = `Could not find a source script for ${templatePathCandidate.path}`;
       // throw new Error(msg);
       return;
@@ -138,14 +137,7 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
           id: 'ts',
           languageId: 'typescript',
           mappings: [
-            // The Volar mapping that maps all TS syntax of the MDX file to the virtual TS file.
-            // So I think in the case of a Single-File-Component (1 <template> tag surrounded by TS),
-            // You'll end up with 2 entries in sourceOffets, representing before the <template> and after the </template>.
             {
-              // sourceOffsets: [],
-              // generatedOffsets: [],
-              // lengths: [],
-
               // Hacked hardwired values for now.
               sourceOffsets: [0],
               generatedOffsets: [0],

--- a/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
+++ b/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
@@ -4,6 +4,7 @@ import { ScriptSnapshot } from './script-snapshot.js';
 import type ts from 'typescript';
 import { Directive, rewriteModule } from '../transform/index.js';
 import { GlintConfig } from '../index.js';
+import { CodegenContext, SourceScript } from '@volar/language-core/lib/types.js';
 export type TS = typeof ts;
 
 interface EmbeddedCodeWithDirectives extends VirtualCode {
@@ -16,6 +17,9 @@ interface EmbeddedCodeWithDirectives extends VirtualCode {
  * components are only supported when using `ember-loose` environment.
  */
 export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
+
+  embeddedCodes: EmbeddedCodeWithDirectives[] = [];
+
   /**
    * The id is a unique (within the VirtualCode and its embedded files) id for Volar to identify it. It could be any string.
    */
@@ -33,6 +37,7 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
     private glintConfig: GlintConfig,
     public snapshot: IScriptSnapshot,
     public fileUri: string,
+    public codegenContext: CodegenContext,
   ) {
     this.update(snapshot);
   }
@@ -61,72 +66,95 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
 
     const contents = snapshot.getText(0, length);
 
-    const templatePathCandidates = this.glintConfig.environment.getPossibleTemplatePaths(this.fileUri);
+    const templatePathCandidate = this.glintConfig.environment.getPossibleTemplatePaths(
+      this.fileUri,
+    )[0];
 
-    // templatePathCandidates.forEach((templatePath) => {
-    // });
+    if (!templatePathCandidate) {
+      // TODO: this probably shouldn't be an error; just trying to fail fast for tests for now
+      throw new Error(`Could not find a template file candidate for ${this.fileUri}`);
+    }
 
-    let script = { filename: 'disregard.gts', contents };
-    let template = undefined;
+    const hbsSourceScript = this.codegenContext.getAssociatedScript(
+      templatePathCandidate.path,
+    )?.snapshot;
+
+    if (!hbsSourceScript) {
+      // TODO: this probably shouldn't be an error; just trying to fail fast for tests for now
+      // TODO: why does this sometimes fail to find the source script? Race condition, where .ts loads before .hbs?
+      throw new Error(`Could not find a source script for ${templatePathCandidate.path}`);
+    }
+
+    const hbsLength = hbsSourceScript.getLength();
+    const hbsContent = hbsSourceScript.getText(0, hbsLength);
 
     const transformedModule = rewriteModule(
       this.glintConfig.ts,
-      { script, template },
+      {
+        script: {
+          filename: 'disregard.ts', // not sure why this is disregard but template file is not?
+          contents,
+        },
+        template: {
+          filename: templatePathCandidate.path,
+          contents: hbsContent,
+        },
+      },
       this.glintConfig.environment,
     );
 
     this.transformedModule = transformedModule;
 
-    // if (transformedModule) {
-    //   const mappings = transformedModule.toVolarMappings();
-    //   this.embeddedCodes = [
-    //     {
-    //       embeddedCodes: [],
-    //       id: 'ts',
-    //       languageId: 'typescript',
-    //       mappings,
-    //       snapshot: new ScriptSnapshot(transformedModule.transformedContents),
-    //       directives: transformedModule.directives,
-    //     },
-    //   ];
-    // } else {
-    //   // Null transformed module means there's no embedded HBS templates,
-    //   // so just return a full "no-op" mapping from source to transformed.
-    //   this.embeddedCodes = [
-    //     {
-    //       embeddedCodes: [],
-    //       id: 'ts',
-    //       languageId: 'typescript',
-    //       mappings: [
-    //         // The Volar mapping that maps all TS syntax of the MDX file to the virtual TS file.
-    //         // So I think in the case of a Single-File-Component (1 <template> tag surrounded by TS),
-    //         // You'll end up with 2 entries in sourceOffets, representing before the <template> and after the </template>.
-    //         {
-    //           // sourceOffsets: [],
-    //           // generatedOffsets: [],
-    //           // lengths: [],
+    if (transformedModule) {
+      const mappings = transformedModule.toVolarMappings();
+      this.embeddedCodes = [
+        {
+          embeddedCodes: [],
+          id: 'ts',
+          languageId: 'typescript',
+          mappings,
+          snapshot: new ScriptSnapshot(transformedModule.transformedContents),
+          directives: transformedModule.directives,
+        },
+      ];
+    } else {
+      // Null transformed module means there's no embedded HBS templates,
+      // so just return a full "no-op" mapping from source to transformed.
+      this.embeddedCodes = [
+        {
+          embeddedCodes: [],
+          id: 'ts',
+          languageId: 'typescript',
+          mappings: [
+            // The Volar mapping that maps all TS syntax of the MDX file to the virtual TS file.
+            // So I think in the case of a Single-File-Component (1 <template> tag surrounded by TS),
+            // You'll end up with 2 entries in sourceOffets, representing before the <template> and after the </template>.
+            {
+              // sourceOffsets: [],
+              // generatedOffsets: [],
+              // lengths: [],
 
-    //           // Hacked hardwired values for now.
-    //           sourceOffsets: [0],
-    //           generatedOffsets: [0],
-    //           lengths: [length],
+              // Hacked hardwired values for now.
+              sourceOffsets: [0],
+              generatedOffsets: [0],
+              lengths: [length],
 
-    //           // This controls which language service features are enabled within this root virtual code.
-    //           // Since this is just .ts, we want all of them enabled.
-    //           data: {
-    //             completion: true,
-    //             format: false,
-    //             navigation: true,
-    //             semantic: true,
-    //             structure: true,
-    //             verification: true,
-    //           },
-    //         },
-    //       ],
-    //       snapshot: new ScriptSnapshot(contents),
-    //       directives: [],
-    //     },
-    //   ];
-    // }
+              // This controls which language service features are enabled within this root virtual code.
+              // Since this is just .ts, we want all of them enabled.
+              data: {
+                completion: true,
+                format: false,
+                navigation: true,
+                semantic: true,
+                structure: true,
+                verification: true,
+              },
+            },
+          ],
+          snapshot: new ScriptSnapshot(contents),
+          directives: [],
+        },
+      ];
+    }
   }
 }

--- a/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
+++ b/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
@@ -91,12 +91,13 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
 
     const hbsLength = hbsSourceScript.snapshot.getLength();
     const hbsContent = hbsSourceScript.snapshot.getText(0, hbsLength);
+    const sourceTsFileName = String(this.fileId)
 
     const transformedModule = rewriteModule(
       this.glintConfig.ts,
       {
         script: {
-          filename: 'disregard.ts', // not sure why this is disregard but template file is not?
+          filename: sourceTsFileName,
           contents,
         },
         template: {
@@ -110,7 +111,8 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
     this.transformedModule = transformedModule;
 
     if (transformedModule) {
-      const mappings = transformedModule.toVolarMappings();
+      const volarTsMappings = transformedModule.toVolarMappings(sourceTsFileName);
+      const volarHbsMappings = transformedModule.toVolarMappings(templatePathCandidate.path);
       this.embeddedCodes = [
         {
           embeddedCodes: [],
@@ -118,12 +120,12 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
           languageId: 'typescript',
 
           // Mappings from the backing component class file to the transformed module.
-          mappings: [],
+          mappings: volarTsMappings,
           snapshot: new ScriptSnapshot(transformedModule.transformedContents),
           directives: transformedModule.directives,
 
           // Mappings from the .hbs template file to the transformed module.
-          associatedScriptMappings: new Map([[hbsSourceScript.id, mappings]]),
+          associatedScriptMappings: new Map([[hbsSourceScript.id, volarHbsMappings]]),
         },
       ];
     } else {

--- a/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
+++ b/packages/core/src/volar/loose-mode-backing-component-class-virtual-code.ts
@@ -26,12 +26,13 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
   transformedModule: ReturnType<typeof rewriteModule> | null = null;
 
   get languageId(): string {
-    return "typescript"
+    return 'typescript';
   }
 
   constructor(
     private glintConfig: GlintConfig,
-    public snapshot: IScriptSnapshot
+    public snapshot: IScriptSnapshot,
+    public fileUri: string,
   ) {
     this.update(snapshot);
   }
@@ -59,6 +60,11 @@ export class LooseModeBackingComponentClassVirtualCode implements VirtualCode {
     };
 
     const contents = snapshot.getText(0, length);
+
+    const templatePathCandidates = this.glintConfig.environment.getPossibleTemplatePaths(this.fileUri);
+
+    // templatePathCandidates.forEach((templatePath) => {
+    // });
 
     let script = { filename: 'disregard.gts', contents };
     let template = undefined;


### PR DESCRIPTION
Starts in on support for ember-loose mode, the classic Ember component authoring format when you provide (optional) backing .ts/.js class with a separate .hbs template file.

## Learnings / Takeways:

TL;DR, we can't follow support loose mode until we finish migrating to TS Plugin. Next steps are to find out how much of a lift that'll be.

- Volar only recently added support for two-file templating system (initially added for Angular-Webstorm; Angular has .ts files with .html template files)
- Volar's support only applies to TS Plugins, and does not currently offer support for two files in the (quickly-becoming-legacy) Language Server APIs
  - This means Glint will need to convert to using TS Plugin before we can support this
  - Alternatively Johnson from Volar might possibly be convinced to add support to the LS, but I think if we can get TS Plugin working, better to align with the future.
- Basic Volar scheme for two-file component systems:
  - In order to typecheck an .hbs file, you need to regard the backing `.ts` file as Volar's "entrypoint", in that you need to provide a VirtualCode for .ts files and teach those files how to find the "associated" .hbs template file. If you correctly/successfully do that, then when you attempt to typecheck the .hbs file, Volar will already know that it has been associated with the .ts file that it'll use as part of the transformation.
    - Note this doesn't cover the case of standalone .hbs files, which Ember classically supports
      - It is TBD whether we'll try to support this vs some other (hopefully scriptable) migration method, but if we do:
      - We would probably have to implement another HandlebarsVirtualCode and rely on Volar's internal algorithm to use the TS+associated HBS transformation/type-checking algorithm to "win" over the fallback HandlebarsVirtualCode used for standalone templates.

