### PR TITLE
Widen peerDependencies to allow @glimmer/component v2

### DIFF
--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -27,7 +27,7 @@
     "registry/**/*.{js,d.ts}"
   ],
   "peerDependencies": {
-    "@glimmer/component": "^1.1.2",
+    "@glimmer/component": ">=1.1.2",
     "@glint/template": "^1.5.0",
     "@types/ember__array": "^4.0.2",
     "@types/ember__component": "^4.0.10",


### PR DESCRIPTION
Apparently, @glimmer/component v2 is not allowed by current peerDependencies