### PR TITLE
Reinstate acceptance tests (gts)

### DIFF
--- a/packages/core/__tests__/language-server/diagnostics.test.ts
+++ b/packages/core/__tests__/language-server/diagnostics.test.ts
@@ -123,7 +123,7 @@ describe('Language Server: Diagnostics', () => {
       expect(diagnostics).toMatchObject([
         {
           message: "Property 'foo' does not exist on type '{}'.",
-          source: 'ts',
+          source: 'glint',
           code: 2339,
         },
       ]);
@@ -165,7 +165,7 @@ describe('Language Server: Diagnostics', () => {
       expect(diagnostics).toMatchObject([
         {
           message: "Property 'foo' does not exist on type '{}'.",
-          source: 'ts',
+          source: 'glint',
           code: 2339,
         },
       ]);

--- a/packages/vscode/__fixtures__/custom-app/src/index.custom
+++ b/packages/vscode/__fixtures__/custom-app/src/index.custom
@@ -1,5 +1,0 @@
-import Greeting from './Greeting';
-
-<template>
-  <Greeting @target="World" />
-</template>

--- a/packages/vscode/__tests__/smoketest-ember.test.ts
+++ b/packages/vscode/__tests__/smoketest-ember.test.ts
@@ -52,7 +52,7 @@ describe.skip('Smoke test: Ember', () => {
       expect(languages.getDiagnostics(templateURI)).toMatchObject([
         {
           message: "Property 'message' does not exist on type 'ColocatedLayoutComponent'.",
-          source: 'ts',
+          source: 'glint',
           code: 2339,
           range: new Range(0, 7, 0, 14),
         },
@@ -77,7 +77,7 @@ describe.skip('Smoke test: Ember', () => {
       expect(languages.getDiagnostics(scriptURI)).toMatchObject([
         {
           message: "Property 'foo' does not exist on type 'MyTestContext'.",
-          source: 'ts',
+          source: 'glint',
           code: 2339,
           range: new Range(17, 13, 17, 16),
         },

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -14,7 +14,7 @@ import { describe, afterEach, test } from 'mocha';
 import { expect } from 'expect';
 import { waitUntil } from './helpers/async';
 
-describe.skip('Smoke test: ETI Environment', () => {
+describe('Smoke test: ETI Environment', () => {
   const rootDir = path.resolve(__dirname, '../../__fixtures__/template-imports-app');
 
   afterEach(async () => {
@@ -44,7 +44,7 @@ describe.skip('Smoke test: ETI Environment', () => {
       expect(languages.getDiagnostics(scriptURI)).toMatchObject([
         {
           message: "Type 'number' is not assignable to type 'string'.",
-          source: 'ts',
+          source: 'glint',
           code: 2322,
           range: new Range(6, 13, 6, 19),
         },
@@ -75,12 +75,14 @@ describe.skip('Smoke test: ETI Environment', () => {
           new Range(new Position(10, 9), new Position(10, 9)),
         );
 
-        expect(fixes.length).toBe(3);
+        expect(fixes.length).toBe(4);
 
-        expect(fixes[1].title).toBe(`Declare property 'undocumentedProperty'`);
+        const fix = fixes.find((fix) => fix.title === 'Declare property \'undocumentedProperty\'');
+
+        expect(fix).toBeDefined();
 
         // apply the missing arg fix
-        await workspace.applyEdit(fixes![1].edit!);
+        await workspace.applyEdit(fix!.edit!);
 
         await waitUntil(
           () =>

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -92,10 +92,6 @@ describe('Smoke test: ETI Environment', () => {
       });
     });
 
-    test('ensure ci is running', async () => {
-      throw new Error('wat');
-    });
-
     describe('codeactions locals', () => {
       test('add local props to a class', async () => {
         let scriptURI = Uri.file(`${rootDir}/src/Greeting.gts`);

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -77,7 +77,7 @@ describe('Smoke test: ETI Environment', () => {
 
         expect(fixes.length).toBe(4);
 
-        const fix = fixes.find((fix) => fix.title === 'Declare property \'undocumentedProperty\'');
+        const fix = fixes.find((fix) => fix.title === "Declare property 'undocumentedProperty'");
 
         expect(fix).toBeDefined();
 
@@ -121,7 +121,7 @@ describe('Smoke test: ETI Environment', () => {
 
         expect(fixes.length).toBe(4);
 
-        const fix = fixes.find((fix) => fix.title === 'Declare property \'localProp\'');
+        const fix = fixes.find((fix) => fix.title === "Declare property 'localProp'");
 
         expect(fix).toBeDefined();
 

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -92,6 +92,10 @@ describe('Smoke test: ETI Environment', () => {
       });
     });
 
+    test('ensure ci is running', async () => {
+      throw new Error('wat');
+    });
+
     describe('codeactions locals', () => {
       test('add local props to a class', async () => {
         let scriptURI = Uri.file(`${rootDir}/src/Greeting.gts`);

--- a/packages/vscode/__tests__/smoketest-template-imports.test.ts
+++ b/packages/vscode/__tests__/smoketest-template-imports.test.ts
@@ -115,12 +115,14 @@ describe('Smoke test: ETI Environment', () => {
           new Range(new Position(10, 12), new Position(10, 12)),
         );
 
-        expect(fixes.length).toBe(3);
+        expect(fixes.length).toBe(4);
 
-        expect(fixes[1].title).toBe(`Declare property 'localProp'`);
+        const fix = fixes.find((fix) => fix.title === 'Declare property \'localProp\'');
+
+        expect(fix).toBeDefined();
 
         // select ignore
-        await workspace.applyEdit(fixes![0].edit!);
+        await workspace.applyEdit(fix!.edit!);
 
         await waitUntil(
           () =>


### PR DESCRIPTION
Soon we'll be writing acceptance tests to test out the ts-plugin mode (because Volar doesn't yet have testing facilities for ts-plugin and figuring out how to get [typescript-server-harness](https://github.com/microsoft/typescript-server-harness) working is too much of a lift). This PR reinstates previously pended acceptance tests for classic LS mode with the intent that a follow up PR will introduce acceptance tests that exercise the TS Plugin.