### PR TITLE
Re-write extension to use reactive-vscode, align with Vue extension

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,8 @@ dist/
 !/packages/environment*/-private/dsl/**/*.d.ts
 !/packages/environment*/-private/intrinsics/**/*.d.ts
 
+!/packages/vscode/generated-meta.ts
+
 # Markdown files: the formatting Prettier uses by default *does. not. match.*
 # the formatting applied by Gitbook. Having both present is a recipe for ongoing
 # CI problems.

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,7 +20,7 @@ dist/
 !/packages/environment*/-private/dsl/**/*.d.ts
 !/packages/environment*/-private/intrinsics/**/*.d.ts
 
-!/packages/vscode/src/generated-meta.ts
+/packages/vscode/src/generated-meta.ts
 
 # Markdown files: the formatting Prettier uses by default *does. not. match.*
 # the formatting applied by Gitbook. Having both present is a recipe for ongoing

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,7 +20,7 @@ dist/
 !/packages/environment*/-private/dsl/**/*.d.ts
 !/packages/environment*/-private/intrinsics/**/*.d.ts
 
-!/packages/vscode/generated-meta.ts
+!/packages/vscode/src/generated-meta.ts
 
 # Markdown files: the formatting Prettier uses by default *does. not. match.*
 # the formatting applied by Gitbook. Having both present is a recipe for ongoing

--- a/packages/vscode/.gitignore
+++ b/packages/vscode/.gitignore
@@ -4,3 +4,5 @@ node_modules
 lib/
 dist/
 tsconfig.tsbuildinfo
+
+generated-meta.ts

--- a/packages/vscode/__tests__/support/launch-from-cli.mts
+++ b/packages/vscode/__tests__/support/launch-from-cli.mts
@@ -1,11 +1,9 @@
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { fileURLToPath } from 'node:url';
 import { runTests } from '@vscode/test-electron';
 import * as fs from 'node:fs';
 
-const dirname = path.dirname(fileURLToPath(import.meta.url));
-const packageRoot = path.resolve(dirname, '../../..');
+const packageRoot = path.resolve(process.cwd());
 const emptyExtensionsDir = path.join(os.tmpdir(), `extensions-${Math.random()}`);
 const emptyUserDataDir = path.join(os.tmpdir(), `user-data-${Math.random()}`);
 
@@ -28,13 +26,13 @@ let disableExtensionArgs: string[] = [];
 let testRunner: string;
 switch (testType) {
   case 'language-server':
-    testRunner = 'vscode-runner-language-server.js';
+    testRunner = 'lib/__tests__/support/vscode-runner-language-server.js';
 
     // Disable vanilla TS for full "takeover" mode.
     disableExtensionArgs = ['--disable-extension', 'vscode.typescript-language-features'];
     break;
   case 'ts-plugin':
-    testRunner = 'vscode-runner-ts-plugin.js';
+    testRunner = 'lib/__tests__/support/vscode-runner-ts-plugin.js';
 
     // Note: here, we WANT vanilla TS to be enabled since we're testing the TS Plugin.
     break;
@@ -44,9 +42,9 @@ switch (testType) {
 }
 
 try {
-  await runTests({
+  runTests({
     extensionDevelopmentPath: packageRoot,
-    extensionTestsPath: path.resolve(dirname, testRunner),
+    extensionTestsPath: path.resolve(process.cwd(), testRunner),
     launchArgs: [
       // Don't show the "hey do you trust this folder?" prompt
       '--disable-workspace-trust',

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -37,7 +37,7 @@
     "extension:package": "vsce package --no-dependencies",
     "extension:publish": "vsce publish --no-dependencies",
     "postinstall": "vscode-ext-gen --scope glint",
-    "prebuild": "yarn postinstall && yarn build"
+    "prebuild": "vscode-ext-gen --scope glint"
   },
   "engines": {
     "vscode": "^1.68.1"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -35,7 +35,9 @@
     "bundle": "node ./scripts/build.mjs",
     "bundle:watch": "node ./scripts/build.mjs -- --watch",
     "extension:package": "vsce package --no-dependencies",
-    "extension:publish": "vsce publish --no-dependencies"
+    "extension:publish": "vsce publish --no-dependencies",
+    "postinstall": "vscode-ext-gen --scope glint",
+    "prebuild": "yarn postinstall && yarn build"
   },
   "engines": {
     "vscode": "^1.68.1"
@@ -188,6 +190,7 @@
     ],
     "configuration": [
       {
+        "type": "object",
         "title": "Glint",
         "properties": {
           "glint.libraryPath": {
@@ -205,18 +208,44 @@
               "verbose"
             ]
           },
-          "glint.server.typescriptMode": {
-            "type": "string",
-            "default": "languageServer",
+          "glint.server.hybridMode": {
+            "type": [
+              "boolean",
+              "string"
+            ],
+            "default": "auto",
             "enum": [
-              "languageServer",
-              "typescriptPlugin"
+              "auto",
+              "typeScriptPluginOnly",
+              true,
+              false
             ],
             "enumDescriptions": [
-              "(Old) use Glint Language Server for typechecking",
-              "(New) Use TypeScript server plugin for typechecking"
+              "Automatically detect and enable TypeScript Plugin/Hybrid Mode in a safe environment.",
+              "Only enable Glint TypeScript Plugin but disable the Glint language server.",
+              "Enable TypeScript Plugin/Hybrid Mode.",
+              "Disable TypeScript Plugin/Hybrid Mode."
             ],
-            "description": "Glint 2 shifts typechecking to a TypeScript server plugin. This setting allows you to opt into the new behavior."
+            "description": "Hybrid mode means that Glint will use a TypeScript server plugin for typechecking and use the Glint language server for other features. This is the recommended mode."
+          },
+          "glint.server.compatibleExtensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Set compatible extensions to skip automatic detection of Hybrid Mode."
+          },
+          "glint.server.includeLanguages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "glimmer-js",
+              "glimmer-ts",
+              "handlebars"
+            ]
           }
         }
       }
@@ -241,7 +270,9 @@
     "esbuild": "^0.15.16",
     "expect": "^29.5.0",
     "glob": "^10.2.4",
-    "mocha": "^10.2.0"
+    "mocha": "^10.2.0",
+    "reactive-vscode": "0.2.7-beta.1",
+    "vscode-ext-gen": "^0.5.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/vscode/src/compatibility.ts
+++ b/packages/vscode/src/compatibility.ts
@@ -1,0 +1,57 @@
+import { computed, useAllExtensions } from 'reactive-vscode';
+import * as semver from 'semver';
+import * as vscode from 'vscode';
+import { config } from './config';
+
+// TODO: does Glint need this concept of "compatible" extensions?
+
+const defaultCompatibleExtensions = new Set([
+	'astro-build.astro-vscode',
+	'bierner.lit-html',
+	'Divlo.vscode-styled-jsx-languageserver',
+	'GitHub.copilot-chat',
+	'ije.esm-vscode',
+	'jenkey2011.string-highlight',
+	'johnsoncodehk.vscode-tsslint',
+	'kimuson.ts-type-expand',
+	'miaonster.vscode-tsx-arrow-definition',
+	'ms-dynamics-smb.al',
+	'mxsdev.typescript-explorer',
+	'nrwl.angular-console',
+	'p42ai.refactor',
+	'runem.lit-plugin',
+	'ShenQingchuan.vue-vine-extension',
+	'styled-components.vscode-styled-components',
+	'unifiedjs.vscode-mdx',
+	'VisualStudioExptTeam.vscodeintellicode',
+	'Vue.volar',
+]);
+
+const extensions = useAllExtensions();
+
+export const incompatibleExtensions = computed(() => {
+	return extensions.value
+		.filter(ext => isExtensionCompatibleWithHybridMode(ext) === false)
+		.map(ext => ext.id);
+});
+
+export const unknownExtensions = computed(() => {
+	return extensions.value
+		.filter(ext => isExtensionCompatibleWithHybridMode(ext) === undefined && !!ext.packageJSON?.contributes?.typescriptServerPlugins)
+		.map(ext => ext.id);
+});
+
+function isExtensionCompatibleWithHybridMode(extension: vscode.Extension<any>) {
+	if (
+		defaultCompatibleExtensions.has(extension.id) ||
+		config.server.compatibleExtensions.includes(extension.id)
+	) {
+		return true;
+	}
+	if (extension.id === 'denoland.vscode-deno') {
+		return !vscode.workspace.getConfiguration('deno').get<boolean>('enable');
+	}
+	if (extension.id === 'svelte.svelte-vscode') {
+		return semver.gte(extension.packageJSON.version, '108.4.0');
+	}
+}

--- a/packages/vscode/src/compatibility.ts
+++ b/packages/vscode/src/compatibility.ts
@@ -6,52 +6,58 @@ import { config } from './config';
 // TODO: does Glint need this concept of "compatible" extensions?
 
 const defaultCompatibleExtensions = new Set([
-	'astro-build.astro-vscode',
-	'bierner.lit-html',
-	'Divlo.vscode-styled-jsx-languageserver',
-	'GitHub.copilot-chat',
-	'ije.esm-vscode',
-	'jenkey2011.string-highlight',
-	'johnsoncodehk.vscode-tsslint',
-	'kimuson.ts-type-expand',
-	'miaonster.vscode-tsx-arrow-definition',
-	'ms-dynamics-smb.al',
-	'mxsdev.typescript-explorer',
-	'nrwl.angular-console',
-	'p42ai.refactor',
-	'runem.lit-plugin',
-	'ShenQingchuan.vue-vine-extension',
-	'styled-components.vscode-styled-components',
-	'unifiedjs.vscode-mdx',
-	'VisualStudioExptTeam.vscodeintellicode',
-	'Vue.volar',
+  'astro-build.astro-vscode',
+  'bierner.lit-html',
+  'Divlo.vscode-styled-jsx-languageserver',
+  'GitHub.copilot-chat',
+  'ije.esm-vscode',
+  'jenkey2011.string-highlight',
+  'johnsoncodehk.vscode-tsslint',
+  'kimuson.ts-type-expand',
+  'miaonster.vscode-tsx-arrow-definition',
+  'ms-dynamics-smb.al',
+  'mxsdev.typescript-explorer',
+  'nrwl.angular-console',
+  'p42ai.refactor',
+  'runem.lit-plugin',
+  'ShenQingchuan.vue-vine-extension',
+  'styled-components.vscode-styled-components',
+  'unifiedjs.vscode-mdx',
+  'VisualStudioExptTeam.vscodeintellicode',
+  'Vue.volar',
 ]);
 
 const extensions = useAllExtensions();
 
 export const incompatibleExtensions = computed(() => {
-	return extensions.value
-		.filter(ext => isExtensionCompatibleWithHybridMode(ext) === false)
-		.map(ext => ext.id);
+  return extensions.value
+    .filter((ext) => isExtensionCompatibleWithHybridMode(ext) === false)
+    .map((ext) => ext.id);
 });
 
 export const unknownExtensions = computed(() => {
-	return extensions.value
-		.filter(ext => isExtensionCompatibleWithHybridMode(ext) === undefined && !!ext.packageJSON?.contributes?.typescriptServerPlugins)
-		.map(ext => ext.id);
+  return extensions.value
+    .filter(
+      (ext) =>
+        isExtensionCompatibleWithHybridMode(ext) === undefined &&
+        !!ext.packageJSON?.contributes?.typescriptServerPlugins,
+    )
+    .map((ext) => ext.id);
 });
 
-function isExtensionCompatibleWithHybridMode(extension: vscode.Extension<any>) {
-	if (
-		defaultCompatibleExtensions.has(extension.id) ||
-		config.server.compatibleExtensions.includes(extension.id)
-	) {
-		return true;
-	}
-	if (extension.id === 'denoland.vscode-deno') {
-		return !vscode.workspace.getConfiguration('deno').get<boolean>('enable');
-	}
-	if (extension.id === 'svelte.svelte-vscode') {
-		return semver.gte(extension.packageJSON.version, '108.4.0');
-	}
+function isExtensionCompatibleWithHybridMode(
+  extension: vscode.Extension<any>,
+): boolean | undefined {
+  if (
+    defaultCompatibleExtensions.has(extension.id) ||
+    config.server.compatibleExtensions.includes(extension.id)
+  ) {
+    return true;
+  }
+  if (extension.id === 'denoland.vscode-deno') {
+    return !vscode.workspace.getConfiguration('deno').get<boolean>('enable');
+  }
+  if (extension.id === 'svelte.svelte-vscode') {
+    return semver.gte(extension.packageJSON.version, '108.4.0');
+  }
 }

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -2,6 +2,6 @@ import { defineConfigObject } from 'reactive-vscode';
 import { NestedScopedConfigs, scopedConfigs } from './generated-meta';
 
 export const config = defineConfigObject<NestedScopedConfigs>(
-	scopedConfigs.scope,
-	scopedConfigs.defaults
+  scopedConfigs.scope,
+  scopedConfigs.defaults,
 );

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -1,0 +1,7 @@
+import { defineConfigObject } from 'reactive-vscode';
+import { NestedScopedConfigs, scopedConfigs } from './generated-meta';
+
+export const config = defineConfigObject<NestedScopedConfigs>(
+	scopedConfigs.scope,
+	scopedConfigs.defaults
+);

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -85,7 +85,7 @@ export const { activate, deactivate } = defineExtension(async () => {
           workspaceFolder,
           (id, name, documentSelector, initOptions, port, outputChannel) => {
             class _LanguageClient extends lsp.LanguageClient {
-              override fillInitializeParams(params: lsp.InitializeParams): lsp.InitializeParams {
+              override fillInitializeParams(params: lsp.InitializeParams): void {
                 // fix https://github.com/vuejs/language-tools/issues/1959
                 params.locale = vscode.env.language;
               }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -86,6 +86,7 @@ export const { activate, deactivate } = defineExtension(async () => {
       addedFolders.forEach((workspaceFolder) => {
         const teardownClient = watchWorkspaceFolderForLanguageClientActivation(
           context,
+          workspaceFolder,
           (id, name, documentSelector, initOptions, port, outputChannel) => {
             class _LanguageClient extends lsp.LanguageClient {
               override fillInitializeParams(params: lsp.InitializeParams) {
@@ -127,6 +128,7 @@ export const { activate, deactivate } = defineExtension(async () => {
                 options: debugOptions,
               },
             };
+
             const clientOptions: lsp.LanguageClientOptions = {
               // middleware,
               documentSelector: documentSelector,

--- a/packages/vscode/src/hybrid-mode.ts
+++ b/packages/vscode/src/hybrid-mode.ts
@@ -170,6 +170,6 @@ function getTsVersion(libPath: string): string | undefined {
 
     return desc.version as string;
   } catch {
-		// Ignore
-	}
+    // Ignore
+  }
 }

--- a/packages/vscode/src/hybrid-mode.ts
+++ b/packages/vscode/src/hybrid-mode.ts
@@ -1,0 +1,200 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { computed, executeCommand, useAllExtensions, useVscodeContext, watchEffect } from 'reactive-vscode';
+import * as semver from 'semver';
+import * as vscode from 'vscode';
+import { incompatibleExtensions, unknownExtensions } from './compatibility';
+import { config } from './config';
+
+const extensions = useAllExtensions();
+
+export const enabledHybridMode = computed(() => {
+	if (config.server.hybridMode === 'typeScriptPluginOnly') {
+		return false;
+	}
+	else if (config.server.hybridMode === 'auto') {
+		if (
+			incompatibleExtensions.value.length ||
+			unknownExtensions.value.length
+		) {
+			return false;
+		}
+		else if (
+			(vscodeTsdkVersion.value && !semver.gte(vscodeTsdkVersion.value, '5.3.0')) ||
+			(workspaceTsdkVersion.value && !semver.gte(workspaceTsdkVersion.value, '5.3.0'))
+		) {
+			return false;
+		}
+		return true;
+	}
+	return config.server.hybridMode;
+});
+
+export const enabledTypeScriptPlugin = computed(() => {
+	return (
+		enabledHybridMode.value ||
+		config.server.hybridMode === 'typeScriptPluginOnly'
+	);
+});
+
+const vscodeTsdkVersion = computed(() => {
+	const nightly = extensions.value.find(
+		({ id }) => id === 'ms-vscode.vscode-typescript-next'
+	);
+	if (nightly) {
+		const libPath = path.join(
+			nightly.extensionPath.replace(/\\/g, '/'),
+			'node_modules/typescript/lib'
+		);
+		return getTsVersion(libPath);
+	}
+
+	if (vscode.env.appRoot) {
+		const libPath = path.join(
+			vscode.env.appRoot.replace(/\\/g, '/'),
+			'extensions/node_modules/typescript/lib'
+		);
+		return getTsVersion(libPath);
+	}
+});
+
+const workspaceTsdkVersion = computed(() => {
+	const libPath = vscode.workspace
+		.getConfiguration('typescript')
+		.get<string>('tsdk')
+		?.replace(/\\/g, '/');
+	if (libPath) {
+		return getTsVersion(libPath);
+	}
+});
+
+export function useHybridModeTips() {
+	useVscodeContext('vueHybridMode', enabledHybridMode);
+
+	watchEffect(() => {
+		if (config.server.hybridMode === 'auto') {
+			if (
+				incompatibleExtensions.value.length ||
+				unknownExtensions.value.length
+			) {
+				vscode.window
+					.showInformationMessage(
+						`Hybrid Mode is disabled automatically because there is a potentially incompatible ${[
+							...incompatibleExtensions.value,
+							...unknownExtensions.value,
+						].join(', ')} TypeScript plugin installed.`,
+						'Open Settings',
+						'Report a false positive'
+					)
+					.then(value => {
+						if (value === 'Open Settings') {
+							executeCommand(
+								'workbench.action.openSettings',
+								'vue.server.hybridMode'
+							);
+						}
+						else if (value == 'Report a false positive') {
+							vscode.env.openExternal(
+								vscode.Uri.parse(
+									'https://github.com/vuejs/language-tools/pull/4206'
+								)
+							);
+						}
+					});
+			}
+			else if (
+				(vscodeTsdkVersion.value && !semver.gte(vscodeTsdkVersion.value, '5.3.0')) ||
+				(workspaceTsdkVersion.value && !semver.gte(workspaceTsdkVersion.value, '5.3.0'))
+			) {
+				let msg = `Hybrid Mode is disabled automatically because TSDK >= 5.3.0 is required (VSCode TSDK: ${vscodeTsdkVersion.value}`;
+				if (workspaceTsdkVersion.value) {
+					msg += `, Workspace TSDK: ${workspaceTsdkVersion.value}`;
+				}
+				msg += `).`;
+				vscode.window
+					.showInformationMessage(msg, 'Open Settings')
+					.then(value => {
+						if (value === 'Open Settings') {
+							executeCommand(
+								'workbench.action.openSettings',
+								'vue.server.hybridMode'
+							);
+						}
+					});
+			}
+		}
+		else if (config.server.hybridMode && incompatibleExtensions.value.length) {
+			vscode.window
+				.showWarningMessage(
+					`You have explicitly enabled Hybrid Mode, but you have installed known incompatible extensions: ${incompatibleExtensions.value.join(
+						', '
+					)}. You may want to change vue.server.hybridMode to "auto" to avoid compatibility issues.`,
+					'Open Settings',
+					'Report a false positive'
+				)
+				.then(value => {
+					if (value === 'Open Settings') {
+						executeCommand(
+							'workbench.action.openSettings',
+							'vue.server.hybridMode'
+						);
+					}
+					else if (value == 'Report a false positive') {
+						vscode.env.openExternal(
+							vscode.Uri.parse(
+								'https://github.com/vuejs/language-tools/pull/4206'
+							)
+						);
+					}
+				});
+		}
+	});
+}
+
+export function useHybridModeStatusItem() {
+	const item = vscode.languages.createLanguageStatusItem(
+		'vue-hybrid-mode',
+		config.server.includeLanguages
+	);
+
+	item.text = 'Hybrid Mode';
+	item.detail =
+		(enabledHybridMode.value ? 'Enabled' : 'Disabled') +
+		(config.server.hybridMode === 'auto' ? ' (Auto)' : '');
+	item.command = {
+		title: 'Open Setting',
+		command: 'workbench.action.openSettings',
+		arguments: ['vue.server.hybridMode'],
+	};
+
+	if (!enabledHybridMode.value) {
+		item.severity = vscode.LanguageStatusSeverity.Warning;
+	}
+}
+
+function getTsVersion(libPath: string) {
+	try {
+		const p = libPath.toString().split('/');
+		const p2 = p.slice(0, -1);
+		const modulePath = p2.join('/');
+		const filePath = modulePath + '/package.json';
+		const contents = fs.readFileSync(filePath, 'utf-8');
+
+		if (contents === undefined) {
+			return;
+		}
+
+		let desc: any = null;
+		try {
+			desc = JSON.parse(contents);
+		}
+		catch (err) {
+			return;
+		}
+		if (!desc || !desc.version) {
+			return;
+		}
+
+		return desc.version as string;
+	} catch { }
+}

--- a/packages/vscode/src/hybrid-mode.ts
+++ b/packages/vscode/src/hybrid-mode.ts
@@ -1,6 +1,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { computed, executeCommand, useAllExtensions, useVscodeContext, watchEffect } from 'reactive-vscode';
+import {
+  computed,
+  executeCommand,
+  useAllExtensions,
+  useVscodeContext,
+  watchEffect,
+} from 'reactive-vscode';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { incompatibleExtensions, unknownExtensions } from './compatibility';
@@ -9,192 +15,161 @@ import { config } from './config';
 const extensions = useAllExtensions();
 
 export const enabledHybridMode = computed(() => {
-	if (config.server.hybridMode === 'typeScriptPluginOnly') {
-		return false;
-	}
-	else if (config.server.hybridMode === 'auto') {
-		if (
-			incompatibleExtensions.value.length ||
-			unknownExtensions.value.length
-		) {
-			return false;
-		}
-		else if (
-			(vscodeTsdkVersion.value && !semver.gte(vscodeTsdkVersion.value, '5.3.0')) ||
-			(workspaceTsdkVersion.value && !semver.gte(workspaceTsdkVersion.value, '5.3.0'))
-		) {
-			return false;
-		}
-		return true;
-	}
-	return config.server.hybridMode;
+  if (config.server.hybridMode === 'typeScriptPluginOnly') {
+    return false;
+  } else if (config.server.hybridMode === 'auto') {
+    if (incompatibleExtensions.value.length || unknownExtensions.value.length) {
+      return false;
+    } else if (
+      (vscodeTsdkVersion.value && !semver.gte(vscodeTsdkVersion.value, '5.3.0')) ||
+      (workspaceTsdkVersion.value && !semver.gte(workspaceTsdkVersion.value, '5.3.0'))
+    ) {
+      return false;
+    }
+    return true;
+  }
+  return config.server.hybridMode;
 });
 
 export const enabledTypeScriptPlugin = computed(() => {
-	return (
-		enabledHybridMode.value ||
-		config.server.hybridMode === 'typeScriptPluginOnly'
-	);
+  return enabledHybridMode.value || config.server.hybridMode === 'typeScriptPluginOnly';
 });
 
 const vscodeTsdkVersion = computed(() => {
-	const nightly = extensions.value.find(
-		({ id }) => id === 'ms-vscode.vscode-typescript-next'
-	);
-	if (nightly) {
-		const libPath = path.join(
-			nightly.extensionPath.replace(/\\/g, '/'),
-			'node_modules/typescript/lib'
-		);
-		return getTsVersion(libPath);
-	}
+  const nightly = extensions.value.find(({ id }) => id === 'ms-vscode.vscode-typescript-next');
+  if (nightly) {
+    const libPath = path.join(
+      nightly.extensionPath.replace(/\\/g, '/'),
+      'node_modules/typescript/lib',
+    );
+    return getTsVersion(libPath);
+  }
 
-	if (vscode.env.appRoot) {
-		const libPath = path.join(
-			vscode.env.appRoot.replace(/\\/g, '/'),
-			'extensions/node_modules/typescript/lib'
-		);
-		return getTsVersion(libPath);
-	}
+  if (vscode.env.appRoot) {
+    const libPath = path.join(
+      vscode.env.appRoot.replace(/\\/g, '/'),
+      'extensions/node_modules/typescript/lib',
+    );
+    return getTsVersion(libPath);
+  }
 });
 
 const workspaceTsdkVersion = computed(() => {
-	const libPath = vscode.workspace
-		.getConfiguration('typescript')
-		.get<string>('tsdk')
-		?.replace(/\\/g, '/');
-	if (libPath) {
-		return getTsVersion(libPath);
-	}
+  const libPath = vscode.workspace
+    .getConfiguration('typescript')
+    .get<string>('tsdk')
+    ?.replace(/\\/g, '/');
+  if (libPath) {
+    return getTsVersion(libPath);
+  }
 });
 
-export function useHybridModeTips() {
-	useVscodeContext('vueHybridMode', enabledHybridMode);
+export function useHybridModeTips(): void {
+  useVscodeContext('glintHybridMode', enabledHybridMode);
 
-	watchEffect(() => {
-		if (config.server.hybridMode === 'auto') {
-			if (
-				incompatibleExtensions.value.length ||
-				unknownExtensions.value.length
-			) {
-				vscode.window
-					.showInformationMessage(
-						`Hybrid Mode is disabled automatically because there is a potentially incompatible ${[
-							...incompatibleExtensions.value,
-							...unknownExtensions.value,
-						].join(', ')} TypeScript plugin installed.`,
-						'Open Settings',
-						'Report a false positive'
-					)
-					.then(value => {
-						if (value === 'Open Settings') {
-							executeCommand(
-								'workbench.action.openSettings',
-								'vue.server.hybridMode'
-							);
-						}
-						else if (value == 'Report a false positive') {
-							vscode.env.openExternal(
-								vscode.Uri.parse(
-									'https://github.com/vuejs/language-tools/pull/4206'
-								)
-							);
-						}
-					});
-			}
-			else if (
-				(vscodeTsdkVersion.value && !semver.gte(vscodeTsdkVersion.value, '5.3.0')) ||
-				(workspaceTsdkVersion.value && !semver.gte(workspaceTsdkVersion.value, '5.3.0'))
-			) {
-				let msg = `Hybrid Mode is disabled automatically because TSDK >= 5.3.0 is required (VSCode TSDK: ${vscodeTsdkVersion.value}`;
-				if (workspaceTsdkVersion.value) {
-					msg += `, Workspace TSDK: ${workspaceTsdkVersion.value}`;
-				}
-				msg += `).`;
-				vscode.window
-					.showInformationMessage(msg, 'Open Settings')
-					.then(value => {
-						if (value === 'Open Settings') {
-							executeCommand(
-								'workbench.action.openSettings',
-								'vue.server.hybridMode'
-							);
-						}
-					});
-			}
-		}
-		else if (config.server.hybridMode && incompatibleExtensions.value.length) {
-			vscode.window
-				.showWarningMessage(
-					`You have explicitly enabled Hybrid Mode, but you have installed known incompatible extensions: ${incompatibleExtensions.value.join(
-						', '
-					)}. You may want to change vue.server.hybridMode to "auto" to avoid compatibility issues.`,
-					'Open Settings',
-					'Report a false positive'
-				)
-				.then(value => {
-					if (value === 'Open Settings') {
-						executeCommand(
-							'workbench.action.openSettings',
-							'vue.server.hybridMode'
-						);
-					}
-					else if (value == 'Report a false positive') {
-						vscode.env.openExternal(
-							vscode.Uri.parse(
-								'https://github.com/vuejs/language-tools/pull/4206'
-							)
-						);
-					}
-				});
-		}
-	});
+  watchEffect(() => {
+    if (config.server.hybridMode === 'auto') {
+      if (incompatibleExtensions.value.length || unknownExtensions.value.length) {
+        vscode.window
+          .showInformationMessage(
+            `Hybrid Mode is disabled automatically because there is a potentially incompatible ${[
+              ...incompatibleExtensions.value,
+              ...unknownExtensions.value,
+            ].join(', ')} TypeScript plugin installed.`,
+            'Open Settings',
+            'Report a false positive',
+          )
+          .then((value) => {
+            if (value === 'Open Settings') {
+              executeCommand('workbench.action.openSettings', 'glint.server.hybridMode');
+            } else if (value == 'Report a false positive') {
+              vscode.env.openExternal(
+                vscode.Uri.parse('https://github.com/vuejs/language-tools/pull/4206'),
+              );
+            }
+          });
+      } else if (
+        (vscodeTsdkVersion.value && !semver.gte(vscodeTsdkVersion.value, '5.3.0')) ||
+        (workspaceTsdkVersion.value && !semver.gte(workspaceTsdkVersion.value, '5.3.0'))
+      ) {
+        let msg = `Hybrid Mode is disabled automatically because TSDK >= 5.3.0 is required (VSCode TSDK: ${vscodeTsdkVersion.value}`;
+        if (workspaceTsdkVersion.value) {
+          msg += `, Workspace TSDK: ${workspaceTsdkVersion.value}`;
+        }
+        msg += `).`;
+        vscode.window.showInformationMessage(msg, 'Open Settings').then((value) => {
+          if (value === 'Open Settings') {
+            executeCommand('workbench.action.openSettings', 'glint.server.hybridMode');
+          }
+        });
+      }
+    } else if (config.server.hybridMode && incompatibleExtensions.value.length) {
+      vscode.window
+        .showWarningMessage(
+          `You have explicitly enabled Hybrid Mode, but you have installed known incompatible extensions: ${incompatibleExtensions.value.join(
+            ', ',
+          )}. You may want to change glint.server.hybridMode to "auto" to avoid compatibility issues.`,
+          'Open Settings',
+          'Report a false positive',
+        )
+        .then((value) => {
+          if (value === 'Open Settings') {
+            executeCommand('workbench.action.openSettings', 'glint.server.hybridMode');
+          } else if (value == 'Report a false positive') {
+            vscode.env.openExternal(
+              vscode.Uri.parse('https://github.com/vuejs/language-tools/pull/4206'),
+            );
+          }
+        });
+    }
+  });
 }
 
-export function useHybridModeStatusItem() {
-	const item = vscode.languages.createLanguageStatusItem(
-		'vue-hybrid-mode',
-		config.server.includeLanguages
-	);
+export function useHybridModeStatusItem(): void {
+  const item = vscode.languages.createLanguageStatusItem(
+    'vue-hybrid-mode',
+    config.server.includeLanguages,
+  );
 
-	item.text = 'Hybrid Mode';
-	item.detail =
-		(enabledHybridMode.value ? 'Enabled' : 'Disabled') +
-		(config.server.hybridMode === 'auto' ? ' (Auto)' : '');
-	item.command = {
-		title: 'Open Setting',
-		command: 'workbench.action.openSettings',
-		arguments: ['vue.server.hybridMode'],
-	};
+  item.text = 'Hybrid Mode';
+  item.detail =
+    (enabledHybridMode.value ? 'Enabled' : 'Disabled') +
+    (config.server.hybridMode === 'auto' ? ' (Auto)' : '');
+  item.command = {
+    title: 'Open Setting',
+    command: 'workbench.action.openSettings',
+    arguments: ['glint.server.hybridMode'],
+  };
 
-	if (!enabledHybridMode.value) {
-		item.severity = vscode.LanguageStatusSeverity.Warning;
+  if (!enabledHybridMode.value) {
+    item.severity = vscode.LanguageStatusSeverity.Warning;
+  }
+}
+
+function getTsVersion(libPath: string): string | undefined {
+  try {
+    const p = libPath.toString().split('/');
+    const p2 = p.slice(0, -1);
+    const modulePath = p2.join('/');
+    const filePath = modulePath + '/package.json';
+    const contents = fs.readFileSync(filePath, 'utf-8');
+
+    if (contents === undefined) {
+      return;
+    }
+
+    let desc: any = null;
+    try {
+      desc = JSON.parse(contents);
+    } catch (err) {
+      return;
+    }
+    if (!desc || !desc.version) {
+      return;
+    }
+
+    return desc.version as string;
+  } catch {
+		// Ignore
 	}
-}
-
-function getTsVersion(libPath: string) {
-	try {
-		const p = libPath.toString().split('/');
-		const p2 = p.slice(0, -1);
-		const modulePath = p2.join('/');
-		const filePath = modulePath + '/package.json';
-		const contents = fs.readFileSync(filePath, 'utf-8');
-
-		if (contents === undefined) {
-			return;
-		}
-
-		let desc: any = null;
-		try {
-			desc = JSON.parse(contents);
-		}
-		catch (err) {
-			return;
-		}
-		if (!desc || !desc.version) {
-			return;
-		}
-
-		return desc.version as string;
-	} catch { }
 }

--- a/packages/vscode/src/language-client.ts
+++ b/packages/vscode/src/language-client.ts
@@ -47,7 +47,7 @@ export function watchWorkspaceFolderForLanguageClientActivation(
   context: vscode.ExtensionContext,
   workspaceFolder: vscode.WorkspaceFolder,
   createLanguageClient: CreateLanguageClient,
-) {
+): () => void {
   // for each
   const activeTextEditor = useActiveTextEditor();
   const visibleTextEditors = useVisibleTextEditors();
@@ -158,7 +158,7 @@ async function activateLanguageClient(
       { deep: true },
     );
 
-    useCommand('glint.restart-language-server', async (restartTsServer: boolean = true) => {
+    useCommand('glint.restart-language-server', async (restartTsServer = true) => {
       if (restartTsServer) {
         await executeCommand('typescript.restartTsServer');
       }
@@ -196,7 +196,7 @@ async function activateLanguageClient(
 
   hasInitialized = true;
 
-  async function requestReloadVscode(msg: string) {
+  async function requestReloadVscode(msg: string): Promise<void> {
     const reload = await vscode.window.showInformationMessage(msg, 'Reload Window');
     if (reload) {
       executeCommand('workbench.action.reloadWindow');

--- a/packages/vscode/src/language-client.ts
+++ b/packages/vscode/src/language-client.ts
@@ -36,10 +36,14 @@ type CreateLanguageClient = (
   outputChannel: vscode.OutputChannel,
 ) => lsp.BaseLanguageClient | null;
 
-// What is this activating?
-//
-// this will get passed a workspace. Then we watch that workspace for LC activation.
-export function activateLanguageClientForWorkspace(
+/**
+ * A workspace consists of 1+ open folders. This function will watch one of
+ * those folders to see if file has been opened with a known language ID
+ * (e.g. 'glimmer-ts', 'handlebars', 'vue', etc.). When that happens we
+ * invoke the `createLanguageClient` function to create a language server
+ * client.
+ */
+export function watchWorkspaceFolderForLanguageClientActivation(
   context: vscode.ExtensionContext,
   createLanguageClient: CreateLanguageClient,
 ) {
@@ -129,6 +133,9 @@ async function activateLanguageClient(
     },
   );
 
+  // NOTE: this will fire when `glint.libraryPath` is changed, among others
+  // (leaving this note here so I don't re-implement the `affectsConfiguration` logic we used
+  // to have when changing this config value)
   watch(
     config.server,
     () => {

--- a/packages/vscode/src/language-client.ts
+++ b/packages/vscode/src/language-client.ts
@@ -1,0 +1,160 @@
+import * as lsp from '@volar/vscode';
+import {
+  executeCommand,
+  nextTick,
+  useActiveTextEditor,
+  useCommand,
+  useOutputChannel,
+  useVisibleTextEditors,
+  useVscodeContext,
+  watch,
+} from 'reactive-vscode';
+import * as vscode from 'vscode';
+import { config } from './config';
+// import { activate as activateDoctor } from './features/doctor';
+// import { activate as activateNameCasing } from './features/nameCasing';
+// import { activate as activateSplitEditors } from './features/splitEditors';
+import {
+  enabledHybridMode,
+  enabledTypeScriptPlugin,
+  useHybridModeStatusItem,
+  useHybridModeTips,
+} from './hybrid-mode';
+// import { useInsidersStatusItem } from './insiders';
+
+let client: lsp.BaseLanguageClient;
+
+type GlintInitializationOptions = any;
+
+type CreateLanguageClient = (
+  id: string,
+  name: string,
+  langs: lsp.DocumentSelector,
+  initOptions: GlintInitializationOptions,
+  port: number,
+  outputChannel: vscode.OutputChannel,
+) => lsp.BaseLanguageClient;
+
+// What is this activating?
+export function activate(context: vscode.ExtensionContext, createLc: CreateLanguageClient) {
+  const activeTextEditor = useActiveTextEditor();
+  const visibleTextEditors = useVisibleTextEditors();
+
+  useHybridModeTips();
+
+  const { stop } = watch(
+    activeTextEditor,
+    () => {
+      if (
+        visibleTextEditors.value.some((editor) =>
+          config.server.includeLanguages.includes(editor.document.languageId),
+        )
+      ) {
+        activateLc(context, createLc);
+        nextTick(() => {
+          stop();
+        });
+      }
+    },
+    {
+      immediate: true, // causes above callback to be run immediately (i.e. not lazily)
+    },
+  );
+}
+
+export function deactivate() {
+  return client?.stop();
+}
+
+async function activateLc(context: vscode.ExtensionContext, createLc: CreateLanguageClient) {
+  useVscodeContext('vue.activated', true);
+  const outputChannel = useOutputChannel('Glint Language Server');
+  const selectors = config.server.includeLanguages;
+
+  client = createLc(
+    'glint',
+    'Glint',
+    selectors,
+    await getInitializationOptions(context, enabledHybridMode.value),
+    6009,
+    outputChannel,
+  );
+
+  watch([enabledHybridMode, enabledTypeScriptPlugin], (newValues, oldValues) => {
+    if (newValues[0] !== oldValues[0]) {
+      requestReloadVscode(
+        `Please reload VSCode to ${newValues[0] ? 'enable' : 'disable'} Hybrid Mode.`,
+      );
+    } else if (newValues[1] !== oldValues[1]) {
+      requestReloadVscode(
+        `Please reload VSCode to ${newValues[1] ? 'enable' : 'disable'} Vue TypeScript Plugin.`,
+      );
+    }
+  });
+
+  watch(
+    () => config.server.includeLanguages,
+    () => {
+      if (enabledHybridMode.value) {
+        requestReloadVscode('Please reload VSCode to apply the new language settings.');
+      }
+    },
+  );
+
+  watch(
+    config.server,
+    () => {
+      if (!enabledHybridMode.value) {
+        executeCommand('vue.action.restartServer', false);
+      }
+    },
+    { deep: true },
+  );
+
+  useCommand('vue.action.restartServer', async (restartTsServer: boolean = true) => {
+    if (restartTsServer) {
+      await executeCommand('typescript.restartTsServer');
+    }
+    await client.stop();
+    outputChannel.clear();
+    client.clientOptions.initializationOptions = await getInitializationOptions(
+      context,
+      enabledHybridMode.value,
+    );
+    await client.start();
+  });
+
+  // activateDoctor(client);
+  // activateNameCasing(client, selectors);
+  // activateSplitEditors(client);
+
+  lsp.activateAutoInsertion(selectors, client);
+  lsp.activateDocumentDropEdit(selectors, client);
+  lsp.activateWriteVirtualFiles('vue.action.writeVirtualFiles', client);
+
+  if (!enabledHybridMode.value) {
+    lsp.activateTsConfigStatusItem(selectors, 'vue.tsconfig', client);
+    lsp.activateTsVersionStatusItem(selectors, 'vue.tsversion', context, (text) => 'TS ' + text);
+    lsp.activateFindFileReferences('vue.findAllFileReferences', client);
+  }
+
+  useHybridModeStatusItem();
+  // useInsidersStatusItem(context);
+
+  async function requestReloadVscode(msg: string) {
+    const reload = await vscode.window.showInformationMessage(msg, 'Reload Window');
+    if (reload) {
+      executeCommand('workbench.action.reloadWindow');
+    }
+  }
+}
+
+async function getInitializationOptions(
+  context: vscode.ExtensionContext,
+  hybridMode: boolean,
+): Promise<GlintInitializationOptions> {
+  return {
+    typescript: { tsdk: (await lsp.getTsdk(context))!.tsdk },
+    vue: { hybridMode },
+  };
+}

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "module": "CommonJS",
-		"moduleResolution": "Node"
+    "moduleResolution": "Node"
   },
   "include": ["src", "__tests__"],
   "references": [{ "path": "../core" }]

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.compileroptions.json",
   "compilerOptions": {
-    "module": "Node16",
-    "outDir": "lib"
+    "outDir": "lib",
+    "module": "CommonJS",
+		"moduleResolution": "Node"
   },
   "include": ["src", "__tests__"],
   "references": [{ "path": "../core" }]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,6 +2684,11 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
 
+"@reactive-vscode/reactivity@0.2.7-beta.1":
+  version "0.2.7-beta.1"
+  resolved "https://registry.yarnpkg.com/@reactive-vscode/reactivity/-/reactivity-0.2.7-beta.1.tgz#a387bf07a420a1b592e4e87353a3159cb6d7994f"
+  integrity sha512-ma7DOAFSXhB7h2HLiDrus4as5So1rS3u4zNHKoKCRRh4cBxxnQDFZUUQNafsssM15ggxtf8km5IXyW81ZCWnsg==
+
 "@release-it-plugins/lerna-changelog@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@release-it-plugins/lerna-changelog/-/lerna-changelog-5.0.0.tgz#cbbbc47fd40ef212f2d7c0e24867d3fcea4cd232"
@@ -12242,6 +12247,13 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+reactive-vscode@0.2.7-beta.1:
+  version "0.2.7-beta.1"
+  resolved "https://registry.yarnpkg.com/reactive-vscode/-/reactive-vscode-0.2.7-beta.1.tgz#6d92f14e9d28892391095c295864bb91db56603b"
+  integrity sha512-7D9sFMA4S6owUNdiuiuiJLOzAuy3y4ZgcNW3bj58n1hME0U8repz3hhYep6VCLbAf89F+TF/bB7u+WNGHndLGg==
+  dependencies:
+    "@reactive-vscode/reactivity" "0.2.7-beta.1"
+
 read-pkg@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
@@ -12873,6 +12885,11 @@ schema-utils@^4.0.0:
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+scule@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/scule/-/scule-1.3.0.tgz#6efbd22fd0bb801bdcc585c89266a7d2daa8fbd3"
+  integrity sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==
 
 semver-diff@^4.0.0:
   version "4.0.0"
@@ -14521,6 +14538,15 @@ volar-service-typescript@volar-2.4:
     vscode-nls "^5.2.0"
     vscode-uri "^3.0.8"
 
+vscode-ext-gen@^0.5.0:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/vscode-ext-gen/-/vscode-ext-gen-0.5.5.tgz#e4f5bb0b237c839c31170da41b6d117afa7dd53e"
+  integrity sha512-wTwcPvGF9xZ0fN7sPgdUPESH+Aw20Tk1vvgbYnKzWT4sFOqRP54qcpxjPUMdDoDGfiVIoXW87TNxn0yKXq3djw==
+  dependencies:
+    cac "^6.7.14"
+    scule "^1.3.0"
+    yargs "^17.7.2"
+
 vscode-jsonrpc@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
@@ -14955,7 +14981,7 @@ yargs@16.2.0, yargs@^16.0.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.0, yargs@^17.5.1:
+yargs@^17.1.0, yargs@^17.5.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
The Vue extension which runs atop Volar still has a number of tricks (hacks?) to get typed Vue in TS Plugin mode (aka hybrid mode) working properly. It'll be easier to follow along with these hacks if our extension has as similar a structure as possible.

To that end I've followed along with the Vue extension's [refactor](https://github.com/vuejs/language-tools/pull/4945) to use [reactive-vscode](https://github.com/KermanX/reactive-vscode). `reactive-vscode` uses Vue's composition API (similar to starbeam signals/computeds/etc) to provide a more user-friendly reactive layer over the more observer-centric VSCode extension API. It's a nice set of primitives on its on but more importantly this lets us follow Vue's extension logic/hackery more closely.