### PR TITLE
Simplify the TO template tag example

### DIFF
--- a/docs/ember/template-imports.md
+++ b/docs/ember/template-imports.md
@@ -62,12 +62,11 @@ interface ShoutSignature {
 
 const louderPlease = (message: string) => message.toUpperCase();
 
-const Shout: TOC<ShoutSignature> = <template>
+export default <template>
     <div ...attributes>
         {{yield (louderPlease @message)}}
     </div>
-</template>;
-export default Shout;
+</template> satisfies TOC<ShoutSignature>;
 ```
 
 {% endcode %}


### PR DESCRIPTION
This version is less verbose. The `export default` part is technically optional as well, but there is a bug which prevents that from working in real apps at the moment.

More info about that bug, with links to relevant issues: https://github.com/emberjs/ember.js/pull/20862#discussion_r1997212481