### PR TITLE
Explicitly accept an Iterable in `each-in`

### DIFF
--- a/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
+++ b/packages/environment-ember-loose/-private/intrinsics/each-in.d.ts
@@ -7,13 +7,18 @@ export type EachInKeyword = abstract new <T>() => InstanceType<
       Named: { key?: string };
     };
     Blocks: {
-      default: [key: EachInKey<T>, value: Exclude<T, null | undefined>[EachInKey<T>]];
+      default: EachInIteratorPair<T>;
       else?: [];
     };
   }>
 >;
 
+type EachInIteratorPair<T> =
+  T extends Iterable<[infer K, infer V]>
+    ? [key: K, value: V]
+    : [key: EachInKey<T>, value: Exclude<T, null | undefined>[EachInKey<T>]];
+
 // `{{each-in}}` internally uses `Object.keys`, so only string keys are included
 // TS, on the other hand, gives a wider result for `keyof` than many users expect
 // for record types: https://github.com/microsoft/TypeScript/issues/29249
-type EachInKey<T> = keyof Exclude<T, null | undefined> & string;
+type EachInKey<T> = Extract<keyof Exclude<T, null | undefined>, string>;

--- a/packages/environment-ember-loose/__tests__/type-tests/intrinsics/each-in.test.ts
+++ b/packages/environment-ember-loose/__tests__/type-tests/intrinsics/each-in.test.ts
@@ -53,6 +53,25 @@ declare const maybeVal: { a: number; b: number } | undefined;
   }
 }
 
+// Can render maybe undefined (map)
+
+declare const maybeMapVal: Map<string, number> | undefined;
+
+{
+  const component = emitComponent(eachIn(maybeMapVal));
+
+  {
+    const [key, value] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<string>();
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+
+  {
+    const [...args] = component.blockParams.else;
+    expectTypeOf(args).toEqualTypeOf<[]>();
+  }
+}
+
 // Can render else when undefined, null, or empty.
 
 {
@@ -111,5 +130,39 @@ declare const maybeVal: { a: number; b: number } | undefined;
     const [key, value] = component.blockParams.default;
     expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
     expectTypeOf(value).toEqualTypeOf<number>();
+  }
+}
+
+// Accepts a Map
+{
+  const component = emitComponent(
+    eachIn(
+      new Map<string, number>([
+        ['a', 5],
+        ['b', 4],
+      ]),
+      { key: 'id', ...NamedArgsMarker },
+    ),
+  );
+  {
+    const [key, value] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<string>();
+    expectTypeOf(value).toEqualTypeOf<number>();
+  }
+}
+
+// Accepts a custom iterable
+{
+  class CustomMap implements Iterable<[Set<string>, bigint]> {
+    [Symbol.iterator](): Iterator<[Set<string>, bigint]> {
+      throw new Error();
+    }
+  }
+
+  const component = emitComponent(eachIn(new CustomMap(), { key: 'id', ...NamedArgsMarker }));
+  {
+    const [key, value] = component.blockParams.default;
+    expectTypeOf(key).toEqualTypeOf<Set<string>>();
+    expectTypeOf(value).toEqualTypeOf<bigint>();
   }
 }


### PR DESCRIPTION
This allows us to extract the generic arguments and use them as the types for the default block.

Resolves: #645