### PR TITLE
volar-service-typescript dep - replace NPM tag with version number

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "semver": "^7.5.2",
     "silent-error": "^1.1.1",
     "uuid": "^8.3.2",
-    "volar-service-typescript": "volar-2.4",
+    "volar-service-typescript": "0.0.64",
     "vscode-languageserver-textdocument": "^1.0.5",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-uri": "^3.0.8",


### PR DESCRIPTION
Yarn does not seem to understand the NPM tag volar-2.4

Would it be possible to use the version number instead?