### PR TITLE
Support extending multiple config files

### DIFF
--- a/packages/core/__tests__/config/load-config.test.ts
+++ b/packages/core/__tests__/config/load-config.test.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os';
 import { describe, beforeEach, afterEach, test, expect, vi } from 'vitest';
 import { loadConfig } from '../../src/config/index.js';
 import { normalizePath } from '../../src/config/config.js';
-import { require } from '../../src/config/loader.js';
+import { findTypeScript, loadConfigInput, require } from '../../src/config/loader.js';
 
 describe('Config: loadConfig', () => {
   const testDir = `${os.tmpdir()}/glint-config-test-load-config-${process.pid}`;
@@ -49,6 +49,87 @@ describe('Config: loadConfig', () => {
 
     expect(config.rootDir).toBe(normalizePath(`${testDir}/deeply`));
     expect(config.environment.getConfiguredTemplateTags()).toEqual({ test: {} });
+  });
+
+  test('recursively extends config', () => {
+    fs.mkdirSync(`${testDir}/deeply/nested/directory`, { recursive: true });
+    fs.mkdirSync(`${testDir}/other`, { recursive: true });
+
+    fs.writeFileSync(
+      `${testDir}/tsconfig.json`,
+      JSON.stringify({
+        extends: './other/tsconfig.json',
+        glint: {
+          environment: '../local-env',
+        },
+      }),
+    );
+    fs.writeFileSync(
+      `${testDir}/other/tsconfig.json`,
+      JSON.stringify({
+        glint: {
+          environment: 'kaboom',
+        },
+      }),
+    );
+
+    fs.writeFileSync(
+      `${testDir}/deeply/tsconfig.json`,
+      JSON.stringify({
+        extends: '../tsconfig.json',
+      }),
+    );
+
+    let ts = findTypeScript(`${testDir}/deeply`);
+    if (!ts) {
+      expect.fail('TypeScript not found');
+    }
+    let glintConfig = loadConfigInput(ts, `${testDir}/deeply/tsconfig.json`);
+    expect(glintConfig).toEqual({ environment: '../local-env' });
+
+    let config = loadConfig(`${testDir}/deeply/nested/directory`);
+    expect(config.rootDir).toBe(normalizePath(`${testDir}/deeply`));
+  });
+
+  test('extends multiple parents', () => {
+    fs.mkdirSync(`${testDir}/deeply/nested/directory`, { recursive: true });
+    fs.mkdirSync(`${testDir}/other`, { recursive: true });
+
+    fs.writeFileSync(
+      `${testDir}/tsconfig.json`,
+      JSON.stringify({
+        glint: {
+          environment: 'kaboom',
+          checkStandaloneTemplates: true,
+        },
+      }),
+    );
+    fs.writeFileSync(
+      `${testDir}/other/tsconfig.json`,
+      JSON.stringify({
+        glint: {
+          environment: '../local-env',
+        },
+      }),
+    );
+
+    fs.writeFileSync(
+      `${testDir}/deeply/tsconfig.json`,
+      JSON.stringify({
+        extends: ['../tsconfig.json', '../other/tsconfig.json'],
+      }),
+    );
+
+    let ts = findTypeScript(`${testDir}/deeply`);
+    if (!ts) {
+      expect.fail('TypeScript not found');
+    }
+    let glintConfig = loadConfigInput(ts, `${testDir}/deeply/tsconfig.json`);
+    expect(glintConfig).toEqual({ environment: '../local-env', checkStandaloneTemplates: true });
+
+    let config = loadConfig(`${testDir}/deeply/nested/directory`);
+    expect(config.rootDir).toBe(normalizePath(`${testDir}/deeply`));
+    expect(config.environment.names).toEqual(['../local-env']);
   });
 
   test('locates config in package', () => {


### PR DESCRIPTION
Since TS5, tsconfig.json `extends` supports being an array of config files to extend.

Resolved #672