### PR TITLE
Improve multi-byte character handling

### DIFF
--- a/packages/core/__tests__/transform/rewrite.test.ts
+++ b/packages/core/__tests__/transform/rewrite.test.ts
@@ -32,6 +32,18 @@ describe('Transform: rewriteModule', () => {
       `);
     });
 
+    test('handles the $ character', () => {
+      let script = {
+        filename: 'test.gts',
+        contents: '<template>${{dollarAmount}}</template>;',
+      };
+
+      let transformedModule = rewriteModule(ts, { script }, emberTemplateImportsEnvironment);
+
+      expect(transformedModule?.errors).toEqual([]);
+      expect(transformedModule?.transformedContents).toMatchInlineSnapshot();
+    });
+
     test('with a class with type parameters', () => {
       let script = {
         filename: 'test.gts',

--- a/packages/core/__tests__/transform/rewrite.test.ts
+++ b/packages/core/__tests__/transform/rewrite.test.ts
@@ -41,7 +41,28 @@ describe('Transform: rewriteModule', () => {
       let transformedModule = rewriteModule(ts, { script }, emberTemplateImportsEnvironment);
 
       expect(transformedModule?.errors).toEqual([]);
-      expect(transformedModule?.transformedContents).toMatchInlineSnapshot();
+      expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
+        "export default ({} as typeof import("@glint/environment-ember-template-imports/-private/dsl")).templateExpression(function(__glintRef__, __glintDSL__: typeof import("@glint/environment-ember-template-imports/-private/dsl")) {
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(dollarAmount)());
+        __glintRef__; __glintDSL__;
+        });"
+      `);
+    });
+
+    test('handles the ` character', () => {
+      let script = {
+        filename: 'test.gts',
+        contents: '<template>`code`</template>;',
+      };
+
+      let transformedModule = rewriteModule(ts, { script }, emberTemplateImportsEnvironment);
+
+      expect(transformedModule?.errors).toEqual([]);
+      expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
+        "export default ({} as typeof import("@glint/environment-ember-template-imports/-private/dsl")).templateExpression(function(__glintRef__, __glintDSL__: typeof import("@glint/environment-ember-template-imports/-private/dsl")) {
+        __glintRef__; __glintDSL__;
+        });"
+      `);
     });
 
     test('with a class with type parameters', () => {

--- a/packages/environment-ember-template-imports/-private/environment/preprocess.ts
+++ b/packages/environment-ember-template-imports/-private/environment/preprocess.ts
@@ -13,7 +13,7 @@ export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, pat
   let templates = p.parse(source, { filename: path });
 
   let templateLocations: Array<TemplateLocation> = [];
-  let segments: Array<string> = [];
+  let contents = '';
   let sourceOffsetBytes = 0;
   let deltaBytes = 0;
 
@@ -25,46 +25,44 @@ export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, pat
     let startTagOffsetBytes = template.startRange.start;
     let endTagOffsetBytes = template.endRange.start;
     let transformedStartBytes = startTagOffsetBytes - deltaBytes;
-
     /**
      * TODO: we want content-tag to manage all this for us, as managing indicies
      *       can be error-prone.
      *
      * SEE: https://github.com/embroider-build/content-tag/issues/39#issuecomment-1832443310
      */
-    let prefixingSegment = sourceBuffer.slice(sourceOffsetBytes, startTagOffsetBytes);
-    segments.push(prefixingSegment.toString());
-    segments.push(TEMPLATE_START);
+    let prefixingSegment = sourceBuffer.subarray(sourceOffsetBytes, startTagOffsetBytes);
+    contents = contents.concat(prefixingSegment.toString());
+    contents = contents.concat(TEMPLATE_START);
 
     // For TEMPLATE_START & TEMPLATE_END, characters === bytes
     deltaBytes += startTagLengthBytes - TEMPLATE_START.length;
 
     let transformedEnd = endTagOffsetBytes - deltaBytes + TEMPLATE_END.length;
-
-    let templateContentSegment = sourceBuffer.slice(
+    let templateContentSegment = sourceBuffer.subarray(
       startTagOffsetBytes + startTagLengthBytes,
       endTagOffsetBytes,
     );
-    segments.push(templateContentSegment.toString());
-    segments.push(TEMPLATE_END);
+
+    contents = contents.concat(templateContentSegment.toString());
+    contents = contents.concat(TEMPLATE_END);
+
     deltaBytes += endTagLengthBytes - TEMPLATE_END.length;
 
     sourceOffsetBytes = endTagOffsetBytes + endTagLengthBytes;
-
     templateLocations.push({
       startTagOffset: byteToCharIndex(source, startTagOffsetBytes),
       endTagOffset: byteToCharIndex(source, endTagOffsetBytes),
       startTagLength: byteToCharIndex(source, startTagLengthBytes),
       endTagLength: byteToCharIndex(source, endTagLengthBytes),
-      transformedStart: byteToCharIndex(source, transformedStartBytes),
-      transformedEnd: byteToCharIndex(source, transformedEnd),
+      transformedStart: byteToCharIndex(contents, transformedStartBytes),
+      transformedEnd: byteToCharIndex(contents, transformedEnd),
     });
   }
 
-  segments.push(sourceBuffer.slice(sourceOffsetBytes).toString());
-
+  contents = contents.concat(sourceBuffer.subarray(sourceOffsetBytes).toString());
   return {
-    contents: segments.join(''),
+    contents,
     data: {
       templateLocations,
     },
@@ -73,7 +71,7 @@ export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, pat
 
 function byteToCharIndex(str: string, byteOffset: number): number {
   const buf = getBuffer(str);
-  return buf.slice(0, byteOffset).toString().length;
+  return buf.subarray(0, byteOffset).toString().length;
 }
 
 const BufferMap = new Map();

--- a/packages/environment-ember-template-imports/-private/environment/preprocess.ts
+++ b/packages/environment-ember-template-imports/-private/environment/preprocess.ts
@@ -43,10 +43,14 @@ export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, pat
       startTagOffsetBytes + startTagLengthBytes,
       endTagOffsetBytes,
     );
+    let templateContentSegmentString = templateContentSegment.toString();
+    let escapedTemplateContentSegment = templateContentSegmentString
+      .replaceAll('$', '\\$')
+      .replaceAll('`', '\\`');
+    deltaBytes += templateContentSegmentString.length - escapedTemplateContentSegment.length;
 
-    contents = contents.concat(templateContentSegment.toString());
+    contents = contents.concat(escapedTemplateContentSegment);
     contents = contents.concat(TEMPLATE_END);
-
     deltaBytes += endTagLengthBytes - TEMPLATE_END.length;
 
     sourceOffsetBytes = endTagOffsetBytes + endTagLengthBytes;

--- a/packages/environment-ember-template-imports/__tests__/transformation.test.ts
+++ b/packages/environment-ember-template-imports/__tests__/transformation.test.ts
@@ -45,6 +45,14 @@ describe('Environment: ETI', () => {
       `);
     });
 
+    test('handles the $ character', () => {
+      let source = '<template>${{dollarAmount}}</template>;';
+
+      let result = preprocess(source, 'index.gts');
+
+      expect(result.contents).toMatchInlineSnapshot(`"[___T\`\${{dollarAmount}}\`];"`);
+    });
+
     test('multiple templates', () => {
       let source = stripIndent`
         <template>
@@ -156,6 +164,14 @@ describe('Environment: ETI', () => {
 
       expect(sourceFile).toMatchInlineSnapshot();
       expect(meta).toMatchInlineSnapshot();
+    });
+
+    test('handles the $ character', () => {
+      let source = '<template>${{dollarAmount}}</template>;';
+
+      let { meta, sourceFile } = applyTransform(source);
+
+      expect(meta).toMatchInlineSnapshot(`Map {}`);
     });
 
     test('single template with satisfies', () => {

--- a/packages/environment-ember-template-imports/__tests__/transformation.test.ts
+++ b/packages/environment-ember-template-imports/__tests__/transformation.test.ts
@@ -27,6 +27,54 @@ describe('Environment: ETI', () => {
       });
     });
 
+    test('handles multi-byte characters', () => {
+      let source = [
+        `const a = <template>one 💩</template>;`,
+        `const b = <template>two</template>;`,
+        `const c = "‘foo’";`,
+        `const d = <template>four</template>;`,
+      ].join('\n');
+
+      let result = preprocess(source, 'index.gts');
+
+      expect(result.contents).toMatchInlineSnapshot(`
+        "const a = [___T\`one 💩\`];
+        const b = [___T\`two\`];
+        const c = "‘foo’";
+        const d = [___T\`four\`];"
+      `);
+      expect(result.data).toMatchInlineSnapshot(`
+        {
+          "templateLocations": [
+            {
+              "endTagLength": 11,
+              "endTagOffset": 26,
+              "startTagLength": 10,
+              "startTagOffset": 10,
+              "transformedEnd": 25,
+              "transformedStart": 10,
+            },
+            {
+              "endTagLength": 11,
+              "endTagOffset": 62,
+              "startTagLength": 10,
+              "startTagOffset": 49,
+              "transformedEnd": 47,
+              "transformedStart": 36,
+            },
+            {
+              "endTagLength": 11,
+              "endTagOffset": 118,
+              "startTagLength": 10,
+              "startTagOffset": 104,
+              "transformedEnd": 91,
+              "transformedStart": 82,
+            },
+          ],
+        }
+      `);
+    });
+
     test('multiple templates', () => {
       let source = stripIndent`
         <template>

--- a/packages/environment-ember-template-imports/__tests__/transformation.test.ts
+++ b/packages/environment-ember-template-imports/__tests__/transformation.test.ts
@@ -43,36 +43,6 @@ describe('Environment: ETI', () => {
         const c = "‘foo’";
         const d = [___T\`four\`];"
       `);
-      expect(result.data).toMatchInlineSnapshot(`
-        {
-          "templateLocations": [
-            {
-              "endTagLength": 11,
-              "endTagOffset": 26,
-              "startTagLength": 10,
-              "startTagOffset": 10,
-              "transformedEnd": 25,
-              "transformedStart": 10,
-            },
-            {
-              "endTagLength": 11,
-              "endTagOffset": 62,
-              "startTagLength": 10,
-              "startTagOffset": 49,
-              "transformedEnd": 47,
-              "transformedStart": 36,
-            },
-            {
-              "endTagLength": 11,
-              "endTagOffset": 118,
-              "startTagLength": 10,
-              "startTagOffset": 104,
-              "transformedEnd": 91,
-              "transformedStart": 82,
-            },
-          ],
-        }
-      `);
     });
 
     test('multiple templates', () => {
@@ -172,6 +142,20 @@ describe('Environment: ETI', () => {
           ],
         ]),
       );
+    });
+
+    test('handles multi-byte characters', () => {
+      let source = [
+        `const a = <template>one 💩</template>;`,
+        `const b = <template>two</template>;`,
+        `const c = "‘foo’";`,
+        `const d = <template>four</template>;`,
+      ].join('\n');
+
+      let { meta, sourceFile } = applyTransform(source);
+
+      expect(sourceFile).toMatchInlineSnapshot();
+      expect(meta).toMatchInlineSnapshot();
     });
 
     test('single template with satisfies', () => {

--- a/packages/environment-ember-template-imports/__tests__/transformation.test.ts
+++ b/packages/environment-ember-template-imports/__tests__/transformation.test.ts
@@ -50,7 +50,15 @@ describe('Environment: ETI', () => {
 
       let result = preprocess(source, 'index.gts');
 
-      expect(result.contents).toMatchInlineSnapshot(`"[___T\`\${{dollarAmount}}\`];"`);
+      expect(result.contents).toMatchInlineSnapshot('"[___T`\\${{dollarAmount}}`];"');
+    });
+
+    test('handles the ` character', () => {
+      let source = '<template>`code`</template>;';
+
+      let result = preprocess(source, 'index.gts');
+
+      expect(result.contents).toMatchInlineSnapshot('"[___T`\\`code\\``];"');
     });
 
     test('multiple templates', () => {
@@ -189,28 +197,6 @@ describe('Environment: ETI', () => {
           ],
         ]),
       );
-    });
-
-    test('handles multi-byte characters', () => {
-      let source = [
-        `const a = <template>one 💩</template>;`,
-        `const b = <template>two</template>;`,
-        `const c = "‘foo’";`,
-        `const d = <template>four</template>;`,
-      ].join('\n');
-
-      let { meta, sourceFile } = applyTransform(source);
-
-      expect(sourceFile).toMatchInlineSnapshot();
-      expect(meta).toMatchInlineSnapshot();
-    });
-
-    test('handles the $ character', () => {
-      let source = '<template>${{dollarAmount}}</template>;';
-
-      let { meta, sourceFile } = applyTransform(source);
-
-      expect(meta).toMatchInlineSnapshot(`Map {}`);
     });
 
     test('single template with satisfies', () => {

--- a/packages/environment-ember-template-imports/__tests__/transformation.test.ts
+++ b/packages/environment-ember-template-imports/__tests__/transformation.test.ts
@@ -101,6 +101,45 @@ describe('Environment: ETI', () => {
         ],
       });
     });
+
+    test('handles multi-byte characters', () => {
+      let source = stripIndent`
+        let a = <template></template>;
+        // ‘
+        let b = <template></template>;
+      `;
+
+      let transformed = stripIndent`
+        let a = [___T\`\`];
+        // ‘
+        let b = [___T\`\`];
+      `;
+
+      let result = preprocess(source, 'index.gts');
+
+      expect(result.contents).toEqual(transformed);
+
+      expect(result.data).toEqual({
+        templateLocations: [
+          {
+            startTagOffset: source.indexOf('<template>'),
+            startTagLength: '<template>'.length,
+            endTagOffset: source.indexOf('</template>'),
+            endTagLength: '</template>'.length,
+            transformedStart: transformed.indexOf('[___T'),
+            transformedEnd: transformed.indexOf(']') + 1,
+          },
+          {
+            startTagOffset: source.lastIndexOf('<template>'),
+            startTagLength: '<template>'.length,
+            endTagOffset: source.lastIndexOf('</template>'),
+            endTagLength: '</template>'.length,
+            transformedStart: transformed.lastIndexOf('[___T'),
+            transformedEnd: transformed.lastIndexOf(']') + 1,
+          },
+        ],
+      });
+    });
   });
 
   describe('transform', () => {


### PR DESCRIPTION
Summary of the issue: https://github.com/embroider-build/content-tag/issues/45
If folks need to do anything with content-tag in the future, there is this: https://github.com/NullVoxPopuli/content-tag-utils

Hoping to resolve:
- https://github.com/typed-ember/glint/issues/841
- https://github.com/typed-ember/glint/issues/840 (not a multi-byte issue, but "feels" similar)