### PR TITLE
Loose mode: only parse .ts in `components/` folder

### DIFF
--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -47,7 +47,6 @@ export function createEmberLanguagePlugin<T extends URI | string>(
         hasEmberLoose &&
         languageId === 'typescript' &&
         !scriptIdStr.endsWith('.d.ts') &&
-
         // only support component .ts files somewhere within in a `components/` folder.
         // This should cover 99% of cases while eliminating the pointless parsing of
         // a large number of non-component .ts files.

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -47,6 +47,11 @@ export function createEmberLanguagePlugin<T extends URI | string>(
         hasEmberLoose &&
         languageId === 'typescript' &&
         !scriptIdStr.endsWith('.d.ts') &&
+
+        // only support component .ts files somewhere within in a `components/` folder.
+        // This should cover 99% of cases while eliminating the pointless parsing of
+        // a large number of non-component .ts files.
+        scriptIdStr.indexOf('/components/') >= 0 &&
         scriptIdStr.indexOf('/node_modules/') < 0
       ) {
         // NOTE: scriptId might not be a path when we convert this plugin:


### PR DESCRIPTION
Implement the perf optimization described here: https://github.com/typed-ember/glint/pull/851#issuecomment-2754636712

TL;DR minimize the parsing of non-loose-mode component .ts files by assuming that loose mode component .ts files are only going to be present in a `components/` folder, which is probably true for 99% of cases.