### PR TITLE
Setup external project linking / testing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     {
       "files": ["*.js", "*.cjs", "*.mjs"],
       "env": {
+        "es6": true,
         "node": true
       }
     },

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pnpm-debug.log
 *.tsbuildinfo
 *.js.map
 tsserver.log
+dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,18 @@ Sometimes it is useful to see the IR of any .hbs template or .gts/.gjs file for 
 
 Your template code will be replaced by the IR directly in your editor window.
 
+## How to link all the packages to an external project?
+
+Set up the links for all the `@glint/*` packages:
+
+1. `pnpm install`
+2. `pnpm build`
+3. `pnpm link:build`
+
+Then in your project that you want to test out local copies of `@glint/*` in:
+
+1. cd to your project
+2. `node ../path/to/glint/bin/link-install.mjs`
+
+The local copies of `@glint/*` packages will now be installed in your external project.
+

--- a/bin/link-build.mjs
+++ b/bin/link-build.mjs
@@ -76,7 +76,7 @@ const unpack = pkgs.map(async (pkg) => {
 await Promise.all(unpack);
 
 const packageJson = `{
-  "name": "glimmer-vm",
+  "name": "glint-monorepo-built",
   "private": true,
   "overrides": {
 ${pkgs.map((pkg) => `    "${pkg.name}": "workspace:*"`).join(',\n')}

--- a/bin/link-build.mjs
+++ b/bin/link-build.mjs
@@ -1,0 +1,119 @@
+import { writeFileSync } from 'node:fs';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import chalk from 'chalk';
+import { execa } from 'execa';
+import { mkdirp } from 'mkdirp';
+import { rimraf } from 'rimraf';
+import { x as untar } from 'tar';
+
+import { packages } from './packages.mjs';
+
+const dist = new URL('../dist', import.meta.url).pathname;
+const pkgs = packages('@glint');
+
+await mkdirp(dist);
+await rimraf(dist + '/*.tgz', { glob: true });
+
+const pack = pkgs.map(async (pkg) => {
+  try {
+    await execa('pnpm', ['pack', '--pack-destination', dist], {
+      cwd: pkg.path,
+    });
+
+    console.log(chalk.green(`Successfully packed ${pkg.name}`));
+  } catch (error) {
+    let message = `Failed to pack ${pkg.name}`;
+
+    if (error instanceof Error) {
+      message += `\n\n${error.stack}`;
+    }
+
+    throw new Error(message);
+  }
+});
+
+await Promise.all(pack);
+
+const unpack = pkgs.map(async (pkg) => {
+  try {
+    const pkgDest = join(dist, pkg.name);
+
+    await mkdirp(pkgDest);
+    await rimraf(pkgDest + '/**/*');
+
+    const tarball = join(dist, pkg.name.replace('@', '').replace('/', '-') + `-${pkg.version}.tgz`);
+
+    await untar({
+      file: tarball,
+      strip: 1,
+      cwd: pkgDest,
+    });
+
+    await unlink(tarball);
+
+    // https://github.com/pnpm/pnpm/issues/881
+    const packageJsonPath = join(pkgDest, 'package.json');
+    const packageJson = JSON.parse(await readFile(packageJsonPath, { encoding: 'utf8' }));
+    delete packageJson.devDependencies;
+    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), {
+      encoding: 'utf8',
+    });
+
+    console.log(chalk.green(`Successfully unpacked ${pkg.name}`));
+  } catch (error) {
+    let message = `Failed to unpack ${pkg.name}`;
+
+    if (error instanceof Error) {
+      message += `\n\n${error.stack}`;
+    }
+
+    throw new Error(message);
+  }
+});
+
+await Promise.all(unpack);
+
+const packageJson = `{
+  "name": "glimmer-vm",
+  "private": true,
+  "overrides": {
+${pkgs.map((pkg) => `    "${pkg.name}": "workspace:*"`).join(',\n')}
+  }
+}
+`;
+
+const workspaceYaml = 'packages:\n' + pkgs.map((pkg) => `  - '${pkg.name}'\n`).join('');
+
+await writeFile(join(dist, 'package.json'), packageJson, { encoding: 'utf8' });
+await writeFile(join(dist, 'pnpm-workspace.yaml'), workspaceYaml, { encoding: 'utf8' });
+
+await execa('pnpm', ['install'], {
+  cwd: dist,
+  stdio: 'inherit',
+});
+
+console.log(chalk.green(`Successfully installed packages`));
+
+// Seems like there are race conditions in pnpm if we try to do these concurrently
+for (const pkg of pkgs) {
+  try {
+    const pkgDest = join(dist, pkg.name);
+
+    await execa('pnpm', ['link', '--global'], {
+      cwd: pkgDest,
+      stdio: 'inherit'
+    });
+
+    console.log(chalk.green(`Successfully linked ${pkg.name}`));
+  } catch (error) {
+    let message = `Failed to link ${pkg.name}`;
+
+    if (error instanceof Error) {
+      message += `\n\n${error.stack}`;
+    }
+
+    throw new Error(message);
+  }
+}

--- a/bin/link-build.mjs
+++ b/bin/link-build.mjs
@@ -103,7 +103,7 @@ for (const pkg of pkgs) {
 
     await execa('pnpm', ['link', '--global'], {
       cwd: pkgDest,
-      stdio: 'inherit'
+      stdio: 'inherit',
     });
 
     console.log(chalk.green(`Successfully linked ${pkg.name}`));

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import execa from 'execa';
+import glob from 'glob';
+
+const rootDir = new URL('..', import.meta.url).pathname;
+
+const packageJsonPaths = glob.sync('**/package.json', {
+  cwd: rootDir,
+  ignore: '**/node_modules/**',
+});
+
+function shouldLink(dep) {
+  return (
+    dep.startsWith('@glint/') 
+  );
+}
+
+const link = packageJsonPaths.map(async (packageJsonPath) => {
+  const packagePath = path.dirname(packageJsonPath);
+
+  try {
+    const packageJson = JSON.parse(await readFileSync(packageJsonPath, { encoding: 'utf8' }));
+
+    for (const [dep] of Object.entries(packageJson.dependencies ?? {})) {
+      if (shouldLink(dep)) {
+        // eslint-disable-next-line no-console
+        console.log(`Linking ${chalk.yellow(dep)} from ${chalk.grey(packagePath)}`);
+        await execa('pnpm', ['link', '--global', dep], { cwd: packagePath });
+      }
+    }
+  } catch (error) {
+    let message = `Failed to link ${packagePath}`;
+
+    if (error instanceof Error) {
+      message += `\n\n${error.stack}`;
+    }
+
+    throw new Error(message);
+  }
+});
+
+await Promise.all(link);

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -12,9 +12,7 @@ const packageJsonPaths = glob.sync('**/package.json', {
 });
 
 function shouldLink(dep) {
-  return (
-    dep.startsWith('@glint/') 
-  );
+  return dep.startsWith('@glint/');
 }
 
 const link = packageJsonPaths.map(async (packageJsonPath) => {

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -27,8 +27,6 @@ function shouldLink(dep) {
   return dep.startsWith('@glint/');
 }
 
-console.log({ packageJsonPaths });
-
 const link = packageJsonPaths.map(async (packageJsonPath) => {
   const packagePath = path.dirname(packageJsonPath);
 

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -33,14 +33,17 @@ const link = packageJsonPaths.map(async (packageJsonPath) => {
   try {
     const packageJson = JSON.parse(await readFileSync(packageJsonPath, { encoding: 'utf8' }));
 
-    console.log(`Gathering packages from ${chalk.gray(rootDir)}`);
+    const friendlyCWD = CWD.replace(process.env.HOME, '~');
+    const friendlyRoot = rootDir.replace(process.env.HOME, '~');
+    console.log(`Gathering packages from ${chalk.gray(friendlyRoot)}`);
+
     for (const [dep] of [
       ...Object.entries(packageJson.dependencies ?? {}),
       ...Object.entries(packageJson.devDependencies ?? {}),
     ]) {
       if (shouldLink(dep)) {
         // eslint-disable-next-line no-console
-        console.log(`Linking ${chalk.yellow(dep)} within ${chalk.grey(CWD)}`);
+        console.log(`Linking ${chalk.yellow(dep)} within ${chalk.grey(friendlyCWD)}`);
         await execa('pnpm', ['link', '--global', dep], { cwd: packagePath });
       }
     }

--- a/bin/packages.mjs
+++ b/bin/packages.mjs
@@ -11,6 +11,6 @@ export function packages(namespace) {
   return JSON.parse(
     execSync(`pnpm ls -r --depth -1 --filter "${namespace}/*" --json`, {
       encoding: 'utf-8',
-    })
-  ).filter(x => !x.private);
+    }),
+  ).filter((x) => !x.private);
 }

--- a/bin/packages.mjs
+++ b/bin/packages.mjs
@@ -1,0 +1,16 @@
+import { execSync } from 'node:child_process';
+
+// export interface Package {
+//   readonly name: string;
+//   readonly version: string;
+//   readonly path: string;
+//   readonly private: boolean;
+// }
+
+export function packages(namespace) {
+  return JSON.parse(
+    execSync(`pnpm ls -r --depth -1 --filter "${namespace}/*" --json`, {
+      encoding: 'utf-8',
+    })
+  ).filter(x => !x.private);
+}

--- a/package.json
+++ b/package.json
@@ -30,12 +30,18 @@
     "test:typecheck": "pnpm --filter '*' run test:typecheck"
   },
   "devDependencies": {
+    "chalk": "^5.4.1",
+    "execa": "^9.5.2",
+    "mkdirp": "^3.0.1",
+    "rimraf": "^6.0.1",
+    "tar": "^7.4.3",
     "@glimmer/component": "^2.0.0",
     "@glint/tsserver-plugin": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "eslint": "^8.27.0",
     "glint-monorepo-test-utils": "workspace:*",
+    "glob": "^10.2.4",
     "prettier": "^3.3.2",
     "release-plan": "^0.16.0",
     "typescript": ">=5.6.0"
@@ -62,12 +68,5 @@
     "@glimmer/validator": "Newer versions of @glimmer/* are ESM-only, and Glint is compiled to CJS, so newer versions of @glimmer/* are not compatible",
     "@types/yargs": "Locking temporarily to avoid an issue with the ESM types in 17.0.14; see DT#63373",
     "@types/node": "Locking to avoid conflicts between the declared version in packages/core and floating '*' versions when we run in CI without the lockfile"
-  },
-  "dependencies": {
-    "chalk": "^5.4.1",
-    "execa": "^9.5.2",
-    "mkdirp": "^3.0.1",
-    "rimraf": "^6.0.1",
-    "tar": "^7.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "format": "prettier --write .",
+    "link:build": "node ./bin/link-build.mjs",
+    "link:install": "node ./bin/link-install.mjs",
     "lint": "pnpm lint:scripts && pnpm lint:formatting",
     "lint:fix": "pnpm lint:scripts --fix && pnpm format",
     "lint:formatting": "pnpm prettier --check .",
@@ -60,5 +62,12 @@
     "@glimmer/validator": "Newer versions of @glimmer/* are ESM-only, and Glint is compiled to CJS, so newer versions of @glimmer/* are not compatible",
     "@types/yargs": "Locking temporarily to avoid an issue with the ESM types in 17.0.14; see DT#63373",
     "@types/node": "Locking to avoid conflicts between the declared version in packages/core and floating '*' versions when we run in CI without the lockfile"
+  },
+  "dependencies": {
+    "chalk": "^5.4.1",
+    "execa": "^9.5.2",
+    "mkdirp": "^3.0.1",
+    "rimraf": "^6.0.1",
+    "tar": "^7.4.3"
   }
 }

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -30,8 +30,8 @@
   ],
   "peerDependencies": {
     "@glimmer/component": ">=1.1.2",
-    "@glint/core": "workspace:*",
-    "@glint/template": "workspace:*",
+    "@glint/core": "*",
+    "@glint/template": "*",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-modifier": "^3.2.7 || ^4.0.0"
   },

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -32,9 +32,9 @@
     "content-tag": "^3.1.2"
   },
   "peerDependencies": {
-    "@glint/core": "workspace:*",
-    "@glint/environment-ember-loose": "workspace:*",
-    "@glint/template": "workspace:*"
+    "@glint/core": "*",
+    "@glint/environment-ember-loose": "*",
+    "@glint/template": "*"
   },
   "devDependencies": {
     "@glint/core": "workspace:*",

--- a/packages/type-test/package.json
+++ b/packages/type-test/package.json
@@ -23,7 +23,7 @@
     "expect-type": "^0.15.0"
   },
   "peerDependencies": {
-    "@glint/template": "^1.4.0"
+    "@glint/template": "*"
   },
   "devDependencies": {
     "@glint/template": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,22 @@ settings:
 importers:
 
   .:
+    dependencies:
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
+      execa:
+        specifier: ^9.5.2
+        version: 9.5.2
+      mkdirp:
+        specifier: ^3.0.1
+        version: 3.0.1
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      tar:
+        specifier: ^7.4.3
+        version: 7.4.3
     devDependencies:
       '@glimmer/component':
         specifier: ^2.0.0
@@ -1954,6 +1970,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3329,6 +3349,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -4901,6 +4925,11 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  glob@11.0.1:
+    resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -5522,6 +5551,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.1.0:
+    resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
+    engines: {node: 20 || >=22}
+
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5869,6 +5902,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -6007,6 +6044,10 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -6070,6 +6111,10 @@ packages:
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
+
+  minizlib@3.0.1:
+    resolution: {integrity: sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==}
+    engines: {node: '>= 18'}
 
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
@@ -6539,6 +6584,10 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
+
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
@@ -7001,6 +7050,15 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
+  rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   rollup-pluginutils@2.8.2:
@@ -7550,6 +7608,10 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -8193,6 +8255,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yam@1.0.0:
     resolution: {integrity: sha512-Hv9xxHtsJ9228wNhk03xnlDReUuWVvHwM4rIbjdAXYvHLs17xjuyF50N6XXFMN6N0omBaqgOok/MCK3At9fTAg==}
@@ -9781,6 +9847,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
 
   '@jest/expect-utils@29.7.0':
     dependencies:
@@ -11646,6 +11716,8 @@ snapshots:
     optional: true
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -14148,6 +14220,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.0.1:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.0
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
   glob@5.0.15:
     dependencies:
       inflight: 1.0.6
@@ -14797,6 +14878,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.1.0:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -15176,6 +15261,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.1.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -15347,6 +15434,10 @@ snapshots:
       tapable: 2.2.1
       webpack: 5.98.0
 
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -15410,6 +15501,11 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+
+  minizlib@3.0.1:
+    dependencies:
+      minipass: 7.1.2
+      rimraf: 5.0.10
 
   mixin-deep@1.3.2:
     dependencies:
@@ -15901,6 +15997,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
+
   path-to-regexp@0.1.12: {}
 
   path-type@3.0.0:
@@ -16380,6 +16481,15 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.4.5
+
+  rimraf@6.0.1:
+    dependencies:
+      glob: 11.0.1
+      package-json-from-dist: 1.0.1
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -17077,6 +17187,15 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.1
+      mkdirp: 3.0.1
+      yallist: 5.0.0
 
   temp@0.9.4:
     dependencies:
@@ -17935,6 +18054,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yam@1.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,22 +8,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      chalk:
-        specifier: ^5.4.1
-        version: 5.4.1
-      execa:
-        specifier: ^9.5.2
-        version: 9.5.2
-      mkdirp:
-        specifier: ^3.0.1
-        version: 3.0.1
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
-      tar:
-        specifier: ^7.4.3
-        version: 7.4.3
     devDependencies:
       '@glimmer/component':
         specifier: ^2.0.0
@@ -37,18 +21,36 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.42.1
         version: 5.62.0(eslint@8.57.1)(typescript@5.8.2)
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
       eslint:
         specifier: ^8.27.0
         version: 8.57.1
+      execa:
+        specifier: ^9.5.2
+        version: 9.5.2
       glint-monorepo-test-utils:
         specifier: workspace:*
         version: link:test-packages/test-utils
+      glob:
+        specifier: ^10.2.4
+        version: 10.4.5
+      mkdirp:
+        specifier: ^3.0.1
+        version: 3.0.1
       prettier:
         specifier: ^3.3.2
         version: 3.5.3
       release-plan:
         specifier: ^0.16.0
         version: 0.16.0
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      tar:
+        specifier: ^7.4.3
+        version: 7.4.3
       typescript:
         specifier: '>=5.6.0'
         version: 5.8.2
@@ -1918,8 +1920,8 @@ packages:
     resolution: {directory: packages/environment-ember-loose, type: directory}
     peerDependencies:
       '@glimmer/component': '>=1.1.2'
-      '@glint/core': workspace:*
-      '@glint/template': workspace:*
+      '@glint/core': '*'
+      '@glint/template': '*'
       ember-cli-htmlbars: ^6.0.1
       ember-modifier: ^3.2.7 || ^4.0.0
     peerDependenciesMeta:
@@ -1931,9 +1933,9 @@ packages:
   '@glint/environment-ember-template-imports@file:packages/environment-ember-template-imports':
     resolution: {directory: packages/environment-ember-template-imports, type: directory}
     peerDependencies:
-      '@glint/core': workspace:*
-      '@glint/environment-ember-loose': workspace:*
-      '@glint/template': workspace:*
+      '@glint/core': '*'
+      '@glint/environment-ember-loose': '*'
+      '@glint/template': '*'
 
   '@glint/template@file:packages/template':
     resolution: {directory: packages/template, type: directory}


### PR DESCRIPTION
This is the same process that glimmer-vm uses to link up with ember-source

Example:
```bash
turborepo-summary-analyzer on  trial-glint-main [+]

  origin  git@github.com:NullVoxPopuli/turborepo-summary-analyzer.git
took 3s
❯ node ../../OpenSource/glint/bin/link-install.mjs
{ packageJsonPaths: [ 'package.json' ] }
Gathering packages from 🏠/Development/OpenSource/glint/
Linking @glint/core within <repo>
Linking @glint/environment-ember-loose within <repo>
Linking @glint/environment-ember-template-imports within <repo>
Linking @glint/template within <repo>
Linking @glint/tsserver-plugin within <repo>
```

Without my terminal sanitizer: 

![image](https://github.com/user-attachments/assets/a1981d23-f9ea-4d0d-912d-66b57b30542d)
