### PR TITLE
Disable esModuleInterop to restore VSCode monkeypatching

### DIFF
--- a/tsconfig.compileroptions.json
+++ b/tsconfig.compileroptions.json
@@ -20,7 +20,7 @@
 
     // new
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
 
     "types": []
   }

--- a/tsconfig.compileroptions.json
+++ b/tsconfig.compileroptions.json
@@ -20,7 +20,7 @@
 
     // new
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
 
     "types": []
   }

--- a/tsconfig.compileroptions.json
+++ b/tsconfig.compileroptions.json
@@ -20,7 +20,11 @@
 
     // new
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+
+    // esModuleInterop needs to be false so that the fs.readFileSync monkeypatch in vscode/src/extension.ts
+    // continues to work (setting esModuleInterop to true will wrap require() in __importStar
+    // which breaks the monkeypatch)
+    "esModuleInterop": false,
 
     "types": []
   }


### PR DESCRIPTION
1. Restore value to esModuleInterop=false so that `fs.readFileSync = ...` monkeypatch continues to work (with esModuleInterop=true, `fs = require(...)` becomes `fs = _importStar(require(...)` and you end up getting a "setting read-only property" error)
2. Remove the try catch wrapping to surface these issues in our test suite (and in the wild as more people start trying out the alpha)

I don't know exactly which specific features this restores; it didn't fix the auto-complete issues I'm seeing but I believe some cases of "Go to Definition" with .gts files have been fixed.