### PR TITLE
Use the tars directly, rather than links

### DIFF
--- a/bin/link-build.mjs
+++ b/bin/link-build.mjs
@@ -1,12 +1,7 @@
-import { writeFileSync } from 'node:fs';
-import { readFile, unlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
-
 import chalk from 'chalk';
 import { execa } from 'execa';
 import { mkdirp } from 'mkdirp';
 import { rimraf } from 'rimraf';
-import { x as untar } from 'tar';
 
 import { packages } from './packages.mjs';
 
@@ -36,84 +31,6 @@ const pack = pkgs.map(async (pkg) => {
 
 await Promise.all(pack);
 
-const unpack = pkgs.map(async (pkg) => {
-  try {
-    const pkgDest = join(dist, pkg.name);
-
-    await mkdirp(pkgDest);
-    await rimraf(pkgDest + '/**/*');
-
-    const tarball = join(dist, pkg.name.replace('@', '').replace('/', '-') + `-${pkg.version}.tgz`);
-
-    await untar({
-      file: tarball,
-      strip: 1,
-      cwd: pkgDest,
-    });
-
-    await unlink(tarball);
-
-    // https://github.com/pnpm/pnpm/issues/881
-    const packageJsonPath = join(pkgDest, 'package.json');
-    const packageJson = JSON.parse(await readFile(packageJsonPath, { encoding: 'utf8' }));
-    delete packageJson.devDependencies;
-    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), {
-      encoding: 'utf8',
-    });
-
-    console.log(chalk.green(`Successfully unpacked ${pkg.name}`));
-  } catch (error) {
-    let message = `Failed to unpack ${pkg.name}`;
-
-    if (error instanceof Error) {
-      message += `\n\n${error.stack}`;
-    }
-
-    throw new Error(message);
-  }
-});
-
-await Promise.all(unpack);
-
-const packageJson = `{
-  "name": "glint-monorepo-built",
-  "private": true,
-  "overrides": {
-${pkgs.map((pkg) => `    "${pkg.name}": "workspace:*"`).join(',\n')}
-  }
-}
-`;
-
-const workspaceYaml = 'packages:\n' + pkgs.map((pkg) => `  - '${pkg.name}'\n`).join('');
-
-await writeFile(join(dist, 'package.json'), packageJson, { encoding: 'utf8' });
-await writeFile(join(dist, 'pnpm-workspace.yaml'), workspaceYaml, { encoding: 'utf8' });
-
-await execa('pnpm', ['install'], {
-  cwd: dist,
-  stdio: 'inherit',
-});
-
-console.log(chalk.green(`Successfully installed packages`));
-
-// Seems like there are race conditions in pnpm if we try to do these concurrently
-for (const pkg of pkgs) {
-  try {
-    const pkgDest = join(dist, pkg.name);
-
-    await execa('pnpm', ['link', '--global'], {
-      cwd: pkgDest,
-      stdio: 'inherit',
-    });
-
-    console.log(chalk.green(`Successfully linked ${pkg.name}`));
-  } catch (error) {
-    let message = `Failed to link ${pkg.name}`;
-
-    if (error instanceof Error) {
-      message += `\n\n${error.stack}`;
-    }
-
-    throw new Error(message);
-  }
-}
+console.log(
+  chalk.green(`Successfully packed all packages. Ready for linking in external project.`),
+);

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -1,7 +1,6 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
-import { execa } from 'execa';
 import { glob } from 'glob';
 import assert from 'node:assert';
 

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
 import { execa } from 'execa';
@@ -6,8 +6,10 @@ import { glob } from 'glob';
 import assert from 'node:assert';
 
 const rootDir = new URL('..', import.meta.url).pathname;
-
 const CWD = process.cwd();
+
+const friendlyCWD = CWD.replace(process.env.HOME, '~');
+const friendlyRoot = rootDir.replace(process.env.HOME, '~');
 
 assert(
   CWD !== rootDir,
@@ -27,14 +29,18 @@ function shouldLink(dep) {
   return dep.startsWith('@glint/');
 }
 
+const tars = glob.sync('*.tgz', {
+  cwd: path.join(rootDir, 'dist'),
+});
+
+console.log(tars);
+
 const link = packageJsonPaths.map(async (packageJsonPath) => {
   const packagePath = path.dirname(packageJsonPath);
 
   try {
     const packageJson = JSON.parse(await readFileSync(packageJsonPath, { encoding: 'utf8' }));
 
-    const friendlyCWD = CWD.replace(process.env.HOME, '~');
-    const friendlyRoot = rootDir.replace(process.env.HOME, '~');
     console.log(`Gathering packages from ${chalk.gray(friendlyRoot)}`);
 
     for (const [dep] of [
@@ -42,11 +48,29 @@ const link = packageJsonPaths.map(async (packageJsonPath) => {
       ...Object.entries(packageJson.devDependencies ?? {}),
     ]) {
       if (shouldLink(dep)) {
+        let tarified = dep.replace('@', '').replace('/', '-');
+        let tar = tars.find((x) => x.startsWith(tarified));
+
+        if (!tar) {
+          console.warn(`Could not find mapping to ${dep} from ${packagePath} using ${tarified}`);
+          continue;
+        }
+
+        let tarPath = path.join(rootDir, 'dist', tar);
+        let relativeTarPath = path.relative(packagePath, tarPath);
+
         // eslint-disable-next-line no-console
-        console.log(`Linking ${chalk.yellow(dep)} within ${chalk.grey(friendlyCWD)}`);
-        await execa('pnpm', ['link', '--global', dep], { cwd: packagePath });
+        console.log(
+          `Linking ${chalk.yellow(dep)} within ${chalk.grey(friendlyCWD)} to ${chalk.green(relativeTarPath)}`,
+        );
+
+        packageJson.pnpm ||= {};
+        packageJson.pnpm.overrides ||= {};
+        Object.assign(packageJson.pnpm.overrides, {});
       }
     }
+
+    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
   } catch (error) {
     let message = `Failed to link ${packagePath}`;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "execa": "^9.5.2",
     "mkdirp": "^3.0.1",
     "rimraf": "^6.0.1",
-    "tar": "^7.4.3",
     "@glimmer/component": "^2.0.0",
     "@glint/tsserver-plugin": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
-      tar:
-        specifier: ^7.4.3
-        version: 7.4.3
       typescript:
         specifier: '>=5.6.0'
         version: 5.8.2
@@ -1972,10 +1969,6 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3351,10 +3344,6 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -6114,10 +6103,6 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
-  minizlib@3.0.1:
-    resolution: {integrity: sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==}
-    engines: {node: '>= 18'}
-
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
@@ -7054,10 +7039,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
-
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
     engines: {node: 20 || >=22}
@@ -7610,10 +7591,6 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-
-  tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
-    engines: {node: '>=18'}
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
@@ -8257,10 +8234,6 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
 
   yam@1.0.0:
     resolution: {integrity: sha512-Hv9xxHtsJ9228wNhk03xnlDReUuWVvHwM4rIbjdAXYvHLs17xjuyF50N6XXFMN6N0omBaqgOok/MCK3At9fTAg==}
@@ -9849,10 +9822,6 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.2
 
   '@jest/expect-utils@29.7.0':
     dependencies:
@@ -11718,8 +11687,6 @@ snapshots:
     optional: true
 
   chownr@2.0.0: {}
-
-  chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -15504,11 +15471,6 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  minizlib@3.0.1:
-    dependencies:
-      minipass: 7.1.2
-      rimraf: 5.0.10
-
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
@@ -16484,10 +16446,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.4.5
-
   rimraf@6.0.1:
     dependencies:
       glob: 11.0.1
@@ -17189,15 +17147,6 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
-
-  tar@7.4.3:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.0.1
-      mkdirp: 3.0.1
-      yallist: 5.0.0
 
   temp@0.9.4:
     dependencies:
@@ -18056,8 +18005,6 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
-
-  yallist@5.0.0: {}
 
   yam@1.0.0:
     dependencies:


### PR DESCRIPTION
Seems easier to use tars instead of actual links.

This technique should also be compatible with folks using volta, since volta doesn't allow using `pnpm add -g`

(I use proto, tho)