### PR TITLE
Prefer variables in scope over global variables

### DIFF
--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -574,10 +574,10 @@ export function templateToTypescript(
     function treatAsGlobal(name: string): boolean {
       if (globals) {
         // If we have a known set of global identifiers, we should only treat
-        // members of that set as global and assume everything else is local.
-        // This is typically true in environments that capture scope, like
-        // strict-mode Ember.
-        return globals.includes(name);
+        // members of that set as global, unless the identifier is in scope,
+        // and assume everything else is local. This is typically true in
+        // environments that capture scope, like strict-mode Ember.
+        return globals.includes(name) && !scope.hasBinding(name);
       } else {
         // Otherwise, we assume everything is global unless we can see it
         // in scope as a block variable. This is the case in resolver-based

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -1491,4 +1491,26 @@ describe('Transform: rewriteTemplate', () => {
       ]);
     });
   });
+
+  describe('global variables', () => {
+    test('uses vaariable in scope over global variable', () => {
+      let template = `
+        {{action "action"}}
+        {{#each actions as |action|}}
+          {{action}}
+        {{/each}}`;
+
+      expect(templateBody(template, { globals: ['action'] })).toMatchInlineSnapshot(`
+        "__glintDSL__.emitContent(__glintDSL__.resolve(__glintDSL__.Globals["action"])("action"));
+        {
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(each)(actions));
+        {
+        const [action] = __glintY__.blockParams["default"];
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(action)());
+        }
+        each;
+        }"
+      `);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #864 

Seems like there is an edge case with `action` helper, unsure if we should treat it as a bug in Ember or add an edge case for it in the `treatGlobal` check.

Ref: https://github.com/typed-ember/glint/issues/864#issuecomment-2764530407