### PR TITLE
Remove `export default` from the Template-only components example

### DIFF
--- a/docs/ember/template-imports.md
+++ b/docs/ember/template-imports.md
@@ -69,7 +69,7 @@ interface ShoutSignature {
 
 const louderPlease = (message: string) => message.toUpperCase();
 
-export default <template>
+<template>
     <div ...attributes>
         {{yield (louderPlease @message)}}
     </div>


### PR DESCRIPTION
Follow-up to https://github.com/typed-ember/glint/pull/821

The bug that prevented this from working in apps has been fixed: https://github.com/embroider-build/content-tag/pull/97