### PR TITLE
Disregard semantic classification tokens from `<template>` portions of .gts files

### DIFF
--- a/packages/core/src/transform/template/map-template-contents.ts
+++ b/packages/core/src/transform/template/map-template-contents.ts
@@ -232,7 +232,12 @@ export function mapTemplateContents(
           hbsRange,
           mappings,
           source,
-          codeFeaturesForNode ?? codeFeaturesProxy.all,
+
+          // Prevent TS's semantic classifications (used for semantic highlighting, see
+          // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide) from being
+          // source-mapped back to the glimmer template. These might be useful to reinstate at some
+          // point in the future but by default tends to make the highlighting in gts files look wrong.
+          codeFeaturesForNode ?? codeFeaturesProxy.withoutHighlight,
         ),
       );
       segmentsStack[0].push(...segments);

--- a/packages/core/src/volar/language-server.ts
+++ b/packages/core/src/volar/language-server.ts
@@ -75,6 +75,8 @@ connection.onInitialize((params) => {
             return ls;
           }
         }
+        // TODO: this branch is hit when running Volar Labs and currently breaks. Figure out
+        // how to reinstate a "simple" LS without a tsconfig.
         return (simpleLs ??= createLs(server, undefined));
       },
       getExistingLanguageServices() {

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -100,8 +100,11 @@ function proxyLanguageServiceForGlint<T>(
       // case 'getDefinitionAndBoundSpan': return getDefinitionAndBoundSpan(ts, language, languageService, glintOptions, asScriptId, target[p]);
       // case 'getQuickInfoAtPosition': return getQuickInfoAtPosition(ts, target, target[p]);
       // TS plugin only
-      case 'getEncodedSemanticClassifications':
-        return getEncodedSemanticClassifications(ts, language, target, asScriptId, target[p]);
+
+      // Left as an example in case we want to augment semantic classification in .gts files.
+      // e.g. Vue does this to semantically classify Component names as `class` tokens.
+      // case 'getEncodedSemanticClassifications':
+      //   return getEncodedSemanticClassifications(ts, language, target, asScriptId, target[p]);
 
       case 'getSemanticDiagnostics':
         return getSemanticDiagnostics(ts, language, languageService, asScriptId, target[p]);
@@ -210,7 +213,6 @@ const windowsPathReg = /\\/g;
 /**
  * Return semantic tokens for semantic highlighting:
  * https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide
- */
 function getEncodedSemanticClassifications<T>(
   ts: typeof import('typescript'),
   language: any, // Language<T>,
@@ -224,27 +226,18 @@ function getEncodedSemanticClassifications<T>(
     const sourceScript = language.scripts.get(asScriptId(fileName));
     const root = sourceScript?.generated?.root;
     if (root instanceof VirtualGtsCode) {
-      result.spans = [];
+      // This would remove all semantic highlighting from .gts files, including the TS parts
+      // outside of the `<template>` tags, which is probably undesirable.
+      // result.spans = [];
 
-    //   const { template } = root.sfc;
-    //   if (template) {
-    //     for (const componentSpan of getComponentSpans.call(
-    //       { typescript: ts, languageService },
-    //       root,
-    //       template,
-    //       {
-    //         start: span.start - template.startTagEnd,
-    //         length: span.length,
-    //       },
-    //     )) {
-    //       result.spans.push(
-    //         componentSpan.start + template.startTagEnd,
-    //         componentSpan.length,
-    //         256, // class
-    //       );
-    //     }
-    //   }
+      // We can push span to the end of the array to override previous entries.
+      // result.spans.push(
+      //   0,
+      //   100,
+      //   256, // class
+      // );
     }
     return result;
   };
 }
+ */


### PR DESCRIPTION
Closes #835

The solution here is to classify the spans/mappings for the generated TS representing code within `<template>` regions as `shouldHightlight=false`. This tells volar to NOT reverse-source-map the classification tokens generated by vanilla TS when parsing the generated TS representation of .gts files.

This has the desired effect of preserving the tokens for the outer TS regions of the .gts file while ignoring the tokens for the templates. It may be desirable at some point in the future to see see how the default classifications for the template portion can be "fixed", but I don't have a sense for how difficult this might be. I suspect the reason the default classifications looking "wrong" is due to some of the constructs used for getting the type-checking aspect of Glint working correctly, e.g. in some cases we might use something like `__glintDSL.resolve('fooBar')` to represent `{{this.fooBar}}` (this is not totally accurate, just an example); this might work really well for the purposes of generating useful diagnostics that can be source-mapped back to .gts, but when doing semantic classification,  TS will classify this as a string argument to a function when really it's a simple property lookup on `this`.