### PR TITLE
Breaking test for SVG

### DIFF
--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -636,4 +636,29 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
       ]
     `);
   });
+
+  test('svg does not produce false positives', async () => {
+    const code = stripIndent`
+    import Component from '@glimmer/component';
+
+    export default class MyComponent {
+      <template>
+        <svg version="1.1"
+            width="300" height="200"
+            xmlns="http://www.w3.org/2000/svg">
+
+          <rect width="100%" height="100%" fill="red" class="foo" />
+        </svg>
+      </template>
+    }
+  `;
+
+    const diagnostics = await requestDiagnostics(
+      'ts-template-imports-app/src/ephemeral-index.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(0);
+  });
 });


### PR DESCRIPTION
Issue reported in Discord that SVG is yielding incorrect diagnostics for attributes like `class`.

https://discord.com/channels/480462759797063690/1357364002258424059/1357394721999425748

@patricklx you did work on this stuff recently, do you see an obvious fix?

Undesired diagnostics from this breaking test:

```
[
        {
          "category": "error",
          "code": 2353,
          "end": {
            "line": 7,
            "offset": 14,
          },
          "start": {
            "line": 7,
            "offset": 9,
          },
          "text": "Object literal may only specify known properties, and 'xmlns' does not exist in type 'Partial<WithDataAttributes<SVGSVGElementAttributes>>'.",
        },
        {
          "category": "error",
          "code": 2353,
          "end": {
            "line": 9,
            "offset": 56,
          },
          "start": {
            "line": 9,
            "offset": 51,
          },
          "text": "Object literal may only specify known properties, and 'class' does not exist in type 'Partial<WithDataAttributes<SVGRectElementAttributes>>'.",
        },
      ]
```