### PR TITLE
Reinstate "unused @glint-expect-error directive"

### DIFF
--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -202,7 +202,7 @@ function getSemanticDiagnostics<T>(
       return tsDiagnostics;
     }
 
-    const augmentedTsDiagnostics = augmentDiagnostics(transformedModule, tsDiagnostics);
+    const augmentedTsDiagnostics = augmentDiagnostics(ts, sourceFile, transformedModule, tsDiagnostics);
 
     return augmentedTsDiagnostics;
   };

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -202,7 +202,12 @@ function getSemanticDiagnostics<T>(
       return tsDiagnostics;
     }
 
-    const augmentedTsDiagnostics = augmentDiagnostics(ts, sourceFile, transformedModule, tsDiagnostics);
+    const augmentedTsDiagnostics = augmentDiagnostics(
+      ts,
+      sourceFile,
+      transformedModule,
+      tsDiagnostics,
+    );
 
     return augmentedTsDiagnostics;
   };

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -637,6 +637,43 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     `);
   });
 
+  test('unused @glint-expect-error triggers a diagnostic', async () => {
+    const componentA = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class ComponentA extends Component {
+        <template>
+          {{! @glint-expect-error }}
+          <Component />
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestDiagnostics(
+      'ts-template-imports-app/src/ephemeral-index.gts',
+      'glimmer-ts',
+      componentA,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "error",
+          "code": 2578,
+          "end": {
+            "line": 5,
+            "offset": 31,
+          },
+          "start": {
+            "line": 5,
+            "offset": 5,
+          },
+          "text": "Unused '@glint-expect-error' directive.",
+        },
+      ]
+    `);
+  });
+
   test('svg does not produce false positives', async () => {
     const code = stripIndent`
     import Component from '@glimmer/component';


### PR DESCRIPTION
Followup to #888; this PR reinstates the "unused @glint-expect-error directive" diagnostic that emits when no diagnostics are emitted within a `@glint-expect-error`'s area of effect.