### PR TITLE
Setup alpha releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glint",
-  "version": "1.4.0",
+  "version": "0.0.0",
   "private": true,
   "repository": "https://github.com/typed-ember/glint",
   "scripts": {
@@ -43,6 +43,15 @@
     "typescript": ">=5.6.0"
   },
   "packageManager": "pnpm@10.6.2",
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "volta": {
     "node": "18.20.3",
     "pnpm": "10.6.2"

--- a/package.json
+++ b/package.json
@@ -43,15 +43,6 @@
     "typescript": ">=5.6.0"
   },
   "packageManager": "pnpm@10.6.2",
-  "release-plan": {
-    "semverIncrementAs": {
-      "major": "prerelease",
-      "minor": "prerelease",
-      "patch": "prerelease"
-    },
-    "semverIncrementTag": "alpha",
-    "publishTag": "alpha"
-  },
   "volta": {
     "node": "18.20.3",
     "pnpm": "10.6.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,15 @@
     "dev": "tsc --watch",
     "prepack": "pnpm build"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "peerDependencies": {
     "typescript": ">=5.6.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glint/core",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.0",
   "repository": "typed-ember/glint",
   "description": "A CLI for performing typechecking on Glimmer templates",
   "license": "MIT",

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -23,6 +23,15 @@
     "build": "tsc --build",
     "prepack": "pnpm build"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "files": [
     "README.md",
     "-private/**/*.{js,d.ts}",

--- a/packages/environment-ember-loose/package.json
+++ b/packages/environment-ember-loose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glint/environment-ember-loose",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.0",
   "repository": "typed-ember/glint",
   "description": "A Glint environment to support loose-mode Ember.js projects",
   "license": "MIT",

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -23,6 +23,15 @@
     "build": "tsc --build",
     "prepack": "pnpm build"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "files": [
     "README.md",
     "-private/**/*.{js,d.ts}",

--- a/packages/environment-ember-template-imports/package.json
+++ b/packages/environment-ember-template-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glint/environment-ember-template-imports",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.0",
   "repository": "typed-ember/glint",
   "description": "A Glint environment to support ember-template-imports projects",
   "license": "MIT",

--- a/packages/tsserver-plugin/package.json
+++ b/packages/tsserver-plugin/package.json
@@ -27,6 +27,15 @@
     "jiti": "~2.4.2",
     "typescript": ">=5.6.0"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tsserver-plugin/package.json
+++ b/packages/tsserver-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glint/tsserver-plugin",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.0",
   "type": "commonjs",
   "repository": "typed-ember/glint",
   "description": "TypeScript Server Plugin for Glint",

--- a/packages/type-test/package.json
+++ b/packages/type-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glint/type-test",
-  "version": "1.4.0",
+  "version": "0.0.0",
   "repository": "typed-ember/glint",
   "description": "Tools for testing inferred types in Glint-enabled templates",
   "license": "MIT",

--- a/packages/type-test/package.json
+++ b/packages/type-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glint/type-test",
-  "version": "0.0.0",
+  "version": "2.0.0-alpha.0",
   "repository": "typed-ember/glint",
   "description": "Tools for testing inferred types in Glint-enabled templates",
   "license": "MIT",
@@ -27,6 +27,15 @@
   },
   "devDependencies": {
     "@glint/template": "workspace:*"
+  },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "glint-vscode",
   "displayName": "Glint",
   "description": "Glint language server integration for VS Code",
-  "version": "2.0.0-alpha.0",
+  "version": "1.4.5",
   "publisher": "typed-ember",
   "private": true,
   "author": "James C. Davis (https://github.com/jamescdavis)",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "glint-vscode",
   "displayName": "Glint",
   "description": "Glint language server integration for VS Code",
-  "version": "1.4.5",
+  "version": "2.0.0-alpha.0",
   "publisher": "typed-ember",
   "private": true,
   "author": "James C. Davis (https://github.com/jamescdavis)",

--- a/test-packages/test-utils/package.json
+++ b/test-packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glint-monorepo-test-utils",
-  "version": "2.0.0-alpha.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/test-packages/test-utils/package.json
+++ b/test-packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glint-monorepo-test-utils",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-ember-app",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.0",
   "private": true,
   "description": "Small description for ts-ember-app goes here",
   "repository": "",

--- a/test-packages/ts-ember-app/package.json
+++ b/test-packages/ts-ember-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-ember-app",
-  "version": "2.0.0-alpha.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Small description for ts-ember-app goes here",
   "repository": "",

--- a/test-packages/ts-ember-preview-types/package.json
+++ b/test-packages/ts-ember-preview-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-ember-preview-types",
-  "version": "1.4.0",
+  "version": "0.0.0",
   "private": true,
   "description": "Small description for ts-ember-preview-types goes here",
   "repository": "",

--- a/test-packages/ts-plugin-test-app/package.json
+++ b/test-packages/ts-plugin-test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-plugin-test-app",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/test-packages/ts-template-imports-app/package.json
+++ b/test-packages/ts-template-imports-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-template-imports-app",
-  "version": "1.4.0",
+  "version": "0.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This allows us to use glint "@ main" in blueprints, which unblocks:
https://github.com/ember-cli/ember-addon-blueprint/pull/57