### PR TITLE
Fix build to prepare for re-releasing alphas

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+
+      # We have a top-level build,
+      # and packages do not curerntly have the ability to
+      # "prepack"
+      - run: pnpm build
       - name: Publish to NPM
         run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,3 +43,4 @@ glint --build --declaration --emitDeclarationOnly --watch
 ```
 
 Please refer to `tsc` docs for other use cases and flags.
+

--- a/packages/environment-ember-loose/README.md
+++ b/packages/environment-ember-loose/README.md
@@ -3,3 +3,4 @@
 This package contains the information necessary for glint to typecheck a standard (non-[strict-mode](http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html)) Ember.js project.
 
 See [the Glint documentation](https://typed-ember.gitbook.io/glint/using-glint/ember/installation) for more detailed instructions on working with Ember.js projects in Glint.
+

--- a/packages/environment-ember-template-imports/README.md
+++ b/packages/environment-ember-template-imports/README.md
@@ -16,3 +16,4 @@ in your Glint configuration in `tsconfig.json`:
   }
 }
 ```
+

--- a/packages/template/README.md
+++ b/packages/template/README.md
@@ -4,3 +4,4 @@ This package contains type declarations used by other [glint] packages for perfo
 
 [glint]: https://github.com/typed-ember/glint
 [glint-environment packages]: https://www.npmjs.com/search?q=keywords:glint-environment
+

--- a/packages/tsserver-plugin/README.md
+++ b/packages/tsserver-plugin/README.md
@@ -3,3 +3,4 @@
 The TypeScript server plugin that performs type-checking.
 
 Old Glint used the LanguageServer to perform type-checking; Glint 2 uses a TypeScript server plugin to follow suit with Volar.
+

--- a/packages/type-test/README.md
+++ b/packages/type-test/README.md
@@ -117,3 +117,4 @@ let hi: string = 'hi';
   {{expectTypeOf hi to.beAssignableToTypeOf a}}
 </template>
 ```
+


### PR DESCRIPTION
We have a new release system (release-plan), and I forgot to configure it to handle our non-package-centric build