### PR TITLE
Reinstate directives in a way that works with tsc (glint binary)

### DIFF
--- a/packages/core/src/transform/template/inlining/tagged-strings.ts
+++ b/packages/core/src/transform/template/inlining/tagged-strings.ts
@@ -1,15 +1,15 @@
-import type ts from 'typescript';
-import { GlintTagConfig } from '@glint/core/config-types';
-import { GlintEnvironment } from '../../../config/index.js';
-import { CorrelatedSpansResult, isEmbeddedInClass, PartialCorrelatedSpan } from './index.js';
-import { templateToTypescript } from '../template-to-typescript.js';
-import { Directive, SourceFile, TransformError, Range } from '../transformed-module.js';
-import { assert, TSLib } from '../../util.js';
 import {
   GlintEmitMetadata,
   GlintSpecialForm,
   GlintSpecialFormConfig,
+  GlintTagConfig,
 } from '@glint/core/config-types';
+import type ts from 'typescript';
+import { GlintEnvironment } from '../../../config/index.js';
+import { assert, TSLib } from '../../util.js';
+import { templateToTypescript } from '../template-to-typescript.js';
+import { Directive, Range, SourceFile, TransformError } from '../transformed-module.js';
+import { CorrelatedSpansResult, isEmbeddedInClass, PartialCorrelatedSpan } from './index.js';
 
 export function calculateTaggedTemplateSpans(
   ts: TSLib,
@@ -91,15 +91,6 @@ export function calculateTaggedTemplateSpans(
     }
 
     if (transformedTemplate.result) {
-      for (let { kind, location, areaOfEffect } of transformedTemplate.result.directives) {
-        directives.push({
-          kind: kind,
-          source: script,
-          location: addOffset(location, templateLocation.start),
-          areaOfEffect: addOffset(areaOfEffect, templateLocation.start),
-        });
-      }
-
       partialSpans.push({
         originalFile: script,
         originalStart: templateLocation.start,

--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -1,9 +1,9 @@
 import { AST } from '@glimmer/syntax';
-import { unreachable, assert } from '../util.js';
+import { GlintEmitMetadata, GlintSpecialForm } from '@glint/core/config-types';
+import { assert, unreachable } from '../util.js';
+import { TextContent } from './glimmer-ast-mapping-tree.js';
 import { EmbeddingSyntax, mapTemplateContents, RewriteResult } from './map-template-contents.js';
 import ScopeStack from './scope-stack.js';
-import { GlintEmitMetadata, GlintSpecialForm } from '@glint/core/config-types';
-import { TextContent } from './glimmer-ast-mapping-tree.js';
 
 const SPLATTRIBUTES = '...attributes';
 
@@ -140,6 +140,8 @@ export function templateToTypescript(
       mapper.text('__glintRef__; __glintDSL__;');
       mapper.newline();
 
+      mapper.emitDirectivePlaceholders();
+
       mapper.dedent();
       mapper.text('})');
 
@@ -173,9 +175,9 @@ export function templateToTypescript(
       let kind = match[1];
       let location = rangeForNode(node);
       if (kind === 'ignore' || kind === 'expect-error') {
-        mapper.directive(kind, location, mapper.rangeForLine(node.loc.end.line + 1));
+        mapper.directive(kind, node, location, mapper.rangeForLine(node.loc.end.line + 1));
       } else if (kind === 'nocheck') {
-        mapper.directive('ignore', location, { start: 0, end: template.length - 1 });
+        mapper.directive('ignore', node, location, { start: 0, end: template.length - 1 });
       } else if (kind === 'in-svg') {
         inHtmlContext = 'svg';
       } else if (kind === 'in-mathml') {

--- a/packages/core/src/transform/template/transformed-module.ts
+++ b/packages/core/src/transform/template/transformed-module.ts
@@ -2,6 +2,7 @@ import GlimmerASTMappingTree from './glimmer-ast-mapping-tree.js';
 import { assert } from '../util.js';
 import { CodeInformation, CodeMapping } from '@volar/language-core';
 import { codeFeatures } from './code-features.js';
+import type { AST } from '@glimmer/syntax';
 
 export type Range = { start: number; end: number };
 export type RangeWithMapping = Range & { mapping?: GlimmerASTMappingTree };
@@ -29,9 +30,12 @@ export type CorrelatedSpan = {
 export type DirectiveKind = 'ignore' | 'expect-error' | 'nocheck';
 export type Directive = {
   kind: DirectiveKind;
+  commentNode: AST.CommentStatement | AST.MustacheCommentStatement;
   source: SourceFile;
   location: Range;
   areaOfEffect: Range;
+  /** The number of errors that have been reported for this directive */
+  errorCount: number;
 };
 
 export type TransformError = {

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -245,12 +245,7 @@ function getSemanticDiagnostics<T>(
       return tsDiagnostics;
     }
 
-    const augmentedTsDiagnostics = augmentDiagnostics(
-      ts,
-      sourceFile,
-      transformedModule,
-      tsDiagnostics,
-    );
+    const augmentedTsDiagnostics = augmentDiagnostics(transformedModule, tsDiagnostics);
 
     return augmentedTsDiagnostics;
   };

--- a/packages/vscode/__fixtures__/ember-app-loose-and-gts/app/components/Greeting-expect-error.gts
+++ b/packages/vscode/__fixtures__/ember-app-loose-and-gts/app/components/Greeting-expect-error.gts
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+
+export interface GreetingSignature {
+  Args: { target: string };
+}
+
+export default class Greeting extends Component<GreetingSignature> {
+  private message = 'Hello';
+
+  <template>
+    {{this.message}},
+    
+    {{!@glint-expect-error this is suppressing a real error}}
+    <NotAThing />
+    
+    {{!@glint-expect-error this is NOT a real error and should hence raise unused expect error diagnostic}}
+    {{@target}}!
+  </template>
+}

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -668,7 +668,7 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
             "line": 5,
             "offset": 5,
           },
-          "text": "Unused '@glint-expect-error' directive.",
+          "text": "Unused '@ts-expect-error' directive.",
         },
       ]
     `);


### PR DESCRIPTION
Closes #898

Reconstruct our implementation of glint-expect-error/glint-ignore to live entirely within the VirtualCodes parsing/mapping system, which runs in all contexts including `tsc` CLI (i.e. the `glint` binary).