### PR TITLE
Fix broken directives that reference suppressed attr name

### DIFF
--- a/packages/core/src/transform/template/template-to-typescript.ts
+++ b/packages/core/src/transform/template/template-to-typescript.ts
@@ -649,8 +649,8 @@ export function templateToTypescript(
               mapper.forNode(attr, () => {
                 mapper.newline();
 
-                start = template.indexOf(attr.name, start + 1);
-                emitHashKey(attr.name.slice(1), start + 1);
+                const attrStartOffset = attr.loc.getStart().offset!;
+                emitHashKey(attr.name.slice(1), attrStartOffset + prefix.length + 1);
                 mapper.text(': ');
 
                 switch (attr.value.type) {
@@ -854,13 +854,10 @@ export function templateToTypescript(
         mapper.newline();
         mapper.indent();
 
-        let start = template.indexOf(node.tag, rangeForNode(node).start) + node.tag.length;
-
         for (let attr of attributes) {
           mapper.forNode(attr, () => {
-            start = template.indexOf(attr.name, start + 1);
-
-            emitHashKey(attr.name, start);
+            const attrStartOffset = attr.loc.getStart().offset!;
+            emitHashKey(attr.name, attrStartOffset + prefix.length);
             mapper.text(': ');
 
             if (attr.value.type === 'MustacheStatement') {

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -261,6 +261,29 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     `);
   });
 
+  test('it should be possible to reference the attr name in the glint-expect-error without deactivating the directive', async () => {
+    const componentA = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class ComponentA extends Component {
+        <template>
+          <div
+            {{! @glint-expect-error there is a problem with unknownAttr }}
+            unknownAttr="wat">
+          </div>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestDiagnostics(
+      'ts-template-imports-app/src/ephemeral-index.gts',
+      'glimmer-ts',
+      componentA,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`[]`);
+  });
+
   test('passing args to vanilla Component should be an error', async () => {
     const componentA = stripIndent`
       import Component from '@glimmer/component';


### PR DESCRIPTION
Closes #919

Root cause of bug was using `indexOf` to find the offset of the attr name, but this didn't take into account the possibility of an inline/in-element `{{@glint-expect-error ...}}` that referenced that attr name.