### PR TITLE
Add value to HTMLTextAreaElementAttributes

### DIFF
--- a/packages/template/-private/dsl/elements.d.ts
+++ b/packages/template/-private/dsl/elements.d.ts
@@ -585,6 +585,10 @@ interface HTMLTextAreaElementAttributes extends GenericAttributes {
   ['readonly']: AttrValue;
   ['required']: AttrValue;
   ['rows']: AttrValue;
+  // This is not actually an HTMLTextAreaElement attribute, but Ember/Glimmer
+  // support `value` attribute syntax to support binding values into
+  // `<textarea>`s, so we include it here.
+  ['value']: AttrValue;
   ['wrap']: AttrValue;
 }
 interface HTMLTimeElementAttributes extends GenericAttributes {


### PR DESCRIPTION
Add this "fake" attribute to support Glimmer/Ember's `<textarea value={{...}}>` binding syntax

Fixes #961