### PR TITLE
Revert "Remove release-plan alpha configuration for v2 prep (#975)"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,15 @@
     "dev": "tsc --watch",
     "prepack": "pnpm build"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "peerDependencies": {
     "typescript": ">=5.6.0"
   },

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -36,6 +36,15 @@
     "svg-element-attributes": "^2.1.0",
     "svg-event-attributes": "^2.0.2"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "preminor",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/tsserver-plugin/package.json
+++ b/packages/tsserver-plugin/package.json
@@ -27,6 +27,15 @@
     "jiti": "~2.4.2",
     "typescript": ">=5.6.0"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/type-test/package.json
+++ b/packages/type-test/package.json
@@ -30,6 +30,15 @@
     "@glint/core": "workspace:*",
     "ember-cli-htmlbars": "^6.0.1"
   },
+  "release-plan": {
+    "semverIncrementAs": {
+      "major": "prerelease",
+      "minor": "prerelease",
+      "patch": "prerelease"
+    },
+    "semverIncrementTag": "alpha",
+    "publishTag": "alpha"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
A few more things to flesh out before we prep for release.

This reverts commit 046cfa6961fffb974fb45a2e721de1ebe082b3ea.