### PR TITLE
Support HTML properties for HTML elements

### DIFF
--- a/bin/build-elements.mjs
+++ b/bin/build-elements.mjs
@@ -18,6 +18,21 @@ const ast = parse(source, {
   plugins: [['typescript', { dts: true }]],
 });
 
+// Ember allow setting both attributes and properties for HTML elements, {html,svg}-element-attributes only provides
+// attributes.
+const htmlElementProperties = new Map([
+  [
+    'HTMLSelectElement',
+    new Map([
+      ['length', 'number'],
+      ['value', 'AttrValue'],
+    ]),
+  ],
+  ['HTMLInputElement', new Map([['indeterminate', 'boolean']])],
+  ['HTMLTextAreaElement', new Map([['value', 'AttrValue']])],
+  ['SVGSVGElement', new Map([['xmlns', 'AttrValue']])],
+]);
+
 const htmlElementsMap = new Map();
 const svgElementsMap = new Map();
 const mathmlElementsMap = new Map();
@@ -66,6 +81,14 @@ export declare namespace HtmlElementAttributes {
     keys.forEach((k) => {
       htmlElementsContent += `  ['${k}']: AttrValue;\n`;
     });
+
+    const properties = htmlElementProperties.get(type);
+    if (properties) {
+      properties.forEach((value, property) => {
+        htmlElementsContent += `  ['${property}']: ${value};\n`;
+      });
+    }
+
     if (name === 'GenericAttributes') {
       ariaAttributes.forEach((k) => {
         htmlElementsContent += `  ['${k}']: AttrValue;\n`;
@@ -106,6 +129,14 @@ export declare namespace SvgElementAttributes {
     keys.forEach((k) => {
       svgElementsContent += `  ['${k}']: AttrValue;\n`;
     });
+
+    const properties = htmlElementProperties.get(type);
+    if (properties) {
+      properties.forEach((value, property) => {
+        svgElementsContent += `  ['${property}']: ${value};\n`;
+      });
+    }
+
     if (name === 'GenericAttributes') {
       svgEventAttributes.forEach((k) => {
         svgElementsContent += `  ['${k}']: AttrValue;\n`;

--- a/packages/template/-private/dsl/elements.d.ts
+++ b/packages/template/-private/dsl/elements.d.ts
@@ -388,6 +388,7 @@ interface HTMLInputElementAttributes extends GenericAttributes {
   ['usemap']: AttrValue;
   ['value']: AttrValue;
   ['width']: AttrValue;
+  ['indeterminate']: boolean;
 }
 interface HTMLLabelElementAttributes extends GenericAttributes {
   ['for']: AttrValue;
@@ -516,6 +517,8 @@ interface HTMLSelectElementAttributes extends GenericAttributes {
   ['name']: AttrValue;
   ['required']: AttrValue;
   ['size']: AttrValue;
+  ['length']: number;
+  ['value']: AttrValue;
 }
 interface HTMLSlotElementAttributes extends GenericAttributes {
   ['name']: AttrValue;
@@ -585,11 +588,8 @@ interface HTMLTextAreaElementAttributes extends GenericAttributes {
   ['readonly']: AttrValue;
   ['required']: AttrValue;
   ['rows']: AttrValue;
-  // This is not actually an HTMLTextAreaElement attribute, but Ember/Glimmer
-  // support `value` attribute syntax to support binding values into
-  // `<textarea>`s, so we include it here.
-  ['value']: AttrValue;
   ['wrap']: AttrValue;
+  ['value']: AttrValue;
 }
 interface HTMLTimeElementAttributes extends GenericAttributes {
   ['datetime']: AttrValue;
@@ -689,7 +689,7 @@ interface HtmlElements {
 }
 
 export declare namespace SvgElementAttributes {
-type GenericAttributes = HtmlElementAttributes.GenericAttributes;
+  type GenericAttributes = HtmlElementAttributes.GenericAttributes;
 interface SVGAElementAttributes extends GenericAttributes {
   ['alignment-baseline']: AttrValue;
   ['baseline-shift']: AttrValue;
@@ -3711,9 +3711,9 @@ interface SVGSVGElementAttributes extends GenericAttributes {
   ['word-spacing']: AttrValue;
   ['writing-mode']: AttrValue;
   ['x']: AttrValue;
-  ['xmlns']: AttrValue;
   ['y']: AttrValue;
   ['zoomAndPan']: AttrValue;
+  ['xmlns']: AttrValue;
 }
 interface SVGSwitchElementAttributes extends GenericAttributes {
   ['alignment-baseline']: AttrValue;

--- a/packages/template/__tests__/attributes.test.ts
+++ b/packages/template/__tests__/attributes.test.ts
@@ -215,3 +215,43 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
     allowusermedia: document.createElement('div'),
   });
 }
+
+// Properties
+{
+  applyAttributes(document.createElement('input'), {
+    indeterminate: true,
+  });
+}
+
+{
+  applyAttributes(document.createElement('input'), {
+    // @ts-expect-error: properties are typed, and indeterminate must be a bool
+    indeterminate: 'true',
+  });
+}
+
+{
+  applyAttributes(document.createElement('textarea'), {
+    value: 'ok',
+  });
+}
+
+{
+  applyAttributes(document.createElement('select'), {
+    value: 'ok',
+    length: 10,
+  });
+}
+
+{
+  applyAttributes(document.createElement('select'), {
+    // @ts-expect-error: properties are typed, and indeterminate must be a number
+    length: '10',
+  });
+}
+
+{
+  applyAttributes(new SVGSVGElement(), {
+    xmlns: 'ok',
+  });
+}


### PR DESCRIPTION
Ember supports setting both attributes and properties for HTML elements. As properties typed compared to attributes, I've included support for setting the specific type.

I've not made sure this is a comprehensive list of properties on HTML elements, there are likely more properties.