### PR TITLE
Changed GlobalSVGAttributes to extend GlobalHTMLAttributes instead of just GlobalAriaAttributes

### DIFF
--- a/bin/build-elements.mjs
+++ b/bin/build-elements.mjs
@@ -173,7 +173,7 @@ interface GlintSvgElementAttributesMap {\n`;
     const interfaceName = type + 'Attributes';
     const extend =
       name === GLOBAL_SVG_ATTRIBUTES_NAME
-        ? 'extends GlobalAriaAttributes'
+        ? 'extends GlobalHTMLAttributes'
         : `extends ${GLOBAL_SVG_ATTRIBUTES_NAME}`;
     svgElementsContent += `interface ${interfaceName} ${extend} {\n`;
     keys.forEach((k) => {

--- a/packages/template/-private/dsl/elements.d.ts
+++ b/packages/template/-private/dsl/elements.d.ts
@@ -706,7 +706,7 @@ interface GlintHtmlElementAttributesMap {
 }
 
 declare global {
-interface GlobalSVGAttributes extends GlobalAriaAttributes {
+interface GlobalSVGAttributes extends GlobalHTMLAttributes {
   ['about']: AttrValue;
   ['class']: AttrValue;
   ['content']: AttrValue;

--- a/packages/template/__tests__/attributes.test.ts
+++ b/packages/template/__tests__/attributes.test.ts
@@ -261,3 +261,17 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
     role: 'presentation',
   });
 }
+
+{
+  applyAttributes(new SVGSVGElement(), {
+    title: 'My Icon',
+  });
+}
+
+{
+  applyAttributes(new SVGSVGElement(), {
+    title: 'Icon',
+    role: 'img',
+    tabindex: '0',
+  });
+}


### PR DESCRIPTION
Global attributes like title should also be available on svg: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/title


Changed GlobalSVGAttributes to extend GlobalHTMLAttributes instead of just GlobalAriaAttributes:

```diff
-interface GlobalSVGAttributes extends GlobalAriaAttributes { ... }
+interface GlobalSVGAttributes extends GlobalHTMLAttributes { ... }
```

Inheritance Chain:
GlobalAriaAttributes (ARIA attrs + role)
↓
GlobalHTMLAttributes extends GlobalAriaAttributes (HTML global attrs like title, tabindex, etc.)
↓
GlobalSVGAttributes extends GlobalHTMLAttributes (SVG-specific attrs)
↓
SVGSVGElementAttributes extends GlobalSVGAttributes (element-specific attrs)

Result:
- ✅ SVG elements now have title attribute (and all other HTML global attributes)
- ✅ SVG elements still have all ARIA attributes (inherited through HTML)
- ✅ SVG elements have their SVG-specific attributes

Tests Added:
- Test for title attribute on SVG
- Test for multiple HTML global attributes (title, role, tabindex) on SVG