### PR TITLE
Support environments with no tsconfig or jsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tsserver.log
 dist/
 .log/
 .cursor
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,29 @@
       ]
     },
     {
+      // For this to work, make sure you're running `tsc --build --watch` at the root, AND
+      // `pnpm bundle:watch` from within vscode directory.
+      "name": "Debug Extension (TS Plugin, no config)",
+      "type": "extensionHost",
+      "request": "launch",
+      // "preLaunchTask": "npm: build",
+      "autoAttachChildProcesses": true,
+      "runtimeExecutable": "${execPath}",
+      "outFiles": [
+        "${workspaceFolder}/**/*.js",
+        "!**/node_modules/**"
+      ],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
+        // Disable v1 vscode glint
+        "--disable-extension",
+        "typed-ember.glint-vscode",
+        // comment to activate your local extensions
+        "--disable-extensions",
+        "${workspaceFolder}/packages/vscode/__fixtures__/ember-app-no-config"
+      ]
+    },
+    {
       "name": "Attach to TS Server",
       "type": "node",
       "request": "attach",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,40 @@ This provides a visual way to understand how your template code is being transfo
 
 NOTE: The Volar Labs plugin might not display diagnostic errors _within_ the transformed/generated .ts code; if you are debugging, for instance, an issue where Glint is unexpectedly showing `any` as the type of some value within your `<template>` tag, try copying the transformed TS contents to a new file ending in `.ts`, which may reveal the underlying issue.
 
+## How to test the Glint experience in the matrix of supported environment?
+
+If you wish to manually test things for a full e2e type situation:
+
+### For VSCode
+
+1. run `pnpm build` at the monorepo root
+1. generate the VSCode extension (instructions above, and in packages/vscode/README)
+1. generate a project
+1. open VSCode in your new project and either uninstall glint or use a blank profile
+1. install the built vsix
+
+### For neovim
+
+1. run `pnpm build` at the monorepo root
+1. generate a project
+1. link the deps
+1. make sure your neovim configuration is using the local `@glint/ember-tsc` instead of a global one
+
+### Scenarios
+
+> [!NOTE]
+> We should convert these to smoke tests so that they run in CI
+
+app in javascript
+```bash
+pnpm dlx ember-cli@latest new my-js-app --pnpm
+```
+
+app in typescript
+```bash
+pnpm dlx ember-cli@latest new my-js-app --pnpm --typescript
+```
+
 ## How to link all the packages to an external project?
 
 Set up the links for all the `@glint/*` packages:
@@ -90,4 +124,5 @@ Then in your project that you want to test out local copies of `@glint/*` in:
 2. `node ../path/to/glint/bin/link-install.mjs`
 
 The local copies of `@glint/*` packages will now be installed in your external project.
+
 

--- a/bin/link-install.mjs
+++ b/bin/link-install.mjs
@@ -65,7 +65,7 @@ const link = packageJsonPaths.map(async (packageJsonPath) => {
 
         packageJson.pnpm ||= {};
         packageJson.pnpm.overrides ||= {};
-        Object.assign(packageJson.pnpm.overrides, {});
+        packageJson.pnpm.overrides[dep] = relativeTarPath;
       }
     }
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -7,19 +7,20 @@ import { GlintEnvironment } from './environment.js';
  * with methods for interrogating project configuration based on its contents.
  */
 export class GlintConfig {
-  declare public readonly ts: typeof import('typescript');
+  declare public readonly ts: typeof import('typescript') | null;
   public readonly rootDir: string;
-  public readonly configPath: string;
+  public readonly configPath: string | undefined;
   public readonly environment: GlintEnvironment;
 
   public constructor(
-    ts: typeof import('typescript'),
-    configPath: string,
+    ts: typeof import('typescript') | null,
+    configPath: string | undefined,
     config: GlintConfigInput,
+    rootDir?: string,
   ) {
     Object.defineProperty(this, 'ts', { value: ts });
-    this.configPath = normalizePath(configPath);
-    this.rootDir = path.dirname(configPath);
+    this.configPath = configPath ? normalizePath(configPath) : undefined;
+    this.rootDir = rootDir ?? (configPath ? path.dirname(configPath) : process.cwd());
     this.environment = GlintEnvironment.load(config);
   }
 }

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -24,6 +24,8 @@ type TypeScript = typeof TS;
 export class ConfigLoader {
   private configs = new Map<string, GlintConfig | null>();
   private logInfo?: (message: string) => void;
+  private loggedNoConfig = new Set<string>();
+  private loggedCachedConfig = new Set<string>();
 
   constructor(logInfo?: (message: string) => void) {
     this.logInfo = logInfo;
@@ -44,14 +46,19 @@ export class ConfigLoader {
     }
 
     let configPath = findNearestConfigFile(ts, directory);
-    if (!configPath) {
+    let cacheKey = configPath ?? directory;
+
+    if (!configPath && !this.loggedNoConfig.has(cacheKey)) {
       this.log(`No tsconfig.json or jsconfig.json found from ${directory}.`);
+      this.loggedNoConfig.add(cacheKey);
     }
 
-    let cacheKey = configPath ?? directory;
     let existing = this.configs.get(cacheKey);
     if (existing !== undefined) {
-      this.log(`Using cached Glint config from ${cacheKey}.`);
+      if (!this.loggedCachedConfig.has(cacheKey)) {
+        this.log(`Using cached Glint config from ${cacheKey}.`);
+        this.loggedCachedConfig.add(cacheKey);
+      }
       return existing;
     }
 

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -41,27 +41,26 @@ export class ConfigLoader {
     let ts = findTypeScript(directory);
     if (!ts) {
       this.log(`No TypeScript installation found from ${directory}.`);
-      return null;
     }
 
     let configPath = findNearestConfigFile(ts, directory);
     if (!configPath) {
       this.log(`No tsconfig.json or jsconfig.json found from ${directory}.`);
-      return null;
     }
 
-    let existing = this.configs.get(configPath);
+    let cacheKey = configPath ?? directory;
+    let existing = this.configs.get(cacheKey);
     if (existing !== undefined) {
-      this.log(`Using cached Glint config from ${configPath}.`);
+      this.log(`Using cached Glint config from ${cacheKey}.`);
       return existing;
     }
 
-    let configInput = loadConfigInput(ts, configPath);
-    let config = new GlintConfig(ts, configPath, configInput || { environment: [] });
+    let configInput = configPath ? loadConfigInput(ts, configPath) : null;
+    let config = new GlintConfig(ts, configPath, configInput || { environment: [] }, directory);
 
-    this.log(`Loaded Glint config from ${configPath}.`);
+    this.log(`Loaded Glint config from ${cacheKey}.`);
 
-    this.configs.set(configPath, config);
+    this.configs.set(cacheKey, config);
 
     return config;
   }
@@ -88,11 +87,15 @@ function tryResolve<T>(load: () => T): T | null {
 }
 
 function parseConfigInput(
-  ts: TypeScript,
+  ts: TypeScript | null,
   entryPath: string,
   currentPath: string,
   fullGlintConfig: Record<string, unknown>,
 ): Record<string, unknown> {
+  if (!ts) {
+    return fullGlintConfig;
+  }
+
   let currentContents: any = ts.readConfigFile(currentPath, ts.sys.readFile).config;
   let currentGlintConfig = currentContents.glint ?? {};
 
@@ -122,11 +125,39 @@ function parseConfigInput(
   return { ...fullGlintConfig, ...currentGlintConfig };
 }
 
-export function loadConfigInput(ts: TypeScript, entryPath: string): GlintConfigInput | null {
+export function loadConfigInput(ts: TypeScript | null, entryPath: string): GlintConfigInput | null {
   return validateConfigInput(parseConfigInput(ts, entryPath, entryPath, {}));
 }
 
-function findNearestConfigFile(ts: TypeScript, searchFrom: string): string {
+function findNearestConfigFile(ts: TypeScript | null, searchFrom: string): string | undefined {
+  if (!ts) {
+    // Fallback: manually search for config files without TypeScript's help
+    let configCandidates: (string | undefined)[] = [];
+    let currentDir = searchFrom;
+    const root = path.parse(currentDir).root;
+
+    while (currentDir !== root) {
+      const tsconfigPath = path.join(currentDir, 'tsconfig.json');
+      const jsconfigPath = path.join(currentDir, 'jsconfig.json');
+
+      if (fs.existsSync(tsconfigPath)) {
+        return tsconfigPath;
+      }
+
+      if (fs.existsSync(jsconfigPath)) {
+        return jsconfigPath;
+      }
+
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+
+    return undefined;
+  }
+
   // Assume that the longest path is the most relevant one in the case that
   // multiple config files exist at or above our current directory.
   let configCandidates = [
@@ -137,6 +168,48 @@ function findNearestConfigFile(ts: TypeScript, searchFrom: string): string {
     .sort((a, b) => b.length - a.length);
 
   return configCandidates[0];
+}
+
+/**
+ * Checks if @glint/template or ember-source is present in the package.json
+ * of the given directory or any parent directory.
+ */
+function hasGlintRelatedDependencies(searchFrom: string): boolean {
+  let currentDir = searchFrom;
+  const root = path.parse(currentDir).root;
+
+  while (currentDir !== root) {
+    const packageJsonPath = path.join(currentDir, 'package.json');
+
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const content = fs.readFileSync(packageJsonPath, 'utf-8');
+        const packageJson = JSON.parse(content);
+
+        const allDependencies = {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+          ...packageJson.peerDependencies,
+          ...packageJson.optionalDependencies,
+        };
+
+        if (allDependencies['@glint/template'] || allDependencies['ember-source']) {
+          return true;
+        }
+      } catch {
+        // Ignore parsing errors and continue searching
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      // Reached filesystem root
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  return false;
 }
 
 function validateConfigInput(input: Record<string, unknown>): GlintConfigInput | null {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,19 @@
 import { GlintConfig, loadConfig, findConfig } from './config/index.js';
-import { createEmberLanguagePlugin } from './volar/ember-language-plugin.js';
+import {
+  createDynamicEmberLanguagePlugin,
+  createEmberLanguagePlugin,
+} from './volar/ember-language-plugin.js';
 
 import { VirtualGtsCode } from './volar/gts-virtual-code.js';
 import { augmentDiagnostics } from './transform/diagnostics/augmentation.js';
 
-export { loadConfig, findConfig, createEmberLanguagePlugin, VirtualGtsCode, augmentDiagnostics };
+export {
+  loadConfig,
+  findConfig,
+  createEmberLanguagePlugin,
+  createDynamicEmberLanguagePlugin,
+  VirtualGtsCode,
+  augmentDiagnostics,
+};
 
 export type { GlintConfig };

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -61,20 +61,28 @@ function normalizeFileName(scriptIdStr: string, getCurrentDirectory?: () => stri
 }
 
 /**
- * Check if ember-source is installed in the given directory and return
- * the appropriate `compilerOptions.types` entries so that Ember's
- * ambient type declarations are visible for import suggestions.
+ * Resolve the absolute path to ember-source's ambient types entry point.
+ *
+ * ember-source's package.json exports `./types` with a `types`-only condition,
+ * which means `require.resolve('ember-source/types')` fails (Node's CJS resolver
+ * doesn't honour the `types` condition) and `compilerOptions.types` doesn't work
+ * because TS type-reference-directive resolution only checks `@types/` directories.
+ *
+ * Instead, we resolve `ember-source/package.json` (which IS exported) and
+ * construct the known path to `types/stable/index.d.ts`.
  */
-function inferEmberTypes(projectDir: string): string[] {
-  const types: string[] = [];
+function resolveEmberSourceTypesFile(projectDir: string): string | null {
   try {
     const req = createRequire(path.join(projectDir, 'package.json'));
-    req.resolve('ember-source/types');
-    types.push('ember-source/types');
+    const pkgJsonPath = req.resolve('ember-source/package.json');
+    const typesFile = path.join(path.dirname(pkgJsonPath), 'types', 'stable', 'index.d.ts');
+    if (fs.existsSync(typesFile)) {
+      return typesFile;
+    }
   } catch {
     // ember-source not installed; skip
   }
-  return types;
+  return null;
 }
 
 function createEmberLanguagePluginInternal<T extends URI | string>(
@@ -174,6 +182,9 @@ function createEmberLanguagePluginInternal<T extends URI | string>(
       ...(allowJs
         ? {
             resolveLanguageServiceHost(host) {
+              // Resolve ember-source types file once, outside the hot path.
+              let emberTypesFile: string | null | undefined;
+
               return {
                 ...host,
                 getCompilationSettings: () => {
@@ -202,20 +213,27 @@ function createEmberLanguagePluginInternal<T extends URI | string>(
                     if (!('moduleResolution' in baseSettings)) {
                       settings.moduleResolution = 100; // ts.ModuleResolutionKind.Bundler
                     }
-                    // Include ember-source/types so that ambient Ember type
-                    // declarations (e.g. @glimmer/component) are visible for
-                    // import suggestions. A jsconfig.json normally specifies
-                    // this in compilerOptions.types.
-                    if (!('types' in baseSettings)) {
-                      const projectDir = host.getCurrentDirectory?.() ?? getCurrentDirectory?.() ?? process.cwd();
-                      const inferredTypes = inferEmberTypes(projectDir);
-                      if (inferredTypes.length > 0) {
-                        settings.types = inferredTypes;
-                      }
-                    }
                   }
 
                   return settings;
+                },
+                getScriptFileNames: () => {
+                  const files = host.getScriptFileNames();
+                  const baseSettings = host.getCompilationSettings();
+
+                  // For inferred projects, inject ember-source ambient types
+                  // so that @glimmer/tracking, @ember/modifier, etc. are visible
+                  // for import suggestions and Quick Fix code actions.
+                  if (baseSettings['configFilePath'] === undefined) {
+                    if (emberTypesFile === undefined) {
+                      const projectDir = host.getCurrentDirectory?.() ?? getCurrentDirectory?.() ?? process.cwd();
+                      emberTypesFile = resolveEmberSourceTypesFile(projectDir);
+                    }
+                    if (emberTypesFile && !files.includes(emberTypesFile)) {
+                      return [...files, emberTypesFile];
+                    }
+                  }
+                  return files;
                 },
               };
             },

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -168,6 +168,13 @@ function createEmberLanguagePluginInternal<T extends URI | string>(
                   // Set sensible defaults for inferred/implicit projects
                   // (projects without a tsconfig.json or jsconfig.json)
                   if (baseSettings['configFilePath'] === undefined) {
+                    // checkJs defaults to false, but should be true so that .gjs
+                    // files (which become .js) get semantic diagnostics.
+                    // jsconfig.json implicitly sets checkJs: true; without a config
+                    // file we need to enable it explicitly.
+                    if (!('checkJs' in baseSettings)) {
+                      settings.checkJs = true;
+                    }
                     // module defaults to CommonJS, but ESNext is more appropriate for modern projects
                     if (!('module' in baseSettings)) {
                       settings.module = 99; // ts.ModuleKind.ESNext
@@ -211,5 +218,6 @@ export function createDynamicEmberLanguagePlugin<T extends URI | string>(
   return createEmberLanguagePluginInternal((fileName) => findConfig(path.dirname(fileName)), {
     clientId,
     getCurrentDirectory,
+    allowJs: true,
   });
 }

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -1,4 +1,6 @@
 import { LanguagePlugin } from '@volar/language-core';
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type ts from 'typescript';
@@ -56,6 +58,23 @@ function normalizeFileName(scriptIdStr: string, getCurrentDirectory?: () => stri
   }
 
   return fileName;
+}
+
+/**
+ * Check if ember-source is installed in the given directory and return
+ * the appropriate `compilerOptions.types` entries so that Ember's
+ * ambient type declarations are visible for import suggestions.
+ */
+function inferEmberTypes(projectDir: string): string[] {
+  const types: string[] = [];
+  try {
+    const req = createRequire(path.join(projectDir, 'package.json'));
+    req.resolve('ember-source/types');
+    types.push('ember-source/types');
+  } catch {
+    // ember-source not installed; skip
+  }
+  return types;
 }
 
 function createEmberLanguagePluginInternal<T extends URI | string>(
@@ -182,6 +201,17 @@ function createEmberLanguagePluginInternal<T extends URI | string>(
                     // moduleResolution defaults to 'node', but 'bundler' is more appropriate for bundler-based projects
                     if (!('moduleResolution' in baseSettings)) {
                       settings.moduleResolution = 100; // ts.ModuleResolutionKind.Bundler
+                    }
+                    // Include ember-source/types so that ambient Ember type
+                    // declarations (e.g. @glimmer/component) are visible for
+                    // import suggestions. A jsconfig.json normally specifies
+                    // this in compilerOptions.types.
+                    if (!('types' in baseSettings)) {
+                      const projectDir = host.getCurrentDirectory?.() ?? getCurrentDirectory?.() ?? process.cwd();
+                      const inferredTypes = inferEmberTypes(projectDir);
+                      if (inferredTypes.length > 0) {
+                        settings.types = inferredTypes;
+                      }
                     }
                   }
 

--- a/packages/core/src/volar/ember-language-plugin.ts
+++ b/packages/core/src/volar/ember-language-plugin.ts
@@ -1,18 +1,71 @@
 import { LanguagePlugin } from '@volar/language-core';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type ts from 'typescript';
 import { URI } from 'vscode-uri';
 import { GlintConfig } from '../index.js';
 import { VirtualGtsCode } from './gts-virtual-code.js';
 export type TS = typeof ts;
 
-/**
- * Create a [Volar](https://volarjs.dev) language plugin to support
- *
- * - .gts/.gjs files (the `ember-template-imports` environment)
- */
-export function createEmberLanguagePlugin<T extends URI | string>(
-  glintConfig: GlintConfig,
-  { clientId }: { clientId?: string } = {},
+type EmberLanguagePluginOptions = {
+  clientId?: string;
+  getCurrentDirectory?: () => string;
+  allowJs?: boolean;
+  throwOnUnexpectedLanguageId?: boolean;
+};
+
+function getLanguageIdForFileName(fileName: string): 'glimmer-ts' | 'glimmer-js' | undefined {
+  if (fileName.endsWith('.gts')) {
+    return 'glimmer-ts';
+  }
+  if (fileName.endsWith('.gjs')) {
+    return 'glimmer-js';
+  }
+}
+
+function isGlimmerLanguageId(
+  languageId: string | undefined,
+): languageId is 'glimmer-ts' | 'glimmer-js' | 'typescript.glimmer' | 'javascript.glimmer' {
+  return (
+    languageId === 'glimmer-ts' ||
+    languageId === 'glimmer-js' ||
+    languageId === 'typescript.glimmer' ||
+    languageId === 'javascript.glimmer'
+  );
+}
+
+function normalizeFileName(scriptIdStr: string, getCurrentDirectory?: () => string): string {
+  let fileName = scriptIdStr;
+  if (scriptIdStr.startsWith('file://')) {
+    try {
+      fileName = fileURLToPath(scriptIdStr);
+    } catch {
+      try {
+        fileName = decodeURIComponent(new URL(scriptIdStr).pathname);
+      } catch {
+        fileName = scriptIdStr;
+      }
+    }
+  }
+
+  if (!path.isAbsolute(fileName)) {
+    const baseDir = getCurrentDirectory?.();
+    if (baseDir) {
+      fileName = path.resolve(baseDir, fileName);
+    }
+  }
+
+  return fileName;
+}
+
+function createEmberLanguagePluginInternal<T extends URI | string>(
+  getGlintConfig: (fileName: string) => GlintConfig | null,
+  {
+    clientId,
+    getCurrentDirectory,
+    allowJs = false,
+    throwOnUnexpectedLanguageId = false,
+  }: EmberLanguagePluginOptions = {},
 ): LanguagePlugin<T> {
   return {
     /**
@@ -34,17 +87,21 @@ export function createEmberLanguagePlugin<T extends URI | string>(
       }
     },
 
-    createVirtualCode(scriptId: URI | string, languageId, snapshot, codegenContext) {
+    createVirtualCode(scriptId: URI | string, languageId, snapshot) {
       const scriptIdStr = String(scriptId);
+      const fileName = normalizeFileName(scriptIdStr, getCurrentDirectory);
+      const inferredLanguageId = languageId ?? getLanguageIdForFileName(fileName);
 
-      if (
-        languageId === 'glimmer-ts' ||
-        languageId === 'glimmer-js' ||
-        languageId === 'typescript.glimmer' ||
-        languageId === 'javascript.glimmer'
-      ) {
-        return new VirtualGtsCode(glintConfig, snapshot, languageId, clientId);
+      if (!isGlimmerLanguageId(inferredLanguageId)) {
+        return;
       }
+
+      const glintConfig = getGlintConfig(fileName);
+      if (!glintConfig) {
+        return;
+      }
+
+      return new VirtualGtsCode(glintConfig, snapshot, inferredLanguageId, clientId);
     },
 
     typescript: {
@@ -89,20 +146,70 @@ export function createEmberLanguagePlugin<T extends URI | string>(
               scriptKind: 1 satisfies ts.ScriptKind.JS,
             };
           default:
-            throw new Error(`getScript: Unexpected languageId: ${rootVirtualCode.languageId}`);
+            if (throwOnUnexpectedLanguageId) {
+              throw new Error(`getScript: Unexpected languageId: ${rootVirtualCode.languageId}`);
+            }
         }
       },
 
-      resolveLanguageServiceHost(host) {
-        return {
-          ...host,
-          getCompilationSettings: () => ({
-            ...host.getCompilationSettings(),
-            // Always allow JS for type checking.
-            allowJs: true,
-          }),
-        };
-      },
+      ...(allowJs
+        ? {
+            resolveLanguageServiceHost(host) {
+              return {
+                ...host,
+                getCompilationSettings: () => {
+                  const baseSettings = host.getCompilationSettings();
+                  const settings: any = {
+                    ...baseSettings,
+                    // Always allow JS for type checking.
+                    allowJs: true,
+                  };
+
+                  // Set sensible defaults for inferred/implicit projects
+                  // (projects without a tsconfig.json or jsconfig.json)
+                  if (baseSettings['configFilePath'] === undefined) {
+                    // module defaults to CommonJS, but ESNext is more appropriate for modern projects
+                    if (!('module' in baseSettings)) {
+                      settings.module = 99; // ts.ModuleKind.ESNext
+                    }
+                    // moduleResolution defaults to 'node', but 'bundler' is more appropriate for bundler-based projects
+                    if (!('moduleResolution' in baseSettings)) {
+                      settings.moduleResolution = 100; // ts.ModuleResolutionKind.Bundler
+                    }
+                  }
+
+                  return settings;
+                },
+              };
+            },
+          }
+        : {}),
     },
   };
+}
+
+/**
+ * Create a [Volar](https://volarjs.dev) language plugin to support
+ *
+ * - .gts/.gjs files (the `ember-template-imports` environment)
+ */
+export function createEmberLanguagePlugin<T extends URI | string>(
+  glintConfig: GlintConfig,
+  { clientId }: { clientId?: string } = {},
+): LanguagePlugin<T> {
+  return createEmberLanguagePluginInternal(() => glintConfig, {
+    clientId,
+    allowJs: true,
+    throwOnUnexpectedLanguageId: true,
+  });
+}
+
+export function createDynamicEmberLanguagePlugin<T extends URI | string>(
+  findConfig: (from: string) => GlintConfig | null,
+  { clientId, getCurrentDirectory }: { clientId?: string; getCurrentDirectory: () => string },
+): LanguagePlugin<T> {
+  return createEmberLanguagePluginInternal((fileName) => findConfig(path.dirname(fileName)), {
+    clientId,
+    getCurrentDirectory,
+  });
 }

--- a/packages/core/src/volar/gts-virtual-code.ts
+++ b/packages/core/src/volar/gts-virtual-code.ts
@@ -139,12 +139,15 @@ export class VirtualGtsCode implements VirtualCode {
     const filename = isJavascript ? 'root.gjs' : 'root.gts';
     let script = { filename, contents };
 
-    const transformedModule = rewriteModule(
-      this.glintConfig.ts,
-      { script },
-      this.glintConfig.environment,
-      this.clientId,
-    );
+    const transformedModule =
+      this.glintConfig.ts !== null
+        ? rewriteModule(
+            this.glintConfig.ts,
+            { script },
+            this.glintConfig.environment,
+            this.clientId,
+          )
+        : null;
 
     this.transformedModule = transformedModule;
 

--- a/packages/core/src/volar/language-server.ts
+++ b/packages/core/src/volar/language-server.ts
@@ -74,13 +74,22 @@ connection.onInitialize((params) => {
         if (uri.scheme === 'file') {
           // Use tsserver to find the tsconfig governing this file.
           const fileName = uri.fsPath.replace(/\\/g, '/');
-          const projectInfo = await sendTsServerRequest<ts.server.protocol.ProjectInfo>(
+          let projectInfo = await sendTsServerRequest<ts.server.protocol.ProjectInfo>(
             '_glint:' + ts.server.protocol.CommandTypes.ProjectInfo,
             {
               file: fileName,
               needFileNameList: false,
             } satisfies ts.server.protocol.ProjectInfoRequestArgs,
           );
+          if (!projectInfo) {
+            projectInfo = await sendTsServerRequest<ts.server.protocol.ProjectInfo>(
+              ts.server.protocol.CommandTypes.ProjectInfo,
+              {
+                file: fileName,
+                needFileNameList: false,
+              } satisfies ts.server.protocol.ProjectInfoRequestArgs,
+            );
+          }
           if (projectInfo) {
             const { configFileName } = projectInfo;
             let ls = tsconfigProjects.get(URI.file(configFileName));

--- a/packages/core/src/volar/language-server.ts
+++ b/packages/core/src/volar/language-server.ts
@@ -11,7 +11,20 @@ import { URI } from 'vscode-uri';
 import { ConfigLoader } from '../config/loader.js';
 import { create as createCompilerErrorsPlugin } from '../plugins/g-compiler-errors.js';
 import { create as createTemplateTagSymbolsPlugin } from '../plugins/g-template-tag-symbols.js';
-import { createEmberLanguagePlugin } from './ember-language-plugin.js';
+import {
+  createDynamicEmberLanguagePlugin,
+  createEmberLanguagePlugin,
+} from './ember-language-plugin.js';
+
+/**
+ * Detect inferred project paths returned by tsserver for files
+ * not governed by any tsconfig.json or jsconfig.json.
+ * On Unix these look like `/dev/null/inferredProject1*`,
+ * on Windows like `/dev/null/inferredProject1*` as well (tsserver normalizes).
+ */
+function isInferredProject(configFileName: string): boolean {
+  return configFileName.includes('/dev/null/') || configFileName.includes('inferredProject');
+}
 
 const connection = createConnection();
 const server = createServer(connection);
@@ -65,6 +78,7 @@ connection.onInitialize((params) => {
   let simpleLs: LanguageService | undefined;
   let warnedMissingProjectInfo = false;
   let warnedSimpleLs = false;
+  let warnedInferredProject = false;
 
   return server.initialize(
     params,
@@ -92,12 +106,21 @@ connection.onInitialize((params) => {
           }
           if (projectInfo) {
             const { configFileName } = projectInfo;
-            let ls = tsconfigProjects.get(URI.file(configFileName));
-            if (!ls) {
-              ls = createLanguageServiceHelper(server, configFileName);
-              tsconfigProjects.set(URI.file(configFileName), ls);
+            if (!isInferredProject(configFileName)) {
+              let ls = tsconfigProjects.get(URI.file(configFileName));
+              if (!ls) {
+                ls = createLanguageServiceHelper(server, configFileName);
+                tsconfigProjects.set(URI.file(configFileName), ls);
+              }
+              return ls;
+            } else {
+              if (!warnedInferredProject) {
+                warnedInferredProject = true;
+                logInfo(
+                  `Inferred project detected for ${fileName} (${configFileName}); using simple LS.`,
+                );
+              }
             }
-            return ls;
           } else if (!warnedMissingProjectInfo) {
             warnedMissingProjectInfo = true;
             logWarn(`No tsserver project info for ${fileName}; falling back to simple LS.`);
@@ -155,8 +178,9 @@ connection.onInitialize((params) => {
       },
     ];
 
+    const configLoader = new ConfigLoader(logInfo);
+
     if (tsconfigFileName) {
-      const configLoader = new ConfigLoader(logInfo);
       const glintConfig = configLoader.configForFile(tsconfigFileName);
       if (glintConfig) {
         logInfo(`Glint config active for ${tsconfigFileName}.`);
@@ -166,7 +190,18 @@ connection.onInitialize((params) => {
         logWarn(`Glint config not found for ${tsconfigFileName}; Glint features disabled.`);
       }
     } else {
-      logWarn('No tsconfig/jsconfig provided; Glint config cannot be resolved.');
+      logInfo('No tsconfig/jsconfig; using dynamic Glint config resolution.');
+      const emberLanguagePlugin = createDynamicEmberLanguagePlugin(
+        (from: string) => configLoader.configForDirectory(from),
+        {
+          clientId: 'language-server',
+          getCurrentDirectory: () => {
+            const folders = [...server.workspaceFolders.all];
+            return folders.length > 0 ? URI.parse(folders[0].toString()).fsPath : process.cwd();
+          },
+        },
+      );
+      languagePlugins.push(emberLanguagePlugin);
     }
 
     const language = createLanguage<URI>(languagePlugins, createUriMap(), (uri) => {

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
 import { TransformedModule } from '@glint/ember-tsc/lib/transform';
 import * as path from 'node:path';
 
@@ -189,34 +190,42 @@ const plugin = createLanguageServicePlugin(
     // a config file we need to enable them explicitly.
     if ((compilerOptions as any).configFilePath === undefined) {
       const updatedOptions = info.project.getCompilerOptions();
-      const needsUpdate = !updatedOptions.allowJs || !updatedOptions.checkJs || !updatedOptions.types;
+      const needsUpdate = !updatedOptions.allowJs || !updatedOptions.checkJs;
       if (needsUpdate) {
         const newOptions: any = {
           ...updatedOptions,
           allowJs: true,
           checkJs: true,
         };
-
-        // Include ember-source/types so that ambient Ember type declarations
-        // (e.g. @glimmer/component) are visible for import suggestions.
-        // A jsconfig.json normally specifies this in compilerOptions.types.
-        if (!updatedOptions.types) {
-          const projectDir = info.languageServiceHost.getCurrentDirectory();
-          const types: string[] = [];
-          try {
-            const req = createRequire(path.join(projectDir, 'package.json'));
-            req.resolve('ember-source/types');
-            types.push('ember-source/types');
-          } catch {
-            // ember-source not installed; skip
-          }
-          if (types.length > 0) {
-            newOptions.types = types;
-            logInfo(`Inferred types for no-config project: ${types.join(', ')}`);
-          }
-        }
-
         info.project.setCompilerOptions(newOptions);
+      }
+
+      // Include ember-source/types so that ambient Ember type declarations
+      // (e.g. @glimmer/tracking, @ember/modifier) are visible for import
+      // suggestions and Quick Fix code actions.
+      //
+      // We can't use compilerOptions.types because TS type reference directive
+      // resolution only looks in @types/ directories and won't resolve sub-path
+      // exports like "ember-source/types". We also can't use require.resolve()
+      // because the export only has a "types" condition (no "require"/"default").
+      //
+      // Instead, we resolve the package root via package.json and inject the
+      // types file directly into the project's script file list.
+      const emberTypesFile = resolveEmberSourceTypesFile(
+        info.languageServiceHost.getCurrentDirectory(),
+      );
+      if (emberTypesFile) {
+        logInfo(`Injecting ember-source types from: ${emberTypesFile}`);
+        const origGetScriptFileNames = info.languageServiceHost.getScriptFileNames.bind(
+          info.languageServiceHost,
+        );
+        info.languageServiceHost.getScriptFileNames = () => {
+          const files = origGetScriptFileNames();
+          if (!files.includes(emberTypesFile)) {
+            return [...files, emberTypesFile];
+          }
+          return files;
+        };
       }
     }
 
@@ -360,6 +369,32 @@ const plugin = createLanguageServicePlugin(
 
 export = plugin;
 
+/**
+ * Resolve the absolute path to the ember-source ambient types entry point.
+ *
+ * ember-source's package.json exports `./types` with a `types`-only condition,
+ * which means `require.resolve('ember-source/types')` fails because Node's CJS
+ * resolver doesn't honour the `types` condition. It also means that
+ * `compilerOptions.types: ["ember-source/types"]` doesn't work because TS
+ * type-reference-directive resolution only checks `@types/` directories.
+ *
+ * Instead, we resolve `ember-source/package.json` (which IS exported) and
+ * construct the known path to `types/stable/index.d.ts`.
+ */
+function resolveEmberSourceTypesFile(projectDir: string): string | null {
+  try {
+    const req = createRequire(path.join(projectDir, 'package.json'));
+    const pkgJsonPath = req.resolve('ember-source/package.json');
+    const typesFile = path.join(path.dirname(pkgJsonPath), 'types', 'stable', 'index.d.ts');
+    if (existsSync(typesFile)) {
+      return typesFile;
+    }
+  } catch {
+    // ember-source not installed; skip
+  }
+  return null;
+}
+
 function findConfigForProject(
   info: ts.server.PluginCreateInfo,
   findConfig: (from: string) => any,
@@ -411,7 +446,8 @@ function proxyLanguageServiceForGlint<T>(
       case 'getCompletionsAtPosition':
         return getCompletionsAtPosition(ts, language, languageService, asScriptId, target[p]);
       // case 'getCompletionEntryDetails': return getCompletionEntryDetails(language, asScriptId, target[p]);
-      // case 'getCodeFixesAtPosition': return getCodeFixesAtPosition(target[p]);
+      case 'getCodeFixesAtPosition':
+        return getCodeFixesAtPositionProxy(ts, language, languageService, asScriptId, target[p]);
       // case 'getDefinitionAndBoundSpan': return getDefinitionAndBoundSpan(ts, language, languageService, glintOptions, asScriptId, target[p]);
       // case 'getQuickInfoAtPosition': return getQuickInfoAtPosition(ts, target, target[p]);
       // TS plugin only
@@ -526,6 +562,127 @@ function getSemanticDiagnostics<T>(
 }
 
 const windowsPathReg = /\\/g;
+
+/**
+ * Well-known Ember import mappings for identifiers whose export names
+ * differ from their conventional import aliases (e.g. `Component` is
+ * conventionally imported from `@glimmer/component` but the package's
+ * default export is actually named `GlimmerComponent`).
+ *
+ * Each entry maps an identifier name to the module specifier and whether
+ * it is a default or named import.
+ */
+const EMBER_IMPORT_MAP: Record<
+  string,
+  { module: string; isDefault: boolean }
+> = {
+  // GlimmerComponent's default export is named `GlimmerComponent`, not `Component`,
+  // so TS's native fixMissingImport can't match the conventional `Component` alias.
+  Component: { module: '@glimmer/component', isDefault: true },
+};
+
+/**
+ * Error codes for "Cannot find name" diagnostics that may be fixable
+ * by adding an import.
+ */
+const MISSING_NAME_ERROR_CODES = [
+  2304, // Cannot find name '{0}'.
+  2552, // Cannot find name '{0}'. Did you mean '{1}'?
+];
+
+/**
+ * Augment TypeScript's code fixes to inject well-known Ember import
+ * suggestions when TS doesn't natively offer them (e.g. because the
+ * export name differs from the conventional import alias).
+ */
+function getCodeFixesAtPositionProxy<T>(
+  ts: typeof import('typescript'),
+  language: any,
+  languageService: ts.LanguageService,
+  asScriptId: (fileName: string) => T,
+  original: ts.LanguageService['getCodeFixesAtPosition'],
+): ts.LanguageService['getCodeFixesAtPosition'] {
+  return (fileName, start, end, errorCodes, formatOptions, preferences) => {
+    const fixes = original(fileName, start, end, errorCodes, formatOptions, preferences);
+
+    // Only augment for "Cannot find name" errors.
+    if (!errorCodes.some((code) => MISSING_NAME_ERROR_CODES.includes(code))) {
+      return fixes;
+    }
+
+    // Use Volar's language.scripts API to get the file content.
+    // We cannot use program.getSourceFile(fileName) because for .gjs/.gts files,
+    // Volar maps filenames to virtual files, so the original name won't match.
+    const sourceScript = language.scripts.get(asScriptId(fileName));
+    const snapshot = sourceScript?.snapshot;
+    if (!snapshot) {
+      return fixes;
+    }
+
+    // Extract the identifier text at the error span.
+    const identifierText = snapshot.getText(start, end).trim();
+    const mapping = EMBER_IMPORT_MAP[identifierText];
+    if (!mapping) {
+      return fixes;
+    }
+
+    // Check if any existing fix already references the correct module.
+    const alreadySuggested = fixes.some(
+      (fix) =>
+        fix.fixName === 'import' &&
+        fix.changes.some((change) =>
+          change.textChanges.some((tc) => tc.newText.includes(mapping.module)),
+        ),
+    );
+
+    if (alreadySuggested) {
+      return fixes;
+    }
+
+    // Build the import statement.
+    const importText = mapping.isDefault
+      ? `import ${identifierText} from '${mapping.module}';\n`
+      : `import { ${identifierText} } from '${mapping.module}';\n`;
+
+    // Find the insert position: after the last import statement, or at the
+    // start of the file. We scan the file text for import lines.
+    const fileText = snapshot.getText(0, snapshot.getLength());
+    let insertPosition = 0;
+    // Simple regex to find the end of the last import statement.
+    const importRegex = /^import\s.+$/gm;
+    let match;
+    while ((match = importRegex.exec(fileText)) !== null) {
+      const lineEnd = match.index + match[0].length;
+      // Move past the trailing newline if present.
+      if (lineEnd < fileText.length && fileText.charCodeAt(lineEnd) === 10) {
+        insertPosition = lineEnd + 1;
+      } else {
+        insertPosition = lineEnd;
+      }
+    }
+
+    const emberFix: ts.CodeFixAction = {
+      fixName: 'import',
+      description: `Add import from "${mapping.module}"`,
+      changes: [
+        {
+          fileName,
+          textChanges: [
+            {
+              span: { start: insertPosition, length: 0 },
+              newText: importText,
+            },
+          ],
+        },
+      ],
+      fixId: 'fixMissingImport',
+      fixAllDescription: 'Add all missing imports',
+    };
+
+    // Prepend so it appears first in the Quick Fix menu.
+    return [emberFix, ...fixes];
+  };
+}
 
 /**
  * Return semantic tokens for semantic highlighting:

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -189,12 +189,34 @@ const plugin = createLanguageServicePlugin(
     // a config file we need to enable them explicitly.
     if ((compilerOptions as any).configFilePath === undefined) {
       const updatedOptions = info.project.getCompilerOptions();
-      if (!updatedOptions.allowJs || !updatedOptions.checkJs) {
-        info.project.setCompilerOptions({
+      const needsUpdate = !updatedOptions.allowJs || !updatedOptions.checkJs || !updatedOptions.types;
+      if (needsUpdate) {
+        const newOptions: any = {
           ...updatedOptions,
           allowJs: true,
           checkJs: true,
-        });
+        };
+
+        // Include ember-source/types so that ambient Ember type declarations
+        // (e.g. @glimmer/component) are visible for import suggestions.
+        // A jsconfig.json normally specifies this in compilerOptions.types.
+        if (!updatedOptions.types) {
+          const projectDir = info.languageServiceHost.getCurrentDirectory();
+          const types: string[] = [];
+          try {
+            const req = createRequire(path.join(projectDir, 'package.json'));
+            req.resolve('ember-source/types');
+            types.push('ember-source/types');
+          } catch {
+            // ember-source not installed; skip
+          }
+          if (types.length > 0) {
+            newOptions.types = types;
+            logInfo(`Inferred types for no-config project: ${types.join(', ')}`);
+          }
+        }
+
+        info.project.setCompilerOptions(newOptions);
       }
     }
 

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -183,6 +183,21 @@ const plugin = createLanguageServicePlugin(
       });
     }
 
+    // For inferred projects (no tsconfig/jsconfig), enable allowJs and checkJs
+    // so that .gjs files (which become .js via Glint's transformation) get
+    // semantic diagnostics. jsconfig.json implicitly sets these, but without
+    // a config file we need to enable them explicitly.
+    if ((compilerOptions as any).configFilePath === undefined) {
+      const updatedOptions = info.project.getCompilerOptions();
+      if (!updatedOptions.allowJs || !updatedOptions.checkJs) {
+        info.project.setCompilerOptions({
+          ...updatedOptions,
+          allowJs: true,
+          checkJs: true,
+        });
+      }
+    }
+
     if (glintConfig) {
       const gtsLanguagePlugin = createEmberLanguagePlugin(glintConfig, {
         clientId: 'tsserver-plugin',

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -1,5 +1,5 @@
-import type { TransformedModule } from '@glint/ember-tsc/lib/transform';
 import { createRequire } from 'node:module';
+import { TransformedModule } from '@glint/ember-tsc/lib/transform';
 import * as path from 'node:path';
 
 const { createJiti } = require('jiti');
@@ -171,9 +171,17 @@ const plugin = createLanguageServicePlugin(
 
     logInfo(`Using ${resolved.source} ember-tsc from ${resolved.resolvedPath}.`);
 
-    const { findConfig, createEmberLanguagePlugin } = emberTsc;
-    const cwd = info.languageServiceHost.getCurrentDirectory();
-    const glintConfig = findConfig(cwd);
+    const { findConfig, createDynamicEmberLanguagePlugin, createEmberLanguagePlugin } = emberTsc;
+    const glintConfig = findConfigForProject(info, findConfig);
+
+    const compilerOptions = info.project.getCompilerOptions();
+    if (compilerOptions.moduleResolution == null) {
+      info.project.setCompilerOptions({
+        ...compilerOptions,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        module: compilerOptions.module ?? ts.ModuleKind.ESNext,
+      });
+    }
 
     if (glintConfig) {
       const gtsLanguagePlugin = createEmberLanguagePlugin(glintConfig, {
@@ -251,10 +259,22 @@ const plugin = createLanguageServicePlugin(
         },
       };
     } else {
-      logInfo('Glint TS Plugin is not running: no Glint config was found.');
+      logInfo('Glint TS Plugin did not find config at init; using dynamic activation.');
 
+      const gtsLanguagePlugin = createDynamicEmberLanguagePlugin(findConfig, {
+        clientId: 'tsserver-plugin',
+        getCurrentDirectory: () => info.languageServiceHost.getCurrentDirectory(),
+      });
       return {
-        languagePlugins: [],
+        languagePlugins: [gtsLanguagePlugin],
+        setup: (language: any) => {
+          info.languageService = proxyLanguageServiceForGlint(
+            ts,
+            language,
+            info.languageService,
+            (fileName) => fileName,
+          );
+        },
       };
     }
 
@@ -302,6 +322,43 @@ const plugin = createLanguageServicePlugin(
 );
 
 export = plugin;
+
+function findConfigForProject(
+  info: ts.server.PluginCreateInfo,
+  findConfig: (from: string) => any,
+): any {
+  const candidateDirs: string[] = [];
+  const projectCurrentDirectory =
+    typeof (info.project as any).getCurrentDirectory === 'function'
+      ? (info.project as any).getCurrentDirectory()
+      : undefined;
+
+  if (projectCurrentDirectory) {
+    candidateDirs.push(projectCurrentDirectory);
+  }
+
+  candidateDirs.push(info.languageServiceHost.getCurrentDirectory());
+
+  const scriptFileNames = info.project.getScriptFileNames();
+  for (const fileName of scriptFileNames) {
+    if (fileName.endsWith('.gts') || fileName.endsWith('.gjs')) {
+      candidateDirs.push(path.dirname(fileName));
+    }
+  }
+
+  for (const fileName of scriptFileNames) {
+    candidateDirs.push(path.dirname(fileName));
+  }
+
+  for (const dir of candidateDirs) {
+    const config = findConfig(dir);
+    if (config) {
+      return config;
+    }
+  }
+
+  return null;
+}
 
 function proxyLanguageServiceForGlint<T>(
   ts: typeof import('typescript'),

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -18,9 +18,7 @@ tsconfig.tsbuildinfo
 
 node_modules/**/
 !node_modules/glint-tsserver-plugin-pack/index.js
-!node_modules/glint-ember-tsc-pack/index.js
-!node_modules/glint-ember-tsc-pack/bin/glint-language-server.js
-!node_modules/glint-ember-tsc-pack/content_tag_bg.wasm
-!node_modules/glint-ember-tsc-pack/bin/content_tag_bg.wasm
+!node_modules/glint-ember-tsc-pack/**
+
 
 scripts/

--- a/packages/vscode/__fixtures__/ember-app-no-config/package.json
+++ b/packages/vscode/__fixtures__/ember-app-no-config/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-app-no-config",
+  "private": true
+}

--- a/packages/vscode/__fixtures__/ember-app-no-config/src/GreetingUntyped.gjs
+++ b/packages/vscode/__fixtures__/ember-app-no-config/src/GreetingUntyped.gjs
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class Greeting extends Component {
+  message = 'Hello';
+
+  <template>
+    {{this.message}}, {{@target}}!
+  </template>
+}

--- a/packages/vscode/__fixtures__/ember-app-no-config/src/OtherUntyped.gjs
+++ b/packages/vscode/__fixtures__/ember-app-no-config/src/OtherUntyped.gjs
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import Colocated from './colocated-folder';
+import Greeting from './GreetingUntyped';
+
+export default class Other extends Component {
+  message = 'Hello';
+
+  <template>
+    <Greeting @target="World" data-test-whatever data-test="value" />
+    <Colocated @target="World" />
+  </template>
+}

--- a/packages/vscode/scripts/build.mjs
+++ b/packages/vscode/scripts/build.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
-import { copyFile, mkdir } from 'node:fs/promises';
+import { copyFile, cp, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -22,6 +22,7 @@ const ctx = await context({
     'node_modules/glint-ember-tsc-pack/index': '../core/lib/index.js',
     'node_modules/glint-ember-tsc-pack/bin/glint-language-server':
       '../core/bin/glint-language-server.js',
+    'node_modules/glint-ember-tsc-pack/language-server': '../core/lib/volar/language-server.js',
   },
   external: ['vscode'],
   logLevel: 'info',
@@ -76,15 +77,82 @@ async function copyWasmFile() {
   }
 }
 
+async function copyHtmlLanguageService() {
+  try {
+    // Find vscode-html-languageservice dynamically in pnpm store
+    const workspaceRoot = join(__dirname, '../../../');
+    const pnpmDir = join(workspaceRoot, 'node_modules/.pnpm');
+    
+    // Find the vscode-html-languageservice directory
+    const fs = await import('node:fs/promises');
+    const files = await fs.readdir(pnpmDir);
+    const htmlServiceDir = files.find(f => f.startsWith('vscode-html-languageservice@'));
+    
+    if (!htmlServiceDir) {
+      console.warn('vscode-html-languageservice not found in pnpm store');
+      return;
+    }
+    
+    // Copy the entire vscode-html-languageservice package with its node_modules dependencies
+    // Use dereference: true to follow symlinks and avoid circular reference issues with pnpm
+    const sourceDir = join(pnpmDir, htmlServiceDir, 'node_modules');
+    const targetDir = join(__dirname, '../node_modules/glint-ember-tsc-pack/node_modules');
+
+    // Remove target directory if it exists to avoid symlink conflicts
+    try {
+      await fs.rm(targetDir, { recursive: true, force: true });
+    } catch (e) {
+      // Ignore if directory doesn't exist
+    }
+
+    await mkdir(targetDir, { recursive: true });
+    await cp(sourceDir, targetDir, { recursive: true, dereference: true });
+    console.log('Copied vscode-html-languageservice and its dependencies to glint-ember-tsc-pack');
+  } catch (error) {
+    console.error('Failed to copy vscode-html-languageservice files:', error);
+  }
+}
+
+async function copyTypeScript() {
+  try {
+    // Find TypeScript dynamically in pnpm store
+    const workspaceRoot = join(__dirname, '../../../');
+    const pnpmDir = join(workspaceRoot, 'node_modules/.pnpm');
+    
+    const fs = await import('node:fs/promises');
+    const files = await fs.readdir(pnpmDir);
+    const tsDir = files.find(f => f.startsWith('typescript@'));
+    
+    if (!tsDir) {
+      console.warn('TypeScript not found in pnpm store');
+      return;
+    }
+    
+    // Copy the entire TypeScript package with its dependencies
+    const sourceDir = join(pnpmDir, tsDir, 'node_modules');
+    const targetDir = join(__dirname, '../node_modules/glint-ember-tsc-pack/node_modules');
+
+    await mkdir(targetDir, { recursive: true });
+    await cp(sourceDir, targetDir, { recursive: true, dereference: true });
+    console.log('Copied TypeScript to glint-ember-tsc-pack');
+  } catch (error) {
+    console.error('Failed to copy TypeScript files:', error);
+  }
+}
+
 if (watch) {
   // Start watch mode
   await ctx.watch();
   await copyWasmFile();
+  await copyHtmlLanguageService();
+  await copyTypeScript();
   console.log('Watching for changes...');
 } else {
   // Do a single build
   await ctx.rebuild();
   await copyWasmFile();
+  await copyHtmlLanguageService();
+  await copyTypeScript();
   await ctx.dispose();
 }
 

--- a/packages/vscode/scripts/build.mjs
+++ b/packages/vscode/scripts/build.mjs
@@ -82,17 +82,17 @@ async function copyHtmlLanguageService() {
     // Find vscode-html-languageservice dynamically in pnpm store
     const workspaceRoot = join(__dirname, '../../../');
     const pnpmDir = join(workspaceRoot, 'node_modules/.pnpm');
-    
+
     // Find the vscode-html-languageservice directory
     const fs = await import('node:fs/promises');
     const files = await fs.readdir(pnpmDir);
-    const htmlServiceDir = files.find(f => f.startsWith('vscode-html-languageservice@'));
-    
+    const htmlServiceDir = files.find((f) => f.startsWith('vscode-html-languageservice@'));
+
     if (!htmlServiceDir) {
       console.warn('vscode-html-languageservice not found in pnpm store');
       return;
     }
-    
+
     // Copy the entire vscode-html-languageservice package with its node_modules dependencies
     // Use dereference: true to follow symlinks and avoid circular reference issues with pnpm
     const sourceDir = join(pnpmDir, htmlServiceDir, 'node_modules');
@@ -118,16 +118,16 @@ async function copyTypeScript() {
     // Find TypeScript dynamically in pnpm store
     const workspaceRoot = join(__dirname, '../../../');
     const pnpmDir = join(workspaceRoot, 'node_modules/.pnpm');
-    
+
     const fs = await import('node:fs/promises');
     const files = await fs.readdir(pnpmDir);
-    const tsDir = files.find(f => f.startsWith('typescript@'));
-    
+    const tsDir = files.find((f) => f.startsWith('typescript@'));
+
     if (!tsDir) {
       console.warn('TypeScript not found in pnpm store');
       return;
     }
-    
+
     // Copy the entire TypeScript package with its dependencies
     const sourceDir = join(pnpmDir, tsDir, 'node_modules');
     const targetDir = join(__dirname, '../node_modules/glint-ember-tsc-pack/node_modules');

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -496,7 +496,7 @@ function resolveBundledEmberTscServerPath(): string | undefined {
 
     const bundledPath = path.join(
       glintExtension.extensionPath,
-      'node_modules/glint-ember-tsc-pack/bin/glint-language-server.js',
+      'node_modules/glint-ember-tsc-pack/language-server.js',
     );
 
     return fs.existsSync(bundledPath) ? bundledPath : undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,34 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  test-packages/ts-template-imports-app-no-config:
+    dependenciesMeta:
+      '@glint/ember-tsc':
+        injected: true
+      '@glint/template':
+        injected: true
+      '@glint/tsserver-plugin':
+        injected: true
+    devDependencies:
+      '@glimmer/component':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@glint/ember-tsc':
+        specifier: workspace:*
+        version: file:packages/core(typescript@5.9.3)
+      '@glint/template':
+        specifier: workspace:*
+        version: file:packages/template
+      '@glint/tsserver-plugin':
+        specifier: workspace:*
+        version: file:packages/tsserver-plugin
+      ember-source:
+        specifier: ^6.2.0
+        version: 6.7.0(@glimmer/component@2.0.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   test-packages/unstable-release:
     dependencies:
       execa:

--- a/test-packages/package-test-core/__tests__/config/config-loader.test.ts
+++ b/test-packages/package-test-core/__tests__/config/config-loader.test.ts
@@ -1,0 +1,15 @@
+import { findConfig } from '@glint/ember-tsc';
+import * as path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+describe('ConfigLoader', () => {
+  test('activates without tsconfig when package.json has Glint deps', () => {
+    const fixtureRoot = path.resolve(__dirname, '../../../ts-template-imports-app-no-config');
+
+    const config = findConfig(fixtureRoot);
+
+    expect(config).not.toBeNull();
+    expect(config!.environment.getSourceKind('example.gts')).toBe('typed-script');
+    expect(config!.environment.getSourceKind('example.gjs')).toBe('untyped-script');
+  });
+});

--- a/test-packages/package-test-core/__tests__/language-server/code-fixes.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/code-fixes.test.ts
@@ -1,0 +1,102 @@
+import { stripIndent } from 'common-tags';
+import {
+  getSharedTestWorkspaceHelper,
+  prepareDocument,
+  requestTsserverDiagnostics,
+  teardownSharedTestWorkspaceAfterEach,
+} from 'glint-monorepo-test-utils';
+import { URI } from 'vscode-uri';
+import { afterEach, describe, expect, test } from 'vitest';
+
+describe('Language Server: Code Fixes (ts plugin)', () => {
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('suggests @glimmer/component import for Component identifier (.gts)', async () => {
+    const code = stripIndent`
+      export default class Application extends Component {
+        <template>
+          hello
+        </template>
+      }
+    `;
+
+    const fixes = await requestCodeFixes(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+      'Component',
+      [2304],
+    );
+
+    const glimmerFix = fixes.find(
+      (fix: any) => fix.description?.includes('@glimmer/component'),
+    );
+
+    expect(glimmerFix).toBeDefined();
+    expect(glimmerFix.description).toContain('@glimmer/component');
+  });
+
+  test('suggests @glimmer/component import for Component identifier (.gjs)', async () => {
+    const code = stripIndent`
+      export default class Application extends Component {
+        <template>
+          hello
+        </template>
+      }
+    `;
+
+    const fixes = await requestCodeFixes(
+      'ts-template-imports-app-no-config/src/empty-fixture.gjs',
+      'glimmer-js',
+      code,
+      'Component',
+      [2304],
+    );
+
+    const glimmerFix = fixes.find(
+      (fix: any) => fix.description?.includes('@glimmer/component'),
+    );
+
+    expect(glimmerFix).toBeDefined();
+    expect(glimmerFix.description).toContain('@glimmer/component');
+  });
+});
+
+async function requestCodeFixes(
+  fileName: string,
+  languageId: string,
+  content: string,
+  identifierText: string,
+  errorCodes: number[],
+): Promise<any[]> {
+  const workspaceHelper = await getSharedTestWorkspaceHelper();
+  const document = await prepareDocument(fileName, languageId, content);
+  const filePath = URI.parse(document.uri).fsPath;
+
+  // Find the position of the identifier in the content (line/offset, 1-based).
+  const offset = content.indexOf(identifierText);
+  expect(offset).toBeGreaterThanOrEqual(0);
+
+  const beforeIdentifier = content.slice(0, offset);
+  const lines = beforeIdentifier.split('\n');
+  const startLine = lines.length;
+  const startOffset = lines[lines.length - 1].length + 1; // 1-based
+
+  const endOffset = startOffset + identifierText.length;
+
+  const res = await workspaceHelper.tsserver.message({
+    seq: workspaceHelper.nextSeq(),
+    command: 'getCodeFixes',
+    arguments: {
+      file: filePath,
+      startLine,
+      startOffset,
+      endLine: startLine,
+      endOffset,
+      errorCodes,
+    },
+  });
+
+  expect(res.success).toBe(true);
+  return res.body ?? [];
+}

--- a/test-packages/package-test-core/__tests__/language-server/completions.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/completions.test.ts
@@ -311,6 +311,38 @@ describe('Language Server: Completions (ts plugin)', () => {
       await requestCompletion('ts-template-imports-app/src/index.gts', 'typescript', code),
     ).toMatchInlineSnapshot();
   });
+
+  test('import suggestions available without tsconfig (.gjs)', async () => {
+    const completions = await requestCompletion(
+      'ts-template-imports-app-no-config/src/empty-fixture.gjs',
+      'glimmer-js',
+      stripIndent`
+        import Component from '%';
+      `,
+    );
+
+    const glimmerComponent = completions.find(
+      (item: any) => item.name === '@glimmer/component',
+    );
+
+    expect(glimmerComponent).toBeDefined();
+  });
+
+  test('import suggestions available without tsconfig (.gts)', async () => {
+    const completions = await requestCompletion(
+      'ts-template-imports-app-no-config/src/empty-fixture.gts',
+      'glimmer-ts',
+      stripIndent`
+        import Component from '%';
+      `,
+    );
+
+    const glimmerComponent = completions.find(
+      (item: any) => item.name === '@glimmer/component',
+    );
+
+    expect(glimmerComponent).toBeDefined();
+  });
 });
 
 async function requestCompletionItem(

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -73,6 +73,28 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     `);
   });
 
+  test('activates without tsconfig when package.json has Glint deps', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Application extends Component {
+        private message = 'Hello';
+
+        <template>
+          {{this.message}}
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app-no-config/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`[]`);
+  });
+
   test('honors @glint-expect-error / ignore shared test throws error', async () => {
     const componentA = stripIndent`
       import Component from '@glimmer/component';

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -73,7 +73,7 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     `);
   });
 
-  test('activates without tsconfig when package.json has Glint deps', async () => {
+  test('activates without tsconfig when package.json has Glint deps (.gts)', async () => {
     const code = stripIndent`
       import Component from '@glimmer/component';
 
@@ -93,6 +93,51 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     );
 
     expect(diagnostics).toMatchInlineSnapshot(`[]`);
+  });
+
+  test('activates without tsconfig when package.json has Glint deps (.gjs)', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Application extends Component {
+        message = 'Hello';
+
+        <template>
+          {{this.message}}
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app-no-config/src/empty-fixture.gjs',
+      'glimmer-js',
+      code,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`[]`);
+  });
+
+  test('reports diagnostics in .gjs without tsconfig', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Application extends Component {
+        message = 'Hello';
+
+        <template>
+          {{this.messag}}
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app-no-config/src/empty-fixture.gjs',
+      'glimmer-js',
+      code,
+    );
+
+    expect(diagnostics.length).toBeGreaterThan(0);
+    expect(diagnostics[0].code).toBe(2551);
   });
 
   test('honors @glint-expect-error / ignore shared test throws error', async () => {

--- a/test-packages/package-test-core/__tests__/language-server/hover.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/hover.test.ts
@@ -9,6 +9,36 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 
+describe('Language Server: Hover (ts plugin) - no config', () => {
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('activates without tsconfig when package.json has Glint deps', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Application extends Component {
+        private message = 'Hello';
+
+        <template>
+          {{this.mess%age}}
+        </template>
+      }
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app-no-config/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const hoverInfo = await performHoverRequest(doc, offset);
+
+    expect(hoverInfo).toBeDefined();
+    expect(hoverInfo.displayString).toContain('message');
+    expect(hoverInfo.displayString).toContain('string');
+  });
+});
+
 // skipped because giving more complicated displayString and documentation exposing my local file paths.
 describe.skip('Language Server: Hover (ts plugin)', () => {
   afterEach(teardownSharedTestWorkspaceAfterEach);

--- a/test-packages/ts-template-imports-app-no-config/package.json
+++ b/test-packages/ts-template-imports-app-no-config/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ts-template-imports-app-no-config",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "dependenciesMeta": {
+    "@glint/template": {
+      "injected": true
+    },
+    "@glint/ember-tsc": {
+      "injected": true
+    },
+    "@glint/tsserver-plugin": {
+      "injected": true
+    }
+  },
+  "devDependencies": {
+    "@glimmer/component": "^2.0.0",
+    "@glint/ember-tsc": "workspace:*",
+    "@glint/template": "workspace:*",
+    "@glint/tsserver-plugin": "workspace:*",
+    "ember-source": "^6.2.0",
+    "typescript": "^5.9.3"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}


### PR DESCRIPTION
This tweaks the logic for when glint should activate (which has to happen independent of opening a file (for vscode reasons))


To test it out:

[glint2-vscode-1.0.3-no-config.zip](https://github.com/user-attachments/files/25222917/glint2-vscode-1.0.3-no-config.zip)


> [!IMPORTANT]
> in order for template-aware intellisense, you _MUST_ have `@glint/template` and `@glint/ember-tsc` installed (which means also having typescript) -- this is because the Volar virtual files require `@glint/template` and `@glint/ember-tsc` and import _as if_ your app defined these dependencies.


> [!NOTE]
> in order to get intellisense for ember-source things, you _MUST_ have a jsconfig.json or tsconfig.json

This PR is about making the experience not terrible for folks that haven't done either of the above