### PR TITLE
ember-tsc: add fullSemanticMode option for standalone LSP clients

### DIFF
--- a/packages/ember-tsc/src/volar/language-server.ts
+++ b/packages/ember-tsc/src/volar/language-server.ts
@@ -3,11 +3,13 @@ import { createLanguage } from '@volar/language-core';
 import type { LanguagePlugin, LanguageServer } from '@volar/language-server';
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject.js';
 import { createConnection, createServer } from '@volar/language-server/node.js';
+import { createTypeScriptProject } from '@volar/language-server/lib/project/typescriptProject.js';
 import type { LanguageServiceContext, LanguageServicePlugin } from '@volar/language-service';
 import { createLanguageService, createUriMap, LanguageService } from '@volar/language-service';
 import * as ts from 'typescript';
 import { create as createHtmlSyntacticPlugin } from 'volar-service-html';
 import { create as createTypeScriptSyntacticPlugin } from 'volar-service-typescript/lib/plugins/syntactic.js';
+import { create as createTypeScriptSemanticPlugin } from 'volar-service-typescript/lib/plugins/semantic.js';
 import { URI } from 'vscode-uri';
 import { ConfigLoader } from '../config/loader.js';
 import { createDefaultConfig } from '../config/index.js';
@@ -54,6 +56,33 @@ connection.onInitialize((params) => {
     logWarn('No workspace folder or root URI provided by client.');
   }
 
+  const fullSemanticMode = !!(params.initializationOptions as any)?.fullSemanticMode;
+
+  if (fullSemanticMode) {
+    logInfo('Using full semantic mode (createTypeScriptProject).');
+    return server.initialize(
+      params,
+      createTypeScriptProject(ts, undefined, async ({ configFileName }) => {
+        const languagePlugins = [];
+        if (configFileName) {
+          const configLoader = new ConfigLoader(logInfo);
+          const glintConfig = configLoader.configForFile(configFileName);
+          if (glintConfig) {
+            logInfo(`Glint config active for ${configFileName}.`);
+            languagePlugins.push(createEmberLanguagePlugin(glintConfig));
+          } else {
+            logWarn(`Glint config not found for ${configFileName}; Glint features disabled.`);
+          }
+        } else {
+          logWarn('No tsconfig/jsconfig provided; Glint config cannot be resolved.');
+        }
+        return { languagePlugins };
+      }),
+      getLanguageServicePluginsForLanguageServer(),
+    );
+  }
+
+  logInfo('Using hybrid mode (tsserver delegation).');
   const tsconfigProjects = createUriMap<LanguageService>();
 
   server.fileWatcher.onDidChangeWatchedFiles((obj: any) => {
@@ -189,6 +218,18 @@ connection.onInitialize((params) => {
 connection.onInitialized(server.initialized);
 
 connection.onShutdown(server.shutdown);
+
+function getLanguageServicePluginsForLanguageServer(): LanguageServicePlugin[] {
+  return [
+    // Lightweight syntax-only TS Language Service. Provides Symbols (e.g. Outline view) and other features.
+    createTypeScriptSyntacticPlugin(ts),
+    createHtmlSyntacticPlugin(),
+    // Full TypeScript semantic language service for diagnostics, completions, etc.
+    createTypeScriptSemanticPlugin(ts),
+    createTemplateTagSymbolsPlugin(),
+    createCompilerErrorsPlugin(),
+  ];
+}
 
 function getHybridModeLanguageServicePluginsForLanguageServer(
   tsPluginClient: TsPluginClient,

--- a/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
@@ -1,0 +1,216 @@
+import { stripIndent } from 'common-tags';
+import {
+  requestFullSemanticModeDiagnostics,
+  teardownFullSemanticModeWorkspaceAfterEach,
+  prepareDocumentFullSemanticMode,
+  getFullSemanticModeWorkspaceHelper,
+  extractCursor,
+} from 'glint-monorepo-test-utils';
+import { afterEach, describe, expect, test } from 'vitest';
+import { Position } from '@volar/language-server';
+import { URI } from 'vscode-uri';
+
+describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => {
+  // Full semantic mode startup (createTypeScriptProject) takes longer than hybrid mode.
+  afterEach(teardownFullSemanticModeWorkspaceAfterEach, 60_000);
+
+  test('reports a type error in an inline template', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      type ApplicationArgs = { version: string };
+
+      export default class Application extends Component<{ Args: ApplicationArgs }> {
+        private startupTime = new Date().toISOString();
+
+        <template>
+          Welcome to app <code>v{{@version}}</code>.
+          The current time is {{this.startupTimee}}.
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestFullSemanticModeDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    const typeError = diagnostics.find((d: any) => d.code === 2551);
+    expect(typeError).toBeDefined();
+    expect(typeError.message).toContain('startupTimee');
+    expect(typeError.message).toContain('startupTime');
+  });
+
+  test('reports no diagnostics for a valid template', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      type ApplicationArgs = { version: string };
+
+      export default class Application extends Component<{ Args: ApplicationArgs }> {
+        private startupTime = new Date().toISOString();
+
+        <template>
+          Welcome to app <code>v{{@version}}</code>.
+          The current time is {{this.startupTime}}.
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestFullSemanticModeDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    const typeErrors = diagnostics.filter((d: any) => d.severity === 1);
+    expect(typeErrors).toHaveLength(0);
+  });
+
+  test('syntax error in template is reported', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class MyComponent extends Component {
+        <template>
+          <div>SYNTAX {{ERROR</div>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestFullSemanticModeDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    const syntaxError = diagnostics.find((d: any) => d.message?.includes('Parse error'));
+    expect(syntaxError).toBeDefined();
+    expect(syntaxError.severity).toBe(1);
+  });
+
+  test('plugin deactivates for project without glint config', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Application extends Component {
+        private startupTime = new Date().toISOString();
+
+        <template>
+          The current time is {{this.startupTimee}}.
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestFullSemanticModeDiagnostics(
+      'ts-template-imports-app-no-config/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    // Without glint config, template type-checking (2551/2339) should not be reported.
+    const templateTypeErrors = diagnostics.filter(
+      (d: any) => d.code === 2551 || d.code === 2339,
+    );
+    expect(templateTypeErrors).toHaveLength(0);
+  });
+
+  test('completions are provided in full semantic mode', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class MyComponent extends Component {
+        private startupTime = new Date().toISOString();
+
+        <template>
+          {{this.startup%}}
+        </template>
+      }
+    `);
+
+    const server = await getFullSemanticModeWorkspaceHelper();
+    const document = await prepareDocumentFullSemanticMode(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    // Convert character offset to LSP Position
+    const textBefore = content.slice(0, offset);
+    const lines = textBefore.split('\n');
+    const position: Position = {
+      line: lines.length - 1,
+      character: lines[lines.length - 1].length,
+    };
+
+    const completions = await server.sendCompletionRequest(document.uri, position);
+    expect(completions).not.toBeNull();
+    const items = completions?.items ?? [];
+    const startupTimeCompletion = items.find((item: any) => item.label === 'startupTime');
+    expect(startupTimeCompletion).toBeDefined();
+  });
+
+  test('hover info is provided in full semantic mode', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class MyComponent extends Component {
+        private startupTime% = new Date().toISOString();
+
+        <template>
+          {{this.startupTime}}
+        </template>
+      }
+    `);
+
+    const server = await getFullSemanticModeWorkspaceHelper();
+    const document = await prepareDocumentFullSemanticMode(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const textBefore = content.slice(0, offset);
+    const lines = textBefore.split('\n');
+    const position: Position = {
+      line: lines.length - 1,
+      character: lines[lines.length - 1].length,
+    };
+
+    const hover = await server.sendHoverRequest(document.uri, position);
+    expect(hover).not.toBeNull();
+    const hoverText = JSON.stringify(hover?.contents ?? '');
+    expect(hoverText).toContain('startupTime');
+  });
+
+  test('passing wrong arg to component is an error in full semantic mode', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface GreetingSignature {
+        Args: { target: string };
+      }
+
+      class Greeting extends Component<GreetingSignature> {
+        <template>{{@target}}</template>
+      }
+
+      export default class extends Component {
+        <template>
+          <Greeting @target2="world" />
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestFullSemanticModeDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    const argError = diagnostics.find((d: any) => d.code === 2561 || d.code === 2353);
+    expect(argError).toBeDefined();
+    expect(argError.message).toContain('target2');
+  });
+});

--- a/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
@@ -8,7 +8,6 @@ import {
 } from 'glint-monorepo-test-utils';
 import { afterEach, describe, expect, test } from 'vitest';
 import { Position } from '@volar/language-server';
-import { URI } from 'vscode-uri';
 
 describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => {
   // Full semantic mode startup (createTypeScriptProject) takes longer than hybrid mode.
@@ -39,7 +38,8 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
     const typeError = diagnostics.find((d: any) => d.code === 2551);
     expect(typeError).toBeDefined();
     expect(typeError.message).toContain('startupTimee');
-    expect(typeError.message).toContain('startupTime');
+    // Use "Did you mean" phrasing to avoid false positive: 'startupTime' is a substring of 'startupTimee'
+    expect(typeError.message).toContain("Did you mean 'startupTime'");
   });
 
   test('reports no diagnostics for a valid template', async () => {
@@ -64,8 +64,7 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
       code,
     );
 
-    const typeErrors = diagnostics.filter((d: any) => d.severity === 1);
-    expect(typeErrors).toHaveLength(0);
+    expect(diagnostics).toHaveLength(0);
   });
 
   test('syntax error in template is reported', async () => {
@@ -96,6 +95,7 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
 
       export default class Application extends Component {
         private startupTime = new Date().toISOString();
+        private badType: number = 'not a number';
 
         <template>
           The current time is {{this.startupTimee}}.
@@ -112,6 +112,10 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
     // Without glint config, template type-checking (2551/2339) should not be reported.
     const templateTypeErrors = diagnostics.filter((d: any) => d.code === 2551 || d.code === 2339);
     expect(templateTypeErrors).toHaveLength(0);
+
+    // Plain TS errors should still be reported (TS is active, only glint template-checking is off).
+    const tsTypeError = diagnostics.find((d: any) => d.code === 2322);
+    expect(tsTypeError).toBeDefined();
   });
 
   test('completions are provided in full semantic mode', async () => {
@@ -180,6 +184,8 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
     expect(hover).not.toBeNull();
     const hoverText = JSON.stringify(hover?.contents ?? '');
     expect(hoverText).toContain('startupTime');
+    // TS type annotation in hover confirms TS analysis is active, not just a text match
+    expect(hoverText).toContain(': string');
   });
 
   test('passing wrong arg to component is an error in full semantic mode', async () => {
@@ -209,6 +215,7 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
 
     const argError = diagnostics.find((d: any) => d.code === 2561 || d.code === 2353);
     expect(argError).toBeDefined();
-    expect(argError.message).toContain('target2');
+    expect(argError.message).toContain('target2'); // the unknown argument passed
+    expect(argError.message).toMatch(/\btarget\b/); // the expected argument in the type shape
   });
 });

--- a/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
@@ -110,9 +110,7 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
     );
 
     // Without glint config, template type-checking (2551/2339) should not be reported.
-    const templateTypeErrors = diagnostics.filter(
-      (d: any) => d.code === 2551 || d.code === 2339,
-    );
+    const templateTypeErrors = diagnostics.filter((d: any) => d.code === 2551 || d.code === 2339);
     expect(templateTypeErrors).toHaveLength(0);
   });
 

--- a/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/full-semantic-mode.test.ts
@@ -90,12 +90,11 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
   });
 
   test('plugin deactivates for project without glint config', async () => {
-    const code = stripIndent`
+    const gtsCode = stripIndent`
       import Component from '@glimmer/component';
 
       export default class Application extends Component {
         private startupTime = new Date().toISOString();
-        private badType: number = 'not a number';
 
         <template>
           The current time is {{this.startupTimee}}.
@@ -103,18 +102,27 @@ describe('Language Server: Full Semantic Mode (createTypeScriptProject)', () => 
       }
     `;
 
-    const diagnostics = await requestFullSemanticModeDiagnostics(
+    const gtsDiagnostics = await requestFullSemanticModeDiagnostics(
       'ts-template-imports-app-no-config/src/empty-fixture.gts',
       'glimmer-ts',
-      code,
+      gtsCode,
     );
 
-    // Without glint config, template type-checking (2551/2339) should not be reported.
-    const templateTypeErrors = diagnostics.filter((d: any) => d.code === 2551 || d.code === 2339);
+    // Without glint config, the ember language plugin is not registered, so TypeScript
+    // cannot process .gts files (no extraFileExtensions for .gts). Template type-checking
+    // errors (2551/2339) should not be reported.
+    const templateTypeErrors = gtsDiagnostics.filter((d: any) => d.code === 2551 || d.code === 2339);
     expect(templateTypeErrors).toHaveLength(0);
 
-    // Plain TS errors should still be reported (TS is active, only glint template-checking is off).
-    const tsTypeError = diagnostics.find((d: any) => d.code === 2322);
+    // Verify TypeScript is still active for plain .ts files even when glint is deactivated.
+    // We check a .ts file (not .gts) because without the ember plugin, TypeScript cannot
+    // process .gts files at all — but it still handles .ts files via its native project support.
+    const tsDiagnostics = await requestFullSemanticModeDiagnostics(
+      'ts-template-imports-app-no-config/src/type-error.ts',
+      'typescript',
+      `const x: number = 'not a number';`,
+    );
+    const tsTypeError = tsDiagnostics.find((d: any) => d.code === 2322);
     expect(tsTypeError).toBeDefined();
   });
 

--- a/test-packages/test-utils/src/shared-test-workspace.ts
+++ b/test-packages/test-utils/src/shared-test-workspace.ts
@@ -178,7 +178,10 @@ export async function getFullSemanticModeWorkspaceHelper(): Promise<LanguageServ
   if (!fullSemanticServerHandle) {
     const glintLSPath = require.resolve('@glint/ember-tsc/bin/glint-language-server');
     fullSemanticServerHandle = startLanguageServer(glintLSPath, testWorkspacePath);
-    fullSemanticServerHandle.connection.onNotification(PublishDiagnosticsNotification.type, () => {});
+    fullSemanticServerHandle.connection.onNotification(
+      PublishDiagnosticsNotification.type,
+      () => {},
+    );
     fullSemanticServerHandle.connection.onRequest(ConfigurationRequest.type, ({ items }) => {
       return items.map(({ section }: { section?: string }) => {
         if (section?.startsWith('glint.inlayHints.')) return true;
@@ -235,7 +238,9 @@ export async function requestFullSemanticModeDiagnostics(
 ): Promise<any[]> {
   const server = await getFullSemanticModeWorkspaceHelper();
   const document = await prepareDocumentFullSemanticMode(fileName, languageId, content);
-  const report = (await server.sendDocumentDiagnosticRequest(document.uri)) as FullDocumentDiagnosticReport;
+  const report = (await server.sendDocumentDiagnosticRequest(
+    document.uri,
+  )) as FullDocumentDiagnosticReport;
   return report.items ?? [];
 }
 

--- a/test-packages/test-utils/src/shared-test-workspace.ts
+++ b/test-packages/test-utils/src/shared-test-workspace.ts
@@ -161,6 +161,84 @@ export async function getSharedTestWorkspaceHelper(): Promise<{
 
 const openedDocuments: TextDocument[] = [];
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Full Semantic Mode helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+let fullSemanticServerHandle: LanguageServerHandle | undefined;
+const fullSemanticOpenedDocuments: TextDocument[] = [];
+
+/**
+ * Returns a Glint language server handle initialized in full semantic mode
+ * (`fullSemanticMode: true`). Uses `createTypeScriptProject` instead of the
+ * hybrid tsserver-delegation path. Each call after teardown creates a new
+ * server; within the same test it is reused.
+ */
+export async function getFullSemanticModeWorkspaceHelper(): Promise<LanguageServerHandle> {
+  if (!fullSemanticServerHandle) {
+    const glintLSPath = require.resolve('@glint/ember-tsc/bin/glint-language-server');
+    fullSemanticServerHandle = startLanguageServer(glintLSPath, testWorkspacePath);
+    fullSemanticServerHandle.connection.onNotification(PublishDiagnosticsNotification.type, () => {});
+    fullSemanticServerHandle.connection.onRequest(ConfigurationRequest.type, ({ items }) => {
+      return items.map(({ section }: { section?: string }) => {
+        if (section?.startsWith('glint.inlayHints.')) return true;
+        return null;
+      });
+    });
+
+    await fullSemanticServerHandle.initialize(
+      URI.file(testWorkspacePath).toString(),
+      { fullSemanticMode: true },
+      { workspace: { configuration: true } },
+    );
+  }
+  return fullSemanticServerHandle;
+}
+
+export async function teardownFullSemanticModeWorkspaceAfterEach(): Promise<void> {
+  if (fullSemanticServerHandle) {
+    const handle = fullSemanticServerHandle;
+    // Reset state immediately so subsequent tests don't reuse a dying server.
+    fullSemanticServerHandle = undefined;
+    fullSemanticOpenedDocuments.length = 0;
+
+    // In full semantic mode the TypeScript project keeps running after each
+    // request, so shutdown() can take a long time. Force-kill after 5 s.
+    const shutdownOrTimeout = Promise.race([
+      handle.shutdown().catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+    await shutdownOrTimeout;
+    handle.connection.dispose();
+    handle.process.kill();
+  }
+}
+
+export async function prepareDocumentFullSemanticMode(
+  fileName: string,
+  languageId: string,
+  content: string,
+): Promise<TextDocument> {
+  const server = await getFullSemanticModeWorkspaceHelper();
+  const uri = URI.file(`${testWorkspacePath}/${fileName}`).toString();
+  const document = await server.openInMemoryDocument(uri, languageId, content);
+  if (fullSemanticOpenedDocuments.every((d) => d.uri !== document.uri)) {
+    fullSemanticOpenedDocuments.push(document);
+  }
+  return document;
+}
+
+export async function requestFullSemanticModeDiagnostics(
+  fileName: string,
+  languageId: string,
+  content: string,
+): Promise<any[]> {
+  const server = await getFullSemanticModeWorkspaceHelper();
+  const document = await prepareDocumentFullSemanticMode(fileName, languageId, content);
+  const report = (await server.sendDocumentDiagnosticRequest(document.uri)) as FullDocumentDiagnosticReport;
+  return report.items ?? [];
+}
+
 export async function ensureNoOpenDocuments(): Promise<void> {
   if (!serverHandle) {
     return;

--- a/test-packages/ts-template-imports-app-no-config/tsconfig.json
+++ b/test-packages/ts-template-imports-app-no-config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/ember",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "types": ["ember-source/types"]
+  },
+  "include": ["src", "types"]
+}


### PR DESCRIPTION
## Problem

\`@glint/ember-tsc\`'s language server delegates TypeScript semantic analysis to a
separate tsserver process (hybrid mode). This works well when tsserver is already
running — VS Code with the TypeScript extension, or editors like Neovim/Zed with a
TypeScript LSP configured.

However, some setups don't run tsserver at all — CI pipelines, type-checking scripts,
or minimal editor configurations — and benefit from a single self-contained process
that handles all TypeScript semantics internally.

## Change

Add an opt-in \`fullSemanticMode\` initialization option. When set to \`true\` in
\`initializationOptions\`, the language server uses Volar's built-in
\`createTypeScriptProject\` + \`createTypeScriptSemanticPlugin\` instead of tsserver
delegation.

**Hybrid mode remains the default.** No behavior change for existing users.

\`\`\`json
// In your LSP client's initialize options:
{ "initializationOptions": { "fullSemanticMode": true } }
\`\`\`

## When to use each mode

- **Hybrid mode (default):** When tsserver is already running (VS Code, or Neovim/Zed
  with \`ts_ls\` configured). TypeScript diagnostics come from tsserver. No duplicate
  work.
- **Full semantic mode:** When you want a single standalone process — CI, type-checking
  scripts, or setups without a separate TypeScript LSP. All diagnostics (TypeScript +
  Glimmer template) come from the Glint language server itself.

## Memory note

Full semantic mode loads the TypeScript program into the language server process.
Large projects (>5000 files) may need \`--max-old-space-size=8192\`.

## Tests

Added \`__tests__/language-server/full-semantic-mode.test.ts\` with 7 tests that
exercise the \`fullSemanticMode: true\` path directly (no tsserver involved):

- Type error in template is reported via the language server
- Valid template produces no diagnostics
- Syntax error in template is reported
- Plugin deactivates for projects without a glint config
- Completions work in full semantic mode
- Hover info works in full semantic mode
- Wrong component arg is flagged as an error

Also added test helpers to \`test-utils\` for starting/tearing down a full-semantic-mode
server instance (\`getFullSemanticModeWorkspaceHelper\`, \`requestFullSemanticModeDiagnostics\`, etc.).

## Tested on

AuditBoard's Ember codebase — 6682 .gts/.gjs files, full TypeScript + Glimmer
template diagnostics working correctly with \`fullSemanticMode: true\`.

## Dependencies already satisfied

\`@glint/ember-tsc@1.1.1\` already depends on:
- \`@volar/language-server@~2.4.28\` (needs ≥2.4.27 for \`createTypeScriptProject\`)
- \`volar-service-typescript@~0.0.68\` (needs ≥0.0.68 for semantic plugin)

No version bumps required.