### PR TITLE
Support Glint in JS-only Ember projects without tsconfig/jsconfig

### DIFF
--- a/packages/ember-tsc/src/config/index.ts
+++ b/packages/ember-tsc/src/config/index.ts
@@ -1,4 +1,6 @@
+import * as path from 'node:path';
 import SilentError from 'silent-error';
+import type TS from 'typescript';
 import { GlintConfig } from './config.js';
 import { ConfigLoader } from './loader.js';
 
@@ -27,4 +29,14 @@ export function loadConfig(from: string): GlintConfig {
  */
 export function findConfig(from: string): GlintConfig | null {
   return new ConfigLoader().configForDirectory(from);
+}
+
+/**
+ * Creates a default GlintConfig with ember-template-imports environment
+ * for use when no tsconfig.json or jsconfig.json exists. This enables
+ * Glint to provide IntelliSense in JavaScript-only Ember projects.
+ */
+export function createDefaultConfig(ts: typeof TS, rootDir: string): GlintConfig {
+  const syntheticConfigPath = path.join(rootDir, 'jsconfig.json');
+  return new GlintConfig(ts, syntheticConfigPath, { environment: 'ember-template-imports' });
 }

--- a/packages/ember-tsc/src/index.ts
+++ b/packages/ember-tsc/src/index.ts
@@ -1,9 +1,16 @@
-import { GlintConfig, loadConfig, findConfig } from './config/index.js';
+import { GlintConfig, loadConfig, findConfig, createDefaultConfig } from './config/index.js';
 import { createEmberLanguagePlugin } from './volar/ember-language-plugin.js';
 
 import { VirtualGtsCode } from './volar/gts-virtual-code.js';
 import { augmentDiagnostics } from './transform/diagnostics/augmentation.js';
 
-export { loadConfig, findConfig, createEmberLanguagePlugin, VirtualGtsCode, augmentDiagnostics };
+export {
+  loadConfig,
+  findConfig,
+  createDefaultConfig,
+  createEmberLanguagePlugin,
+  VirtualGtsCode,
+  augmentDiagnostics,
+};
 
 export type { GlintConfig };

--- a/packages/ember-tsc/src/volar/ember-language-plugin.ts
+++ b/packages/ember-tsc/src/volar/ember-language-plugin.ts
@@ -100,6 +100,8 @@ export function createEmberLanguagePlugin<T extends URI | string>(
             ...host.getCompilationSettings(),
             // Always allow JS for type checking.
             allowJs: true,
+            // Ember uses legacy/experimental decorators.
+            experimentalDecorators: true,
           }),
         };
       },

--- a/packages/ember-tsc/src/volar/ember-language-plugin.ts
+++ b/packages/ember-tsc/src/volar/ember-language-plugin.ts
@@ -100,8 +100,6 @@ export function createEmberLanguagePlugin<T extends URI | string>(
             ...host.getCompilationSettings(),
             // Always allow JS for type checking.
             allowJs: true,
-            // Ember uses legacy/experimental decorators.
-            experimentalDecorators: true,
           }),
         };
       },

--- a/packages/ember-tsc/src/volar/language-server.ts
+++ b/packages/ember-tsc/src/volar/language-server.ts
@@ -147,9 +147,10 @@ connection.onInitialize((params) => {
 
     {
       let glintConfig = null;
-      const isRealConfigFile = tsconfigFileName
-        && !tsconfigFileName.startsWith('/dev/null')
-        && (tsconfigFileName.endsWith('.json'));
+      const isRealConfigFile =
+        tsconfigFileName &&
+        !tsconfigFileName.startsWith('/dev/null') &&
+        tsconfigFileName.endsWith('.json');
       if (isRealConfigFile) {
         const configLoader = new ConfigLoader(logInfo);
         glintConfig = configLoader.configForFile(tsconfigFileName);
@@ -157,9 +158,9 @@ connection.onInitialize((params) => {
       if (!glintConfig) {
         const rootDir = isRealConfigFile
           ? path.dirname(tsconfigFileName!)
-          : (params.workspaceFolders?.[0]
-              ? URI.parse(params.workspaceFolders[0].uri).fsPath
-              : process.cwd());
+          : params.workspaceFolders?.[0]
+            ? URI.parse(params.workspaceFolders[0].uri).fsPath
+            : process.cwd();
         logInfo(`Using default Glint config for ${rootDir}.`);
         glintConfig = createDefaultConfig(ts, rootDir);
       }

--- a/packages/ember-tsc/src/volar/language-server.ts
+++ b/packages/ember-tsc/src/volar/language-server.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { createLanguage } from '@volar/language-core';
 import type { LanguagePlugin, LanguageServer } from '@volar/language-server';
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject.js';
@@ -9,6 +10,7 @@ import { create as createHtmlSyntacticPlugin } from 'volar-service-html';
 import { create as createTypeScriptSyntacticPlugin } from 'volar-service-typescript/lib/plugins/syntactic.js';
 import { URI } from 'vscode-uri';
 import { ConfigLoader } from '../config/loader.js';
+import { createDefaultConfig } from '../config/index.js';
 import { create as createCompilerErrorsPlugin } from '../plugins/g-compiler-errors.js';
 import { create as createComponentHoverPlugin } from '../plugins/g-component-hover.js';
 import type { ComponentMeta, TsPluginClient } from '../plugins/g-component-hover.js';
@@ -143,18 +145,27 @@ connection.onInitialize((params) => {
       },
     ];
 
-    if (tsconfigFileName) {
-      const configLoader = new ConfigLoader(logInfo);
-      const glintConfig = configLoader.configForFile(tsconfigFileName);
-      if (glintConfig) {
-        logInfo(`Glint config active for ${tsconfigFileName}.`);
-        const emberLanguagePlugin = createEmberLanguagePlugin(glintConfig);
-        languagePlugins.push(emberLanguagePlugin);
-      } else {
-        logWarn(`Glint config not found for ${tsconfigFileName}; Glint features disabled.`);
+    {
+      let glintConfig = null;
+      const isRealConfigFile = tsconfigFileName
+        && !tsconfigFileName.startsWith('/dev/null')
+        && (tsconfigFileName.endsWith('.json'));
+      if (isRealConfigFile) {
+        const configLoader = new ConfigLoader(logInfo);
+        glintConfig = configLoader.configForFile(tsconfigFileName);
       }
-    } else {
-      logWarn('No tsconfig/jsconfig provided; Glint config cannot be resolved.');
+      if (!glintConfig) {
+        const rootDir = isRealConfigFile
+          ? path.dirname(tsconfigFileName!)
+          : (params.workspaceFolders?.[0]
+              ? URI.parse(params.workspaceFolders[0].uri).fsPath
+              : process.cwd());
+        logInfo(`Using default Glint config for ${rootDir}.`);
+        glintConfig = createDefaultConfig(ts, rootDir);
+      }
+      logInfo(`Glint config active for ${tsconfigFileName ?? 'default'}.`);
+      const emberLanguagePlugin = createEmberLanguagePlugin(glintConfig);
+      languagePlugins.push(emberLanguagePlugin);
     }
 
     const language = createLanguage<URI>(languagePlugins, createUriMap(), (uri) => {

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -189,8 +189,9 @@ const plugin = createLanguageServicePlugin(
           (fileName) => fileName,
         );
 
-        const resolveModuleNameLiterals =
-          info.languageServiceHost.resolveModuleNameLiterals?.bind(info.languageServiceHost);
+        const resolveModuleNameLiterals = info.languageServiceHost.resolveModuleNameLiterals?.bind(
+          info.languageServiceHost,
+        );
 
         if (resolveModuleNameLiterals) {
           // TS isn't aware of our custom .gts/.gjs extensions by default which causes

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -126,19 +126,7 @@ const plugin = createLanguageServicePlugin(
     const logger = info.project.projectService.logger;
     const logInfo = (message: string): void => logger.info(`[Glint] ${message}`);
 
-    // Early bail-out: if no tsconfig.json or jsconfig.json exists, don't even
-    // attempt to load ember-tsc. This prevents expensive module loading (jiti,
-    // WASM content-tag, etc.) for projects that have no TypeScript config.
     const cwd = info.languageServiceHost.getCurrentDirectory();
-    const hasTsConfig = ts.findConfigFile(cwd, ts.sys.fileExists, 'tsconfig.json');
-    const hasJsConfig = ts.findConfigFile(cwd, ts.sys.fileExists, 'jsconfig.json');
-    if (!hasTsConfig && !hasJsConfig) {
-      logInfo(
-        `No tsconfig.json or jsconfig.json found from ${cwd}. ` +
-          'Glint TS Plugin will not activate.',
-      );
-      return { languagePlugins: [] };
-    }
 
     const config = info.config ?? {};
     const emberTscSource = normalizeEmberTscSource((config as any).emberTscSource);
@@ -185,91 +173,69 @@ const plugin = createLanguageServicePlugin(
 
     logInfo(`Using ${resolved.source} ember-tsc from ${resolved.resolvedPath}.`);
 
-    const { findConfig, createEmberLanguagePlugin } = emberTsc;
-    const glintConfig = findConfig(cwd);
+    const { findConfig, createDefaultConfig, createEmberLanguagePlugin } = emberTsc;
+    const glintConfig = findConfig(cwd) ?? createDefaultConfig(ts, cwd);
 
-    if (glintConfig) {
-      const gtsLanguagePlugin = createEmberLanguagePlugin(glintConfig, {
-        clientId: 'tsserver-plugin',
-      });
-      return {
-        languagePlugins: [gtsLanguagePlugin],
-        setup: (language: any) => {
-          // project2Service.set(info.project, [
-          //   language,
-          //   info.languageServiceHost,
-          //   info.languageService,
-          // ]);
+    const gtsLanguagePlugin = createEmberLanguagePlugin(glintConfig, {
+      clientId: 'tsserver-plugin',
+    });
+    return {
+      languagePlugins: [gtsLanguagePlugin],
+      setup: (language: any) => {
+        info.languageService = proxyLanguageServiceForGlint(
+          ts,
+          language,
+          info.languageService,
+          (fileName) => fileName,
+        );
 
-          info.languageService = proxyLanguageServiceForGlint(
-            ts,
-            language,
-            info.languageService,
-            (fileName) => fileName,
-          );
+        const resolveModuleNameLiterals =
+          info.languageServiceHost.resolveModuleNameLiterals?.bind(info.languageServiceHost);
 
-          const resolveModuleNameLiterals =
-            info.languageServiceHost.resolveModuleNameLiterals?.bind(info.languageServiceHost);
+        if (resolveModuleNameLiterals) {
+          // TS isn't aware of our custom .gts/.gjs extensions by default which causes
+          // issues with resolving imports that omit extensions. We hackishly "teach"
+          // TS about these extensions by overriding `resolveModuleNameLiterals` to
+          // inject non-existent imports that cause TS to consider the extensions when
+          // resolving.
+          //
+          // Origin of this hack:
+          // https://github.com/typed-ember/glint/issues/806#issuecomment-2758616327
+          info.languageServiceHost.resolveModuleNameLiterals = (
+            moduleLiterals,
+            containingFile,
+            redirectedReference,
+            options,
+            ...rest
+          ) => {
+            let fakeImportNodes: any = [];
+            if (moduleLiterals.length > 0) {
+              fakeImportNodes.push({
+                ...moduleLiterals[0],
+                text: './__NONEXISTENT_GLINT_HACK__.gts',
+              });
+              fakeImportNodes.push({
+                ...moduleLiterals[0],
+                text: './__NONEXISTENT_GLINT_HACK__.gjs',
+              });
+            }
 
-          if (resolveModuleNameLiterals) {
-            // TS isn't aware of our custom .gts/.gjs extensions by default which causes
-            // issues with resolving imports that omit extensions. We hackishly "teach"
-            // TS about these extensions by overriding `resolveModuleNameLiterals` to
-            // inject non-existent imports that cause TS to consider the extensions when
-            // resolving.
-            //
-            // Origin of this hack:
-            // https://github.com/typed-ember/glint/issues/806#issuecomment-2758616327
-            info.languageServiceHost.resolveModuleNameLiterals = (
-              moduleLiterals,
+            const result = resolveModuleNameLiterals(
+              [...fakeImportNodes, ...moduleLiterals],
               containingFile,
               redirectedReference,
               options,
-              ...rest
-            ) => {
-              let fakeImportNodes: any = [];
-              if (moduleLiterals.length > 0) {
-                fakeImportNodes.push({
-                  ...moduleLiterals[0],
-                  text: './__NONEXISTENT_GLINT_HACK__.gts',
-                });
-                fakeImportNodes.push({
-                  ...moduleLiterals[0],
-                  text: './__NONEXISTENT_GLINT_HACK__.gjs',
-                });
-              }
+              ...rest,
+            );
 
-              const result = resolveModuleNameLiterals(
-                [...fakeImportNodes, ...moduleLiterals],
-                containingFile,
-                redirectedReference,
-                options,
-                ...rest,
-              );
+            return result.slice(fakeImportNodes.length);
+          };
+        }
 
-              return result.slice(fakeImportNodes.length);
-            };
-          }
-
-          // Add Glint-specific protocol handlers for tsserver communication
-          addGlintCommands();
-
-          // #3963
-          // const timer = setInterval(() => {
-          //   if (info.project['program']) {
-          //     clearInterval(timer);
-          //     info.project['program'].__glint__ = { language };
-          //   }
-          // }, 50);
-        },
-      };
-    } else {
-      logInfo('Glint TS Plugin is not running: no Glint config was found.');
-
-      return {
-        languagePlugins: [],
-      };
-    }
+        // Add Glint-specific protocol handlers for tsserver communication
+        addGlintCommands();
+      },
+    };
 
     // https://github.com/JetBrains/intellij-plugins/blob/6435723ad88fa296b41144162ebe3b8513f4949b/Angular/src-js/angular-service/src/index.ts#L69
     function addGlintCommands(): void {

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -8,8 +8,65 @@ A Visual Studio Code extension for Version 2 of the [Glint] language server.
 
 See the [Glint home page] for a more detailed Getting Started guide.
 
+### If you want type-checking
+
 1. Add `@glint/ember-tsc`, `@glint/template` to your project's `devDependencies`.
-2. (Optional) Add a `"glint"` key to your project's `tsconfig.json` or `jsconfig.json` specifying your environment and any other relevant configuration.
+2. Add a `jsconfig.json` or `tsconfig.json`
+
+<details><summary>example jsconfig</summary>
+
+```js
+{
+  "extends": "@ember/app-tsconfig",
+  "compilerOptions": {
+    "strict": false,
+    "checkJs": false,
+    "types": [
+      "ember-source/types",
+      "@embroider/core/virtual",
+      "vite/client",
+      "@glint/ember-tsc/types"
+    ]
+  }
+}
+```
+
+</details>
+<details><summary>example tsconfig</summary>
+
+
+#### for apps
+
+```js
+{
+  "extends": "@ember/app-tsconfig",
+  "compilerOptions": {
+    "types": [
+      "ember-source/types",
+      "@embroider/core/virtual",
+      "vite/client",
+      "@glint/ember-tsc/types"
+    ]
+  }
+}
+```
+
+#### for libraries
+
+```js
+{
+  "extends": "@ember/library-tsconfig",
+  "include": ["./src/**/*", "./unpublished-development-types/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declarationDir": "declarations",
+    "rootDir": "./src",
+    "types": ["ember-source/types", "@glint/ember-tsc/types"]
+  }
+}
+```
+
+</details>
 
 [glint home page]: https://typed-ember.gitbook.io/glint
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -505,42 +505,6 @@ function resolveBundledEmberTscServerPath(): string | undefined {
   }
 }
 
-/**
- * Check whether a tsconfig.json or jsconfig.json exists anywhere in the
- * workspace directory tree (searching recursively). Returns the first
- * matching path found, or undefined if none.
- */
-function findConfigFileInWorkspace(workspaceRoot: string): string | undefined {
-  // Quick check: look for tsconfig.json / jsconfig.json in the workspace root first.
-  for (const name of ['tsconfig.json', 'jsconfig.json']) {
-    const candidate = path.join(workspaceRoot, name);
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  // Walk immediate sub-directories (1 level deep) to cover monorepo layouts
-  // where the config lives in a child package. We intentionally skip
-  // node_modules and hidden directories to keep this check fast.
-  try {
-    const entries = fs.readdirSync(workspaceRoot, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
-      for (const name of ['tsconfig.json', 'jsconfig.json']) {
-        const candidate = path.join(workspaceRoot, entry.name, name);
-        if (fs.existsSync(candidate)) {
-          return candidate;
-        }
-      }
-    }
-  } catch {
-    // If reading the directory fails, fall through to return undefined.
-  }
-
-  return undefined;
-}
-
 // We need to activate the default VSCode TypeScript extension so that our
 // TS Plugin kicks in. We do this because the TS extension is (obviously) not
 // configured to activate for, say, .gts files:

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -341,16 +341,6 @@ function launch(
     return undefined;
   }
 
-  // Early bail-out: don't launch the Glint language server if there's no
-  // tsconfig.json or jsconfig.json anywhere in the workspace root tree.
-  // This prevents unnecessary overhead for pure JS projects without config.
-  if (!findConfigFileInWorkspace(workspaceFolder.uri.fsPath)) {
-    outputChannel.appendLine(
-      '[Activation] No tsconfig.json or jsconfig.json found in workspace; not launching Glint.',
-    );
-    return undefined;
-  }
-
   const emberTscSource = getEmberTscSourceSetting();
   const libraryPath = getLibraryPathSetting();
   const resolution = resolveEmberTscServerPath(workspaceFolder, emberTscSource, libraryPath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,34 @@ importers:
         specifier: ^6.11.0
         version: 6.11.0
 
+  test-packages/js-ember-app:
+    dependenciesMeta:
+      '@glint/ember-tsc':
+        injected: true
+      '@glint/template':
+        injected: true
+      '@glint/tsserver-plugin':
+        injected: true
+    devDependencies:
+      '@glimmer/component':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@glint/ember-tsc':
+        specifier: workspace:*
+        version: file:packages/ember-tsc
+      '@glint/template':
+        specifier: workspace:*
+        version: file:packages/template
+      '@glint/tsserver-plugin':
+        specifier: workspace:*
+        version: file:packages/tsserver-plugin
+      ember-page-title:
+        specifier: ^9.0.0
+        version: 9.0.3
+      ember-source:
+        specifier: ^6.2.0
+        version: 6.11.0(@glimmer/component@2.0.0)
+
   test-packages/package-test-core:
     devDependencies:
       '@glimmer/component':
@@ -4347,6 +4375,10 @@ packages:
     peerDependenciesMeta:
       ember-source:
         optional: true
+
+  ember-page-title@9.0.3:
+    resolution: {integrity: sha512-fedRHUsvq8tIZgOii8jTrfAyeq+la/9H5eAzhNNwEyzo7nDMmqK2SxsyBUGXprd8fOacsPabLlzlucMi/4mUpA==}
+    engines: {node: 16.* || >= 18}
 
   ember-qunit@9.0.4:
     resolution: {integrity: sha512-rv6gKvrdXdPBTdSZC5co82eIcDWWVR7RjafU/c+5TTz290oXhIHPoVuZbcO2F5RiAqkTW0jKzwkCP8y+2tCjFw==}
@@ -10926,6 +10958,27 @@ snapshots:
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
+  '@glint/ember-tsc@file:packages/ember-tsc':
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@glint/template': link:packages/template
+      '@volar/kit': 2.4.28
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/source-map': 2.4.28
+      '@volar/test-utils': 2.4.28
+      '@volar/typescript': 2.4.28
+      content-tag: 4.1.1
+      silent-error: 1.1.1
+      volar-service-html: 0.0.68(@volar/language-service@2.4.28)
+      volar-service-typescript: 0.0.68(@volar/language-service@2.4.28)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@glint/ember-tsc@file:packages/ember-tsc(typescript@5.9.3)':
     dependencies:
       '@glimmer/syntax': 0.95.0
@@ -11788,6 +11841,14 @@ snapshots:
       '@vitest/pretty-format': 3.0.9
       loupe: 3.1.3
       tinyrainbow: 2.0.0
+
+  '@volar/kit@2.4.28':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -13598,6 +13659,13 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  ember-page-title@9.0.3:
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      '@simple-dom/document': 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   ember-qunit@9.0.4(cf8e636008f6013ca28983c0dc6317d2):
     dependencies:
       '@ember/test-helpers': 5.3.0(9a4647edefd3e35feba5c7227bd077d9)
@@ -13625,6 +13693,53 @@ snapshots:
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.10.2
       '@glimmer/compiler': 0.94.11
+      '@glimmer/destroyable': 0.94.8
+      '@glimmer/global-context': 0.93.4
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/manager': 0.94.10
+      '@glimmer/node': 0.94.10
+      '@glimmer/opcode-compiler': 0.94.10
+      '@glimmer/owner': 0.93.4
+      '@glimmer/program': 0.94.10
+      '@glimmer/reference': 0.94.9
+      '@glimmer/runtime': 0.94.11
+      '@glimmer/syntax': 0.95.0
+      '@glimmer/util': 0.94.8
+      '@glimmer/validator': 0.95.0
+      '@glimmer/vm': 0.94.8
+      '@glimmer/vm-babel-plugins': 0.93.5(@babel/core@7.28.6)
+      '@simple-dom/interface': 1.4.0
+      backburner.js: 2.8.0
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      chalk: 4.1.2
+      ember-cli-babel: 8.2.0(@babel/core@7.28.6)
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-is-package-missing: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-cli-version-checker: 5.1.2
+      ember-router-generator: 2.0.0
+      inflection: 2.0.1
+      route-recognizer: 0.3.4
+      router_js: 8.0.6(route-recognizer@0.3.4)
+      semver: 7.7.3
+      silent-error: 1.1.1
+      simple-html-tokenizer: 0.5.11
+    transitivePeerDependencies:
+      - rsvp
+      - supports-color
+
+  ember-source@6.11.0(@glimmer/component@2.0.0):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@ember/edition-utils': 1.2.0
+      '@embroider/addon-shim': 1.10.2
+      '@glimmer/compiler': 0.94.11
+      '@glimmer/component': 2.0.0
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,26 +313,10 @@ importers:
         version: 6.11.0
 
   test-packages/js-ember-app:
-    dependenciesMeta:
-      '@glint/ember-tsc':
-        injected: true
-      '@glint/template':
-        injected: true
-      '@glint/tsserver-plugin':
-        injected: true
     devDependencies:
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
-      '@glint/ember-tsc':
-        specifier: workspace:*
-        version: file:packages/ember-tsc
-      '@glint/template':
-        specifier: workspace:*
-        version: file:packages/template
-      '@glint/tsserver-plugin':
-        specifier: workspace:*
-        version: file:packages/tsserver-plugin
       ember-page-title:
         specifier: ^9.0.0
         version: 9.0.3
@@ -10958,27 +10942,6 @@ snapshots:
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
-  '@glint/ember-tsc@file:packages/ember-tsc':
-    dependencies:
-      '@glimmer/syntax': 0.95.0
-      '@glint/template': link:packages/template
-      '@volar/kit': 2.4.28
-      '@volar/language-core': 2.4.28
-      '@volar/language-server': 2.4.28
-      '@volar/language-service': 2.4.28
-      '@volar/source-map': 2.4.28
-      '@volar/test-utils': 2.4.28
-      '@volar/typescript': 2.4.28
-      content-tag: 4.1.1
-      silent-error: 1.1.1
-      volar-service-html: 0.0.68(@volar/language-service@2.4.28)
-      volar-service-typescript: 0.0.68(@volar/language-service@2.4.28)
-      vscode-languageserver-protocol: 3.17.5
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@glint/ember-tsc@file:packages/ember-tsc(typescript@5.9.3)':
     dependencies:
       '@glimmer/syntax': 0.95.0
@@ -11841,14 +11804,6 @@ snapshots:
       '@vitest/pretty-format': 3.0.9
       loupe: 3.1.3
       tinyrainbow: 2.0.0
-
-  '@volar/kit@2.4.28':
-    dependencies:
-      '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
-      typesafe-path: 0.2.2
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:

--- a/test-packages/js-ember-app/package.json
+++ b/test-packages/js-ember-app/package.json
@@ -3,22 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
-  "dependenciesMeta": {
-    "@glint/template": {
-      "injected": true
-    },
-    "@glint/ember-tsc": {
-      "injected": true
-    },
-    "@glint/tsserver-plugin": {
-      "injected": true
-    }
-  },
   "devDependencies": {
     "@glimmer/component": "^2.0.0",
-    "@glint/ember-tsc": "workspace:*",
-    "@glint/template": "workspace:*",
-    "@glint/tsserver-plugin": "workspace:*",
     "ember-page-title": "^9.0.0",
     "ember-source": "^6.2.0"
   },

--- a/test-packages/js-ember-app/package.json
+++ b/test-packages/js-ember-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "js-ember-app",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "dependenciesMeta": {
+    "@glint/template": {
+      "injected": true
+    },
+    "@glint/ember-tsc": {
+      "injected": true
+    },
+    "@glint/tsserver-plugin": {
+      "injected": true
+    }
+  },
+  "devDependencies": {
+    "@glimmer/component": "^2.0.0",
+    "@glint/ember-tsc": "workspace:*",
+    "@glint/template": "workspace:*",
+    "@glint/tsserver-plugin": "workspace:*",
+    "ember-page-title": "^9.0.0",
+    "ember-source": "^6.2.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/test-packages/js-ember-app/src/empty-fixture.gjs
+++ b/test-packages/js-ember-app/src/empty-fixture.gjs
@@ -1,0 +1,3 @@
+// This file is intentionally empty.
+// It exists so that tsserver can reference a file path that exists on disk
+// when running in-memory diagnostics tests.

--- a/test-packages/package-test-core/__tests__/language-server/js-ember-app.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/js-ember-app.test.ts
@@ -1,0 +1,118 @@
+import { stripIndent } from 'common-tags';
+import {
+  extractCursor,
+  getSharedTestWorkspaceHelper,
+  prepareDocument,
+  teardownSharedTestWorkspaceAfterEach,
+} from 'glint-monorepo-test-utils';
+import { afterEach, describe, expect, test } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+
+/**
+ * Tests for JS-only Ember projects: no tsconfig.json, no jsconfig.json.
+ * The `js-ember-app` fixture has only runtime Ember deps (no @glint/* in a
+ * real consumer, though here they are wired up so the test harness can load
+ * the tsserver plugin).
+ */
+describe('Language Server: JS Ember App (no tsconfig/jsconfig)', () => {
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('completions for Component include @glimmer/component', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class MyComponent extends Component {
+        <template>
+          {{this.me%}}
+        </template>
+      }
+    `;
+
+    // We just need the file to parse and completions to include something meaningful.
+    // The fact that the tsserver plugin activates at all (without tsconfig) is the key assertion.
+    const completions = await requestCompletion(
+      'js-ember-app/src/empty-fixture.gjs',
+      'glimmer-js',
+      code,
+    );
+
+    // We should get a completion for `message` or at minimum the tsserver plugin should respond.
+    // The completions list proves the plugin is working in a JS-only project.
+    expect(completions).toBeDefined();
+    expect(Array.isArray(completions)).toBe(true);
+  });
+
+  test('completions include Component from @glimmer/component in scope', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      const c: Comp% = '';
+    `;
+
+    const completions = await requestCompletion(
+      'js-ember-app/src/empty-fixture.gjs',
+      'glimmer-js',
+      code,
+    );
+
+    expect(completions).toBeDefined();
+    expect(Array.isArray(completions)).toBe(true);
+    const componentCompletion = completions.find((c: any) => c.name === 'Component');
+    expect(componentCompletion).toBeDefined();
+  });
+
+  test('hover on pageTitle shows documentation from ember-page-title', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      import { page%Title } from 'ember-page-title';
+
+      <template>
+        {{pageTitle "My App"}}
+      </template>
+    `);
+
+    const doc = await prepareDocument('js-ember-app/src/empty-fixture.gjs', 'glimmer-js', content);
+
+    const hover = await performHoverRequest(doc, offset);
+
+    expect(hover).toBeDefined();
+    expect(hover.documentation).toContain('pageTitle');
+  });
+});
+
+async function requestCompletion(
+  fileName: string,
+  languageId: string,
+  contentWithCursor: string,
+): Promise<any> {
+  const [offset, content] = extractCursor(contentWithCursor);
+  const document = await prepareDocument(fileName, languageId, content);
+  const workspaceHelper = await getSharedTestWorkspaceHelper();
+  const res = await workspaceHelper.tsserver.message({
+    seq: workspaceHelper.nextSeq(),
+    command: 'completions',
+    arguments: {
+      file: URI.parse(document.uri).fsPath,
+      position: offset,
+    },
+  });
+
+  expect(res.success).toBe(true);
+  return res.body;
+}
+
+async function performHoverRequest(document: TextDocument, offset: number): Promise<any> {
+  const workspaceHelper = await getSharedTestWorkspaceHelper();
+
+  const res = await workspaceHelper.tsserver.message({
+    seq: workspaceHelper.nextSeq(),
+    command: 'quickinfo',
+    arguments: {
+      file: URI.parse(document.uri).fsPath,
+      position: offset,
+    },
+  });
+  expect(res.success).toBe(true);
+
+  return res.body;
+}


### PR DESCRIPTION
## Summary

- Adds `createDefaultConfig()` to `@glint/ember-tsc` that provides `ember-template-imports` environment defaults without requiring a config file
- Removes the tsconfig/jsconfig early bail-out gates from the tsserver plugin and the VSCode extension's `launch()` function
- Falls back to default config in the language server when tsserver reports an inferred project (e.g. `/dev/null/inferredProject1*`)
- The bundled `ember-tsc` is used automatically when `@glint/ember-tsc` is not installed in the workspace

This enables Glint to provide IntelliSense, code actions, import suggestions, and diagnostics in JavaScript-only Ember apps created via `pnpm dlx ember-cli@latest new my-app --pnpm` — with **no tsconfig.json, no jsconfig.json, no TypeScript installed, and no `@glint/*` dependencies** in the consumer project.

## Test plan

- [x] Verified via `pnpm dlx ember-cli@latest new my-app --pnpm` (JS-only project, no tsconfig/jsconfig, no TS, no @glint/* deps)
- [x] Installed the built VSIX extension and opened `app/templates/application.gjs`
- [x] Confirmed tsserver plugin loads via bundled ember-tsc (tsserver log: `Plugin validation succeeded`)
- [x] Confirmed zero syntax and semantic diagnostics on the `.gjs` file
- [x] Confirmed imports (`ember-page-title`, `ember-welcome-page`) resolve correctly
- [x] Confirmed `_glint:projectInfo` and other protocol handlers are active
- [x] Confirmed the Glint language server connects to the correct workspace root
- [ ] Verify existing projects with tsconfig/jsconfig still work as before (regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)