### PR TITLE
Fallback to built-in TypeScript when project lacks typescript dependency

### DIFF
--- a/packages/ember-tsc/src/config/index.ts
+++ b/packages/ember-tsc/src/config/index.ts
@@ -27,8 +27,8 @@ export function loadConfig(from: string): GlintConfig {
  * and searching upwards. Returns `null` if no configuration is
  * found.
  */
-export function findConfig(from: string): GlintConfig | null {
-  return new ConfigLoader().configForDirectory(from);
+export function findConfig(from: string, fallbackTs?: typeof TS): GlintConfig | null {
+  return new ConfigLoader(undefined, fallbackTs).configForDirectory(from);
 }
 
 /**

--- a/packages/ember-tsc/src/config/loader.ts
+++ b/packages/ember-tsc/src/config/loader.ts
@@ -24,9 +24,11 @@ type TypeScript = typeof TS;
 export class ConfigLoader {
   private configs = new Map<string, GlintConfig | null>();
   private logInfo?: (message: string) => void;
+  private fallbackTypeScript?: TypeScript;
 
-  constructor(logInfo?: (message: string) => void) {
+  constructor(logInfo?: (message: string) => void, fallbackTypeScript?: TypeScript) {
     this.logInfo = logInfo;
+    this.fallbackTypeScript = fallbackTypeScript;
   }
 
   private log(message: string): void {
@@ -38,7 +40,7 @@ export class ConfigLoader {
   }
 
   public configForDirectory(directory: string): GlintConfig | null {
-    let ts = findTypeScript(directory);
+    let ts = findTypeScript(directory) ?? this.fallbackTypeScript ?? null;
     if (!ts) {
       this.log(`No TypeScript installation found from ${directory}.`);
       return null;

--- a/packages/ember-tsc/src/volar/language-server.ts
+++ b/packages/ember-tsc/src/volar/language-server.ts
@@ -43,10 +43,7 @@ function resolveTypeScript(): typeof import('typescript') {
     }
   }
 
-  throw new Error(
-    'TypeScript could not be resolved. Install `typescript` as a dependency, ' +
-      'or ensure the Glint VS Code extension provides a fallback TypeScript path.',
-  );
+  throw new Error('TypeScript could not be resolved. Please install `typescript` as a dependency.');
 }
 
 const ts = resolveTypeScript();

--- a/packages/ember-tsc/src/volar/language-server.ts
+++ b/packages/ember-tsc/src/volar/language-server.ts
@@ -1,11 +1,12 @@
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
+import type TS from 'typescript';
 import { createLanguage } from '@volar/language-core';
 import type { LanguagePlugin, LanguageServer } from '@volar/language-server';
 import { createLanguageServiceEnvironment } from '@volar/language-server/lib/project/simpleProject.js';
 import { createConnection, createServer } from '@volar/language-server/node.js';
 import type { LanguageServiceContext, LanguageServicePlugin } from '@volar/language-service';
 import { createLanguageService, createUriMap, LanguageService } from '@volar/language-service';
-import * as ts from 'typescript';
 import { create as createHtmlSyntacticPlugin } from 'volar-service-html';
 import { create as createTypeScriptSyntacticPlugin } from 'volar-service-typescript/lib/plugins/syntactic.js';
 import { URI } from 'vscode-uri';
@@ -16,6 +17,39 @@ import { create as createComponentHoverPlugin } from '../plugins/g-component-hov
 import type { ComponentMeta, TsPluginClient } from '../plugins/g-component-hover.js';
 import { create as createTemplateTagSymbolsPlugin } from '../plugins/g-template-tag-symbols.js';
 import { createEmberLanguagePlugin } from './ember-language-plugin.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Resolve TypeScript with fallback to a path provided by the host (e.g., VS Code's built-in TypeScript).
+ * This allows the language server to work even when the user's project doesn't have `typescript`
+ * as a direct dependency (only `@glint/ember-tsc` which has it as a peerDep).
+ */
+function resolveTypeScript(): typeof import('typescript') {
+  // Try normal resolution (project's TypeScript or ember-tsc's peer dep)
+  try {
+    return require('typescript');
+  } catch {
+    // ignore
+  }
+
+  // Fall back to TypeScript path provided by the VS Code extension
+  const fallbackPath = process.env['GLINT_TYPESCRIPT_PATH'];
+  if (fallbackPath) {
+    try {
+      return require(fallbackPath);
+    } catch {
+      // ignore
+    }
+  }
+
+  throw new Error(
+    'TypeScript could not be resolved. Install `typescript` as a dependency, ' +
+      'or ensure the Glint VS Code extension provides a fallback TypeScript path.',
+  );
+}
+
+const ts = resolveTypeScript();
 
 const connection = createConnection();
 const server = createServer(connection);
@@ -78,12 +112,12 @@ connection.onInitialize((params) => {
         if (uri.scheme === 'file') {
           // Use tsserver to find the tsconfig governing this file.
           const fileName = uri.fsPath.replace(/\\/g, '/');
-          const projectInfo = await sendTsServerRequest<ts.server.protocol.ProjectInfo>(
+          const projectInfo = await sendTsServerRequest<TS.server.protocol.ProjectInfo>(
             '_glint:' + ts.server.protocol.CommandTypes.ProjectInfo,
             {
               file: fileName,
               needFileNameList: false,
-            } satisfies ts.server.protocol.ProjectInfoRequestArgs,
+            } satisfies TS.server.protocol.ProjectInfoRequestArgs,
           );
           if (projectInfo) {
             const { configFileName } = projectInfo;
@@ -152,7 +186,7 @@ connection.onInitialize((params) => {
         !tsconfigFileName.startsWith('/dev/null') &&
         tsconfigFileName.endsWith('.json');
       if (isRealConfigFile) {
-        const configLoader = new ConfigLoader(logInfo);
+        const configLoader = new ConfigLoader(logInfo, ts);
         glintConfig = configLoader.configForFile(tsconfigFileName);
       }
       if (!glintConfig) {

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -174,7 +174,7 @@ const plugin = createLanguageServicePlugin(
     logInfo(`Using ${resolved.source} ember-tsc from ${resolved.resolvedPath}.`);
 
     const { findConfig, createDefaultConfig, createEmberLanguagePlugin } = emberTsc;
-    const glintConfig = findConfig(cwd) ?? createDefaultConfig(ts, cwd);
+    const glintConfig = findConfig(cwd, ts) ?? createDefaultConfig(ts, cwd);
 
     const gtsLanguagePlugin = createEmberLanguagePlugin(glintConfig, {
       clientId: 'tsserver-plugin',

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -367,13 +367,12 @@ function launch(
 
   // Provide VS Code's built-in TypeScript as a fallback for projects that
   // have @glint/ember-tsc but not typescript as a direct dependency.
-  const builtinTypescriptPath = path.join(
-    vscode.env.appRoot,
-    'extensions/node_modules/typescript/lib/typescript.js',
-  );
+  const builtinTsdkPath = resolveTsdkPath();
   const serverEnv = {
     ...process.env,
-    GLINT_TYPESCRIPT_PATH: builtinTypescriptPath,
+    ...(builtinTsdkPath
+      ? { GLINT_TYPESCRIPT_PATH: path.join(builtinTsdkPath, 'typescript.js') }
+      : {}),
   };
 
   const client = new lsp.LanguageClient(
@@ -496,6 +495,35 @@ function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | und
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Resolve the path to the TypeScript SDK lib directory bundled with the editor.
+ * Supports VS Code and Eclipse Theia.
+ */
+function resolveTsdkPath(): string | undefined {
+  const vscodeTsdk = path.join(
+    vscode.env.appRoot,
+    'extensions',
+    'node_modules',
+    'typescript',
+    'lib',
+  );
+  if (fs.existsSync(vscodeTsdk)) {
+    return vscodeTsdk;
+  }
+
+  const tsExt = vscode.extensions.getExtension('vscode.typescript-language-features');
+  if (tsExt) {
+    // Eclipse Theia
+    // see: https://github.com/eclipse-theia/vscode-builtin-extensions/blob/65c70ec636bd879ef9529d0a2da36f4b99139c40/src/package-vsix.js#L71
+    const theiaTsdk = path.join(tsExt.extensionPath, 'deps', 'typescript', 'lib');
+    if (fs.existsSync(theiaTsdk)) {
+      return theiaTsdk;
+    }
+  }
+
+  return undefined;
 }
 
 function resolveBundledEmberTscServerPath(): string | undefined {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -365,6 +365,17 @@ function launch(
 
   const serverPath = resolution.path;
 
+  // Provide VS Code's built-in TypeScript as a fallback for projects that
+  // have @glint/ember-tsc but not typescript as a direct dependency.
+  const builtinTypescriptPath = path.join(
+    vscode.env.appRoot,
+    'extensions/node_modules/typescript/lib/typescript.js',
+  );
+  const serverEnv = {
+    ...process.env,
+    GLINT_TYPESCRIPT_PATH: builtinTypescriptPath,
+  };
+
   const client = new lsp.LanguageClient(
     'glint',
     'Glint',
@@ -372,12 +383,12 @@ function launch(
       run: {
         module: serverPath,
         transport: lsp.TransportKind.ipc,
-        options: {},
+        options: { env: serverEnv },
       },
       debug: {
         module: serverPath,
         transport: lsp.TransportKind.ipc,
-        options: { execArgv: ['--nolazy', '--inspect=' + 6009] },
+        options: { execArgv: ['--nolazy', '--inspect=' + 6009], env: serverEnv },
       },
     },
     {


### PR DESCRIPTION
## Summary

- When a project has `@glint/ember-tsc` (or `@glint/template`) but not `typescript` as a direct dependency, the language server crashes on startup because the static ESM `import * as ts from 'typescript'` fails
- This adds a fallback chain: try the project's TypeScript first, then fall back to VS Code's built-in TypeScript via a `GLINT_TYPESCRIPT_PATH` env var set by the extension
- `ConfigLoader` and `findConfig()` now accept an optional fallback TypeScript instance, so config loading (tsconfig resolution) also works without a project-level TypeScript
- The tsserver plugin passes its host `ts` to `findConfig()`, ensuring proper config loading in that path too

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm lint` passes
- [ ] Create a test project: `pnpm dlx ember-cli@latest new my-app --pnpm`
- [ ] Add `@glint/ember-tsc` to `package.json` but do NOT add `typescript`
- [ ] Open in VS Code with the Glint extension — language server should start without crashing
- [ ] Verify existing projects with `typescript` installed still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)