### PR TITLE
fix(ember-tsc): emit dotted property access for identifier-safe template globals

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -7,6 +7,12 @@ import ScopeStack from './scope-stack.js';
 
 const SPLATTRIBUTES = '...attributes';
 
+// Matches names that are safe to emit as a JS PropertyAccessExpression
+// (e.g. `foo`, `_bar`, `$baz0`). Used by `emitIdentifierReference` to decide
+// between `Globals.NAME` (which preserves JSDoc on hover/completions) and
+// the bracket-string fallback `Globals["NAME"]` for hyphenated keywords.
+const VALID_JS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
 export type TemplateToTypescriptOptions = {
   typesModule: string;
   meta?: GlintEmitMetadata | undefined;
@@ -599,9 +605,20 @@ export function templateToTypescript(
 
     function emitIdentifierReference(name: string, hbsOffset: number): void {
       if (treatAsGlobal(name)) {
-        mapper.text('__glintDSL__.Globals["');
-        mapper.identifier(JSON.stringify(name).slice(1, -1), hbsOffset, name.length);
-        mapper.text('"]');
+        // Emit dotted property access (e.g. `__glintDSL__.Globals.eq`) when
+        // `name` is a valid JS identifier so the TS language service surfaces
+        // JSDoc, go-to-definition, and completions for the underlying member
+        // of `Globals`. Fall back to bracket-string access for hyphenated
+        // keywords like `each-in` or `in-element`, which cannot be expressed
+        // as a dotted property and so do not benefit from this code path.
+        if (VALID_JS_IDENTIFIER.test(name)) {
+          mapper.text('__glintDSL__.Globals.');
+          mapper.identifier(name, hbsOffset, name.length);
+        } else {
+          mapper.text('__glintDSL__.Globals["');
+          mapper.identifier(JSON.stringify(name).slice(1, -1), hbsOffset, name.length);
+          mapper.text('"]');
+        }
       } else {
         mapper.identifier(makeJSSafe(name), hbsOffset, name.length);
       }

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -434,7 +434,7 @@ describe('Transform: rewriteModule', () => {
 
         | Mapping: TemplateEmbedding
         |  hbs(58:210):  <template>\\n  {{! Intentionally shadowing }}\\n  {{#let (arr 1 2) (h red="blue") as |arr h|}}\\n    Array is {{arr}}\\n    Hash is {{h}}\\n  {{/let}}\\n</template>
-        |  ts(58:653):   export default ({} as typeof import("@glint/ember-tsc/-private/dsl")).templateExpression(function(__glintRef__, __glintDSL__: typeof import("@glint/ember-tsc/-private/dsl")) {\\n{\\nconst __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["let"])((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n}))));\\n{\\nconst [arr, h] = __glintY__.blockParams["default"];\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)());\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());\\n}\\n__glintDSL__.Globals["let"];\\n}\\n__glintRef__; __glintDSL__;\\n})
+        |  ts(58:647):   export default ({} as typeof import("@glint/ember-tsc/-private/dsl")).templateExpression(function(__glintRef__, __glintDSL__: typeof import("@glint/ember-tsc/-private/dsl")) {\\n{\\nconst __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.let)((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n}))));\\n{\\nconst [arr, h] = __glintY__.blockParams["default"];\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)());\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());\\n}\\n__glintDSL__.Globals.let;\\n}\\n__glintRef__; __glintDSL__;\\n})
         |
         | | Mapping: Template
         | |  hbs(68:199):  {{! Intentionally shadowing }}\\n  {{#let (arr 1 2) (h red="blue") as |arr h|}}\\n    Array is {{arr}}\\n    Hash is {{h}}\\n  {{/let}}
@@ -442,7 +442,7 @@ describe('Transform: rewriteModule', () => {
         | |
         | | Mapping: Template
         | |  hbs(68:199):  {{! Intentionally shadowing }}\\n  {{#let (arr 1 2) (h red="blue") as |arr h|}}\\n    Array is {{arr}}\\n    Hash is {{h}}\\n  {{/let}}
-        | |  ts(234:623):  {\\nconst __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["let"])((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n}))));\\n{\\nconst [arr, h] = __glintY__.blockParams["default"];\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)());\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());\\n}\\n__glintDSL__.Globals["let"];\\n}
+        | |  ts(234:617):  {\\nconst __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.let)((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n}))));\\n{\\nconst [arr, h] = __glintY__.blockParams["default"];\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)());\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());\\n}\\n__glintDSL__.Globals.let;\\n}
         | |
         | | | Mapping: TextContent
         | | |  hbs(68:69):
@@ -454,127 +454,127 @@ describe('Transform: rewriteModule', () => {
         | | |
         | | | Mapping: BlockStatement
         | | |  hbs(104:198): {{#let (arr 1 2) (h red="blue") as |arr h|}}\\n    Array is {{arr}}\\n    Hash is {{h}}\\n  {{/let}}
-        | | |  ts(234:622):  {\\nconst __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["let"])((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n}))));\\n{\\nconst [arr, h] = __glintY__.blockParams["default"];\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)());\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());\\n}\\n__glintDSL__.Globals["let"];\\n}
+        | | |  ts(234:616):  {\\nconst __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.let)((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n}))));\\n{\\nconst [arr, h] = __glintY__.blockParams["default"];\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)());\\n__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());\\n}\\n__glintDSL__.Globals.let;\\n}
         | | |
         | | | | Mapping: BlockStatement
         | | | |  hbs(104:198): {{#let (arr 1 2) (h red="blue") as |arr h|}}\\n    Array is {{arr}}\\n    Hash is {{h}}\\n  {{/let}}
-        | | | |  ts(282:409):  __glintDSL__.resolve(__glintDSL__.Globals["let"])((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n})))
+        | | | |  ts(282:406):  __glintDSL__.resolve(__glintDSL__.Globals.let)((__glintDSL__.noop(arr), [1, 2]), (__glintDSL__.noop(h), ({\\nred: "blue",\\n})))
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(107:110): let
-        | | | | |  ts(303:330):  __glintDSL__.Globals["let"]
+        | | | | |  ts(303:327):  __glintDSL__.Globals.let
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(107:110): let
-        | | | | | |  ts(325:328):  let
+        | | | | | |  ts(324:327):  let
         | | | | | |
         | | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(112:115): arr
-        | | | | |  ts(351:354):  arr
+        | | | | |  ts(348:351):  arr
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(112:115): arr
-        | | | | | |  ts(351:354):  arr
+        | | | | | |  ts(348:351):  arr
         | | | | | |
         | | | | |
         | | | | | Mapping: SubExpression
         | | | | |  hbs(111:120): (arr 1 2)
-        | | | | |  ts(357:363):  [1, 2]
+        | | | | |  ts(354:360):  [1, 2]
         | | | | |
         | | | | | | Mapping: NumberLiteral
         | | | | | |  hbs(116:117): 1
-        | | | | | |  ts(358:359):  1
+        | | | | | |  ts(355:356):  1
         | | | | | |
         | | | | | | Mapping: NumberLiteral
         | | | | | |  hbs(118:119): 2
-        | | | | | |  ts(361:362):  2
+        | | | | | |  ts(358:359):  2
         | | | | | |
         | | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(122:123): h
-        | | | | |  ts(385:386):  h
+        | | | | |  ts(382:383):  h
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(122:123): h
-        | | | | | |  ts(385:386):  h
+        | | | | | |  ts(382:383):  h
         | | | | | |
         | | | | |
         | | | | | Mapping: SubExpression
         | | | | |  hbs(121:135): (h red="blue")
-        | | | | |  ts(389:407):  ({\\nred: "blue",\\n})
+        | | | | |  ts(386:404):  ({\\nred: "blue",\\n})
         | | | | |
         | | | | | | Mapping: Identifier
         | | | | | |  hbs(124:127): red
-        | | | | | |  ts(392:395):  red
+        | | | | | |  ts(389:392):  red
         | | | | | |
         | | | | | | Mapping: StringLiteral
         | | | | | |  hbs(128:134): "blue"
-        | | | | | |  ts(397:403):  "blue"
+        | | | | | |  ts(394:400):  "blue"
         | | | | | |
         | | | | |
         | | | |
         | | | | Mapping: Identifier
         | | | |  hbs(140:143): arr
-        | | | |  ts(421:424):  arr
+        | | | |  ts(418:421):  arr
         | | | |
         | | | | Mapping: Identifier
         | | | |  hbs(144:145): h
-        | | | |  ts(426:427):  h
+        | | | |  ts(423:424):  h
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(153:161): Array is
-        | | | |  ts(466:466):
+        | | | |  ts(463:463):
         | | | |
         | | | | Mapping: MustacheStatement
         | | | |  hbs(162:169): {{arr}}
-        | | | |  ts(466:527):  __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)())
+        | | | |  ts(463:524):  __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(arr)())
         | | | |
         | | | | | Mapping: MustacheStatement
         | | | | |  hbs(162:169): {{arr}}
-        | | | | |  ts(491:526):  __glintDSL__.resolveOrReturn(arr)()
+        | | | | |  ts(488:523):  __glintDSL__.resolveOrReturn(arr)()
         | | | | |
         | | | | | | Mapping: PathExpression
         | | | | | |  hbs(164:167): arr
-        | | | | | |  ts(520:523):  arr
+        | | | | | |  ts(517:520):  arr
         | | | | | |
         | | | | | | | Mapping: Identifier
         | | | | | | |  hbs(164:167): arr
-        | | | | | | |  ts(520:523):  arr
+        | | | | | | |  ts(517:520):  arr
         | | | | | | |
         | | | | | |
         | | | | |
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(174:181): Hash is
-        | | | |  ts(529:529):
+        | | | |  ts(526:526):
         | | | |
         | | | | Mapping: MustacheStatement
         | | | |  hbs(182:187): {{h}}
-        | | | |  ts(529:588):  __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)())
+        | | | |  ts(526:585):  __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)())
         | | | |
         | | | | | Mapping: MustacheStatement
         | | | | |  hbs(182:187): {{h}}
-        | | | | |  ts(554:587):  __glintDSL__.resolveOrReturn(h)()
+        | | | | |  ts(551:584):  __glintDSL__.resolveOrReturn(h)()
         | | | | |
         | | | | | | Mapping: PathExpression
         | | | | | |  hbs(184:185): h
-        | | | | | |  ts(583:584):  h
+        | | | | | |  ts(580:581):  h
         | | | | | |
         | | | | | | | Mapping: Identifier
         | | | | | | |  hbs(184:185): h
-        | | | | | | |  ts(583:584):  h
+        | | | | | | |  ts(580:581):  h
         | | | | | | |
         | | | | | |
         | | | | |
         | | | |
         | | | | Mapping: TextContent
         | | | |  hbs(187:188):
-        | | | |  ts(590:590):
+        | | | |  ts(587:587):
         | | | |
         | | | | Mapping: Identifier
         | | | |  hbs(193:196): let
-        | | | |  ts(614:617):  let
+        | | | |  ts(610:613):  let
         | | | |
         | | |
         | |

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -284,7 +284,7 @@ describe('Transform: rewriteTemplate', () => {
           __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.ok)());
           } else {
           {
-          const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["doAThing"])());
+          const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.doAThing)());
           {
           const [ok] = __glintY__.blockParams["default"];
           __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(ok)());
@@ -293,7 +293,7 @@ describe('Transform: rewriteTemplate', () => {
           const [] = __glintY__.blockParams["else"];
           __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.nevermind)());
           }
-          __glintDSL__.Globals["doAThing"];
+          __glintDSL__.Globals.doAThing;
           }
           }"
         `);
@@ -565,7 +565,7 @@ describe('Transform: rewriteTemplate', () => {
           let template = '{{message}}';
 
           expect(templateBody(template)).toMatchInlineSnapshot(
-            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintDSL__.Globals["message"])());"`,
+            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintDSL__.Globals.message)());"`,
           );
         });
 
@@ -725,7 +725,7 @@ describe('Transform: rewriteTemplate', () => {
             expect(templateBody(template, { globals: ['foo'] })).toMatchInlineSnapshot(`
               "{
               const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(Greet)({ 
-              message: __glintDSL__.resolveOrReturn(__glintDSL__.Globals["foo"])(), ...__glintDSL__.NamedArgsMarker }));
+              message: __glintDSL__.resolveOrReturn(__glintDSL__.Globals.foo)(), ...__glintDSL__.NamedArgsMarker }));
               }"
             `);
           });
@@ -746,7 +746,7 @@ describe('Transform: rewriteTemplate', () => {
 
             expect(templateBody(template, { globals: ['let', 'foo'] })).toMatchInlineSnapshot(`
               "{
-              const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["let"])(__glintDSL__.Globals["foo"]));
+              const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.let)(__glintDSL__.Globals.foo));
               {
               const [bar] = __glintY__.blockParams["default"];
               {
@@ -754,7 +754,7 @@ describe('Transform: rewriteTemplate', () => {
               message: bar, ...__glintDSL__.NamedArgsMarker }));
               }
               }
-              __glintDSL__.Globals["let"];
+              __glintDSL__.Globals.let;
               }"
             `);
           });
@@ -874,13 +874,13 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.foo)());
         {
         const [bar, baz] = __glintY__.blockParams["default"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(bar)());
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(baz)());
         }
-        __glintDSL__.Globals["foo"];
+        __glintDSL__.Globals.foo;
         }"
       `);
     });
@@ -896,7 +896,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.foo)());
         {
         const [bar, baz] = __glintY__.blockParams["default"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(bar)());
@@ -906,7 +906,7 @@ describe('Transform: rewriteTemplate', () => {
         const [] = __glintY__.blockParams["else"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.oh)());
         }
-        __glintDSL__.Globals["foo"];
+        __glintDSL__.Globals.foo;
         }"
       `);
     });
@@ -922,7 +922,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.foo)());
         {
         const [bar, baz] = __glintY__.blockParams["default"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(bar)());
@@ -932,7 +932,7 @@ describe('Transform: rewriteTemplate', () => {
         const [] = __glintY__.blockParams["else"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.oh)());
         }
-        __glintDSL__.Globals["foo"];
+        __glintDSL__.Globals.foo;
         }"
       `);
     });
@@ -1019,7 +1019,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["Foo"])({ 
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.Foo)({ 
         bar: "hello", ...__glintDSL__.NamedArgsMarker }));
         }"
       `);
@@ -1034,7 +1034,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["Foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.Foo)());
         {
         const [bar] = __glintY__.blockParams["default"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(bar)());
@@ -1059,7 +1059,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template, { globals: ['let'] })).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["let"])("div"));
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.let)("div"));
         {
         const [div] = __glintY__.blockParams["default"];
         {
@@ -1069,7 +1069,7 @@ describe('Transform: rewriteTemplate', () => {
         }
         }
         }
-        __glintDSL__.Globals["let"];
+        __glintDSL__.Globals.let;
         }"
       `);
     });
@@ -1122,7 +1122,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["Foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.Foo)());
         {
         const [h] = __glintY__.blockParams["head"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(h)());
@@ -1160,7 +1160,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["Foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.Foo)());
         {
         const [NS] = __glintY__.blockParams["default"];
         {
@@ -1185,7 +1185,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["Foo"])());
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.Foo)());
         {
         const [__switch] = __glintY__.blockParams["default"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__switch)());
@@ -1515,7 +1515,7 @@ describe('Transform: rewriteTemplate', () => {
         {{/each}}`;
 
       expect(templateBody(template, { globals: ['action'] })).toMatchInlineSnapshot(`
-        "__glintDSL__.emitContent(__glintDSL__.resolve(__glintDSL__.Globals["action"])("action"));
+        "__glintDSL__.emitContent(__glintDSL__.resolve(__glintDSL__.Globals.action)("action"));
         {
         const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(each)(actions));
         {
@@ -1523,6 +1523,39 @@ describe('Transform: rewriteTemplate', () => {
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(action)());
         }
         each;
+        }"
+      `);
+    });
+
+    test('emits dotted property access for identifier-safe global names', () => {
+      // Dotted access on the `Globals` interface preserves JSDoc, go-to-definition,
+      // and completions in the TypeScript language service for the underlying
+      // keyword (e.g. `eq` → `KeywordsForEmber71.eq`).
+      let template = `{{eq 1 1}}`;
+
+      expect(templateBody(template, { globals: ['eq'] })).toMatchInlineSnapshot(
+        `"__glintDSL__.emitContent(__glintDSL__.resolve(__glintDSL__.Globals.eq)(1, 1));"`,
+      );
+    });
+
+    test('falls back to bracket-string access for hyphenated global names', () => {
+      // Hyphenated keywords (e.g. `each-in`, `in-element`) cannot be expressed as
+      // a JS PropertyAccessExpression, so they must be emitted via bracket-string
+      // access. JSDoc on hover is not surfaced for this form by TS, by design.
+      let template = `
+        {{#each-in items as |k v|}}
+          {{k}}: {{v}}
+        {{/each-in}}`;
+
+      expect(templateBody(template, { globals: ['each-in'] })).toMatchInlineSnapshot(`
+        "{
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["each-in"])(items));
+        {
+        const [k, v] = __glintY__.blockParams["default"];
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(k)());
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(v)());
+        }
+        __glintDSL__.Globals["each-in"];
         }"
       `);
     });


### PR DESCRIPTION

### Summary

In `.gts` / `.gjs` files, hovering a built-in helper or keyword (e.g. `{{eq}}`, `{{on}}`, `{{each}}`, `{{fn}}`, `{{if}}`, …) currently shows no documentation, no go-to-definition, and no signature help, even though those members are fully typed (with JSDoc) on the `Globals` interface that the env registers.

Imported helpers and locally-scoped identifiers work fine because they reach the language service as plain `Identifier` nodes. Free template tokens that the transform classifies as globals do not — they are emitted as a string-keyed indexed access:

```ts
__glintDSL__.Globals["eq"]
```

TypeScript does not propagate JSDoc / quick-info through `obj["key"]` indexed access, so the language service has nothing to show on hover.

### Fix

In `emitIdentifierReference` (template transform), emit a dotted property access whenever the global's name is a valid JS identifier:

```ts
// before                              // after (name === "eq")
__glintDSL__.Globals["eq"]             __glintDSL__.Globals.eq
```

Hyphenated keywords like `each-in` and `in-element` cannot be expressed as a property access and keep the existing bracket-string fallback:

```ts
__glintDSL__.Globals["each-in"]
```

This restores hover docs, go-to-definition, and completions for every identifier-safe built-in, which covers the entire 7.1 helper set (`and`, `array`, `concat`, `eq`, `fn`, `gt`, `gte`, `hash`, `if`, `lt`, `lte`, `neq`, `not`, `on`, `or`, …) plus the long-standing keywords (`each`, `let`, `yield`, `component`, `helper`, `modifier`, …).

### Backwards compatibility

- Mapper position semantics for the emitted identifier itself are unchanged — diagnostics still point at the original HBS span.
- Bracket-string fallback continues to cover every name that is not a syntactically valid JS identifier, so hyphenated keywords behave exactly as before.

### Tests

- 14 inline snapshots in `template-to-typescript.test.ts` and 1 in `rewrite.test.ts` updated to reflect the new emit shape.
- Two new tests pin both code paths:
  - `emits dotted property access for identifier-safe global names` — `{{eq 1 1}}`
  - `falls back to bracket-string access for hyphenated global names` — `{{#each-in items as |k v|}}`

Verified locally in VS Code with the Glint extension built from this branch: hovering `{{eq}}`, `{{on}}`, `{{each}}`, `{{fn}}`, `{{if}}`, etc. now surfaces the JSDoc that lives on the `Globals` interface.
