### PR TITLE
fix(ember-tsc): emit dotted alias for hyphenated template globals

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -13,6 +13,20 @@ const SPLATTRIBUTES = '...attributes';
 // the bracket-string fallback `Globals["NAME"]` for hyphenated keywords.
 const VALID_JS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
+// Hyphenated globals translated to identifier-safe aliases declared on the
+// `Globals` interface (see `KeywordAliasesForEmber` in
+// `types/-private/dsl/globals.d.ts`). Aliases substitute `-` with `_` so the
+// emitted identifier has the SAME length as the source keyword, which keeps
+// the Volar source-to-TS character mapping balanced and lets hover surface
+// JSDoc within the keyword token.
+const HYPHENATED_GLOBAL_ALIASES: Record<string, string> = {
+  'each-in': 'each_in',
+  'has-block': 'has_block',
+  'has-block-params': 'has_block_params',
+  'in-element': 'in_element',
+  'unique-id': 'unique_id',
+};
+
 export type TemplateToTypescriptOptions = {
   typesModule: string;
   meta?: GlintEmitMetadata | undefined;
@@ -608,12 +622,19 @@ export function templateToTypescript(
         // Emit dotted property access (e.g. `__glintDSL__.Globals.eq`) when
         // `name` is a valid JS identifier so the TS language service surfaces
         // JSDoc, go-to-definition, and completions for the underlying member
-        // of `Globals`. Fall back to bracket-string access for hyphenated
-        // keywords like `each-in` or `in-element`, which cannot be expressed
-        // as a dotted property and so do not benefit from this code path.
+        // of `Globals`. For known hyphenated keywords, translate to an
+        // identifier-safe alias declared on the `Globals` interface so JSDoc
+        // still surfaces; fall back to bracket-string access otherwise.
         if (VALID_JS_IDENTIFIER.test(name)) {
           mapper.text('__glintDSL__.Globals.');
           mapper.identifier(name, hbsOffset, name.length);
+        } else if (Object.prototype.hasOwnProperty.call(HYPHENATED_GLOBAL_ALIASES, name)) {
+          // The mapper still receives the original `name.length` so source
+          // positions continue to point at the HBS keyword token, and the
+          // alias has the same character length as the source keyword so the
+          // per-character source-to-TS mapping stays balanced.
+          mapper.text('__glintDSL__.Globals.');
+          mapper.identifier(HYPHENATED_GLOBAL_ALIASES[name], hbsOffset, name.length);
         } else {
           mapper.text('__glintDSL__.Globals["');
           mapper.identifier(JSON.stringify(name).slice(1, -1), hbsOffset, name.length);

--- a/packages/ember-tsc/types/-private/dsl/globals.d.ts
+++ b/packages/ember-tsc/types/-private/dsl/globals.d.ts
@@ -514,6 +514,68 @@ interface KeywordsForEmber71 {
   or: Ember71Only<OrHelper>;
 }
 
-interface Keywords extends KeywordsForEmber, KeywordsForEmber71 {}
+/**
+ * Identifier-safe aliases for hyphenated members of `KeywordsForEmber`.
+ *
+ * The Glint template-to-TypeScript transform emits hyphenated template
+ * keywords (e.g. `{{each-in}}`, `{{in-element}}`) as dotted property accesses
+ * on `Globals` using these snake_case aliases (`each_in`, `in_element`, ...).
+ * Dotted access preserves JSDoc, go-to-definition and completions on hover,
+ * which the bracket-string fallback (`Globals["each-in"]`) does not.
+ *
+ * Each alias intentionally has the SAME character length as its hyphenated
+ * counterpart so that the Volar source-to-TypeScript character mapping for
+ * the keyword stays balanced.
+ */
+interface KeywordAliasesForEmber {
+  /**
+    The `{{each-in}}` helper loops over properties on an object.
+
+    See [the API documentation] for further details.
+
+    [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each-in?anchor=each-in
+  */
+  each_in: EachInKeyword;
+
+  /**
+    `{{has-block}}` indicates if the component was invoked with a block.
+
+    See [the API documentation] for further details.
+
+    [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/hasBlock?anchor=hasBlock
+  */
+  has_block: VM.HasBlockKeyword;
+
+  /**
+    `{{has-block-params}}` indicates if the component was invoked with block params.
+
+    See [the API documentation] for further details.
+
+    [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/hasBlockParams?anchor=hasBlockParams
+  */
+  has_block_params: VM.HasBlockParamsKeyword;
+
+  /**
+    The `{{in-element}}` helper renders its block content outside of the regular flow,
+    into a DOM element given by its `destinationElement` positional argument.
+
+    See [the API documentation] for further details.
+
+    [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/in-element?anchor=in-element
+  */
+  in_element: VM.InElementKeyword;
+
+  /**
+  Use the `{{unique-id}}` helper to generate a unique ID string suitable for use as an ID
+  attribute in the DOM.
+ 
+  See [the API documentation] for further details.
+
+  [the API documentation]: https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/unique-id?anchor=unique-id
+   */
+  unique_id: UniqueIdHelper;
+}
+
+interface Keywords extends KeywordsForEmber, KeywordsForEmber71, KeywordAliasesForEmber {}
 
 export const Globals: Keywords & Globals;

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -1538,10 +1538,12 @@ describe('Transform: rewriteTemplate', () => {
       );
     });
 
-    test('falls back to bracket-string access for hyphenated global names', () => {
-      // Hyphenated keywords (e.g. `each-in`, `in-element`) cannot be expressed as
-      // a JS PropertyAccessExpression, so they must be emitted via bracket-string
-      // access. JSDoc on hover is not surfaced for this form by TS, by design.
+    test('emits dotted access via snake_case alias for known hyphenated global names', () => {
+      // Known hyphenated keywords (e.g. `each-in`, `in-element`) are translated
+      // to identifier-safe aliases declared on the `Globals` interface so JSDoc,
+      // go-to-definition, and completions still surface on hover. The alias has
+      // the same character length as the source keyword so the per-character
+      // source-to-TS mapping stays balanced.
       let template = `
         {{#each-in items as |k v|}}
           {{k}}: {{v}}
@@ -1549,15 +1551,27 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template, { globals: ['each-in'] })).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals["each-in"])(items));
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintDSL__.Globals.each_in)(items));
         {
         const [k, v] = __glintY__.blockParams["default"];
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(k)());
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(v)());
         }
-        __glintDSL__.Globals["each-in"];
+        __glintDSL__.Globals.each_in;
         }"
       `);
+    });
+
+    test('falls back to bracket-string access for unknown hyphenated global names', () => {
+      // Hyphenated names that are not part of the known alias map (e.g. user
+      // helpers) cannot be expressed as a JS PropertyAccessExpression, so they
+      // are emitted via bracket-string access. JSDoc on hover is not surfaced
+      // for this form by TS, by design.
+      let template = `{{some-helper 1 2}}`;
+
+      expect(templateBody(template, { globals: ['some-helper'] })).toMatchInlineSnapshot(
+        `"__glintDSL__.emitContent(__glintDSL__.resolve(__glintDSL__.Globals["some-helper"])(1, 2));"`,
+      );
     });
   });
 });


### PR DESCRIPTION
Hyphenated template keywords such as {{each-in}}, {{in-element}}, {{has-block}}, {{has-block-params}}, and {{unique-id}} were previously emitted as bracket-string access on the Globals interface, e.g. `__glintDSL__.Globals["each-in"]`. TypeScript's language service does not surface JSDoc, go-to-definition, or completions for this form, so hovering these keywords in .gts/.gjs files showed no documentation.

Translate the known set of hyphenated keywords to identifier-safe snake_case aliases declared on a new `KeywordAliasesForEmber` interface that `Keywords` extends, emitting them as dotted property access (e.g. `__glintDSL__.Globals.each_in`). Each alias is chosen to have the same character length as the source keyword so the per-character Volar source-to-TypeScript mapping stays balanced.

Unknown hyphenated names continue to use the bracket-string fallback.