### PR TITLE
fix(ember-tsc): use cooked text for tagged template content to keep `gts` source-map offsets aligned

### DIFF
--- a/packages/ember-tsc/src/transform/template/inlining/tagged-strings.ts
+++ b/packages/ember-tsc/src/transform/template/inlining/tagged-strings.ts
@@ -36,7 +36,19 @@ export function calculateTaggedTemplateSpans(
     );
 
     let { typesModule, globals } = info.tagConfig;
-    let template = node.template.rawText ?? node.template.text;
+    // Use the cooked text (`text`) rather than `rawText`. For .gts files, the
+    // gts preprocessor (see `environment-ember-template-imports/-private/
+    // environment/preprocess.ts`) escapes backticks and `${{` sequences inside
+    // template content so the wrapped chunk parses as a valid JS template
+    // literal. `rawText` preserves those backslash-escapes as literal
+    // characters, which inflates the template length by 1 per escape and
+    // shifts every downstream source-map offset by the same amount (manifests
+    // as hover/go-to-definition spans landing past the start of any identifier
+    // that follows an escaped backtick or `${{` in the same template, e.g.
+    // hyphenated keywords used after backtick-quoted text in a comment). The
+    // cooked `text` reverses those escapes, restoring 1:1 correspondence with
+    // the original source.
+    let template = node.template.text;
 
     // environment-specific transforms may emit templateLocation in meta, in
     // which case we use that. Otherwise we use the reported location from the

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -65,6 +65,51 @@ describe('Transform: rewriteModule', () => {
       `);
     });
 
+    test('source-map offsets are stable after a ` character earlier in the template', () => {
+      // Regression test: the .gts preprocessor escapes backticks inside
+      // template content so the wrapped chunk parses as a valid JS template
+      // literal. Previously the transform used `node.template.rawText`, which
+      // preserves those backslash-escapes verbatim and inflated the template
+      // length by 1 per escape — shifting every downstream source-map offset
+      // by the same amount. The visible symptom was cmd-hover / go-to-def
+      // underlines landing past the start of identifiers (most noticeable
+      // for hyphenated keywords like `in-element`) when a backtick appeared
+      // earlier in the same template (e.g. inside a `{{! ... }}` comment).
+      let script = {
+        filename: 'test.gts',
+        contents: stripIndent`
+          import Component from '@glimmer/component';
+          export default class MyComponent extends Component<{ Args: { dest: Element } }> {
+            <template>
+              {{! Renders into \`dest\`. }}
+              {{#in-element @dest}}hello{{/in-element}}
+            </template>
+          }
+        `,
+      };
+
+      let transformedModule = rewriteModule(ts, { script }, env);
+
+      expect(transformedModule?.errors).toEqual([]);
+
+      // The transform emits `in_element` (identifier-safe) for the hyphenated
+      // `in-element` keyword. Map that identifier back to the original .gts
+      // and confirm it lands exactly on `in-element` rather than +N chars past.
+      let transformed = transformedModule!.transformedContents;
+      let transformedStart = transformed.indexOf('Globals.in_element');
+      expect(transformedStart).toBeGreaterThan(-1);
+      let identifierStart = transformedStart + 'Globals.'.length;
+      let identifierEnd = identifierStart + 'in_element'.length;
+
+      let originalRange = transformedModule!.getOriginalRange(identifierStart, identifierEnd);
+      let originalStart = script.contents.indexOf('in-element');
+
+      expect(originalRange.start).toBe(originalStart);
+      expect(
+        script.contents.slice(originalRange.start, originalRange.start + 'in-element'.length),
+      ).toBe('in-element');
+    });
+
     test('with a class with type parameters', () => {
       let script = {
         filename: 'test.gts',


### PR DESCRIPTION
The `.gts` preprocessor wraps `<template>...</template>` content in a JS template literal and escapes any `` ` `` → `\`` and `${{` → `\${{` so the chunk parses as valid TypeScript. `calculateTaggedTemplateSpans` then fed the template content to `templateToTypescript` via `node.template.rawText`, which preserves those backslash-escapes as literal characters. Each escape inflated the template length by one character, while `embeddingSyntax.prefix`/`suffix` (sliced from the original `script.contents`) and `correlatedSpan.originalStart` remained in original-source space. Every downstream source-map offset (used by Volar, hover, go-to-definition, etc.) was therefore shifted by +N for any identifier appearing after N escaped characters in the same template. The visible symptom was cmd-hover / go-to-def underlines landing past the start of identifiers — most noticeable for hyphenated keywords like `in-element` or `each-in` when a backtick appeared earlier in the template (e.g. inside a `{{! ... }}` comment).

Use `node.template.text` (cooked) instead. The cooked text reverses exactly the escape sequences the preprocessor introduced, restoring 1:1 correspondence between template-space and the original source. Add a regression test that asserts `getOriginalRange` for `in-element` lands exactly on `in-element` (not +N chars past) when a `` ` `` appears earlier in the same template.