### PR TITLE
feat(vscode): auto-discover @glint/ember-tsc from active file

### DIFF
--- a/packages/vscode/__tests__/resolve-ember-tsc.test.ts
+++ b/packages/vscode/__tests__/resolve-ember-tsc.test.ts
@@ -1,0 +1,213 @@
+import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { findEmberTscByWalkingUp, resolveEmberTscServerPath } from '../src/resolve-ember-tsc';
+
+const SERVER_REL = path.join('node_modules', '@glint', 'ember-tsc', 'bin', 'glint-language-server');
+
+function makeEmberTscInstall(rootDir: string): string {
+  const binPath = path.join(rootDir, SERVER_REL);
+  const pkgJson = path.join(rootDir, 'node_modules', '@glint', 'ember-tsc', 'package.json');
+  fs.mkdirSync(path.dirname(binPath), { recursive: true });
+  fs.writeFileSync(binPath, '#!/usr/bin/env node\n');
+  fs.writeFileSync(
+    pkgJson,
+    JSON.stringify({
+      name: '@glint/ember-tsc',
+      version: '0.0.0-test',
+      bin: { 'glint-language-server': './bin/glint-language-server' },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(rootDir, 'package.json'),
+    JSON.stringify({ name: 'host', version: '0.0.0' }),
+  );
+  return binPath;
+}
+
+describe('resolveEmberTscServerPath', () => {
+  let tmpRoot: string;
+  const bundledServerPath = '/bundled/glint-language-server.js';
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'glint-resolve-')));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('uses bundled server when source is "bundled"', () => {
+    const workspaceRoot = tmpRoot;
+    makeEmberTscInstall(workspaceRoot); // present but ignored
+    const result = resolveEmberTscServerPath({
+      workspaceRoot,
+      libraryPath: '.',
+      emberTscSource: 'bundled',
+      bundledServerPath,
+    });
+    assert.equal(result.source, 'bundled');
+    assert.equal(result.path, bundledServerPath);
+    assert.equal(result.usedFallback, false);
+    assert.equal(result.autoDiscovered, false);
+  });
+
+  it('resolves from the configured libraryPath', () => {
+    const workspaceRoot = tmpRoot;
+    const uiDir = path.join(workspaceRoot, 'ui');
+    fs.mkdirSync(uiDir, { recursive: true });
+    const binPath = makeEmberTscInstall(uiDir);
+
+    const result = resolveEmberTscServerPath({
+      workspaceRoot,
+      libraryPath: 'ui',
+      emberTscSource: 'workspace',
+      bundledServerPath,
+    });
+    assert.equal(result.source, 'workspace');
+    assert.equal(result.path, binPath);
+    assert.equal(result.usedFallback, false);
+    assert.equal(result.autoDiscovered, false);
+  });
+
+  it('auto-discovers ember-tsc by walking up from the active file', () => {
+    const workspaceRoot = tmpRoot;
+    const uiDir = path.join(workspaceRoot, 'ui');
+    const deepDir = path.join(uiDir, 'app', 'components');
+    fs.mkdirSync(deepDir, { recursive: true });
+    const binPath = makeEmberTscInstall(uiDir);
+    const activeFile = path.join(deepDir, 'foo.gts');
+    fs.writeFileSync(activeFile, '<template>hi</template>');
+
+    const result = resolveEmberTscServerPath({
+      workspaceRoot,
+      libraryPath: '.',
+      emberTscSource: 'auto',
+      activeFileFsPath: activeFile,
+      bundledServerPath,
+    });
+    assert.equal(result.source, 'workspace');
+    assert.equal(result.path, binPath);
+    assert.equal(result.autoDiscovered, true);
+    assert.equal(result.usedFallback, false);
+    assert.equal(result.resolutionDir, uiDir);
+  });
+
+  it('auto-discovers from a .gjs file too', () => {
+    const workspaceRoot = tmpRoot;
+    const uiDir = path.join(workspaceRoot, 'web');
+    const deepDir = path.join(uiDir, 'app');
+    fs.mkdirSync(deepDir, { recursive: true });
+    makeEmberTscInstall(uiDir);
+    const activeFile = path.join(deepDir, 'bar.gjs');
+    fs.writeFileSync(activeFile, '<template>hi</template>');
+
+    const result = resolveEmberTscServerPath({
+      workspaceRoot,
+      libraryPath: '.',
+      emberTscSource: 'auto',
+      activeFileFsPath: activeFile,
+      bundledServerPath,
+    });
+    assert.equal(result.autoDiscovered, true);
+    assert.equal(result.resolutionDir, uiDir);
+  });
+
+  it('falls back to bundled when no workspace install exists', () => {
+    const workspaceRoot = tmpRoot;
+    fs.writeFileSync(path.join(workspaceRoot, 'package.json'), JSON.stringify({ name: 'host' }));
+    const activeFile = path.join(workspaceRoot, 'app', 'x.gts');
+    fs.mkdirSync(path.dirname(activeFile), { recursive: true });
+    fs.writeFileSync(activeFile, '');
+
+    const result = resolveEmberTscServerPath({
+      workspaceRoot,
+      libraryPath: '.',
+      emberTscSource: 'auto',
+      activeFileFsPath: activeFile,
+      bundledServerPath,
+    });
+    assert.equal(result.source, 'bundled');
+    assert.equal(result.path, bundledServerPath);
+    assert.equal(result.usedFallback, true);
+    assert.equal(result.autoDiscovered, false);
+  });
+
+  it('does not auto-discover in "workspace" mode (only honors configured libraryPath)', () => {
+    const workspaceRoot = tmpRoot;
+    const uiDir = path.join(workspaceRoot, 'ui');
+    fs.mkdirSync(uiDir, { recursive: true });
+    makeEmberTscInstall(uiDir);
+    const activeFile = path.join(uiDir, 'foo.gts');
+    fs.writeFileSync(activeFile, '');
+
+    const result = resolveEmberTscServerPath({
+      workspaceRoot,
+      libraryPath: '.', // workspace root has no @glint
+      emberTscSource: 'workspace',
+      activeFileFsPath: activeFile,
+      bundledServerPath,
+    });
+    // Workspace mode failed to find at root; falls back to bundled, never walks up.
+    assert.equal(result.source, 'bundled');
+    assert.equal(result.usedFallback, true);
+    assert.equal(result.autoDiscovered, false);
+  });
+
+  it('does not walk up past the workspace root', () => {
+    // Install lives ABOVE the workspace root — `findEmberTscByWalkingUp`
+    // must not pick it up. (Note: Node's standard `require.resolve` _will_
+    // walk up the `node_modules` chain — that's intentional and handled by
+    // the primary resolution path, not by the walk-up fallback.)
+    const workspaceRoot = path.join(tmpRoot, 'workspace');
+    fs.mkdirSync(workspaceRoot, { recursive: true });
+    makeEmberTscInstall(tmpRoot);
+
+    const activeFile = path.join(workspaceRoot, 'app', 'x.gts');
+    fs.mkdirSync(path.dirname(activeFile), { recursive: true });
+    fs.writeFileSync(activeFile, '');
+
+    assert.equal(findEmberTscByWalkingUp(activeFile, workspaceRoot), undefined);
+  });
+});
+
+describe('findEmberTscByWalkingUp', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'glint-walkup-')));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns undefined when start is outside stopDir', () => {
+    const stop = path.join(tmpRoot, 'a');
+    const outside = path.join(tmpRoot, 'b', 'file.gts');
+    fs.mkdirSync(path.dirname(outside), { recursive: true });
+    fs.mkdirSync(stop, { recursive: true });
+    fs.writeFileSync(outside, '');
+    assert.equal(findEmberTscByWalkingUp(outside, stop), undefined);
+  });
+
+  it('picks the nearest install when multiple ancestors have one', () => {
+    const outer = tmpRoot;
+    const inner = path.join(outer, 'ui');
+    fs.mkdirSync(inner, { recursive: true });
+    makeEmberTscInstall(outer);
+    const innerBin = makeEmberTscInstall(inner);
+
+    const file = path.join(inner, 'app', 'x.gts');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '');
+
+    const found = findEmberTscByWalkingUp(file, outer);
+    assert.ok(found);
+    assert.equal(found.serverPath, innerBin);
+    assert.equal(found.resolutionDir, inner);
+  });
+});

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -24,7 +24,8 @@
     "Linters"
   ],
   "scripts": {
-    "test": "pnpm build && pnpm test-ts-plugin",
+    "test": "pnpm build && pnpm test:unit && pnpm test-ts-plugin",
+    "test:unit": "pnpm compile && node --test lib/__tests__/resolve-ember-tsc.test.js",
     "test-ts-plugin": "node lib/__tests__/support/launch-from-cli.mjs",
     "test:typecheck": "echo 'no standalone typecheck within this project'",
     "test:tsc": "echo 'no standalone tsc within this project'",
@@ -108,13 +109,15 @@
         "title": "Glint V2",
         "properties": {
           "glint2.libraryPath": {
-            "markdownDescription": "The path, relative to your workspace folder root, from which to resolve `ember-tsc`. Defaults to `'.'`.",
+            "markdownDescription": "The path, relative to your workspace folder root, from which to resolve `ember-tsc`. Defaults to `'.'`. When unset and `#glint2.emberTscSource#` is `auto`, the extension walks up from the active `.gts`/`.gjs` file to find the nearest `@glint/ember-tsc` install (useful for monorepos).",
             "order": 1,
+            "scope": "resource",
             "type": "string"
           },
           "glint2.emberTscSource": {
-            "markdownDescription": "Which ember-tsc to use: `auto` prefers the workspace package and falls back to the bundled version when missing.",
+            "markdownDescription": "Which ember-tsc to use: `auto` prefers a workspace install (auto-discovered from the active file's directory if `#glint2.libraryPath#` is unset) and falls back to the bundled version when missing.",
             "order": 2,
+            "scope": "resource",
             "type": "string",
             "default": "auto",
             "enum": [

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -7,8 +7,13 @@ import {
 } from '@volar/vscode';
 import * as lsp from '@volar/vscode/node';
 import * as fs from 'node:fs';
-import { createRequire } from 'node:module';
 import * as path from 'node:path';
+
+import {
+  resolveEmberTscServerPath as resolveEmberTscServerPathPure,
+  type EmberTscSource,
+  type ResolveEmberTscResult,
+} from './resolve-ember-tsc';
 import {
   defineExtension,
   executeCommand,
@@ -56,8 +61,6 @@ const TS_PLUGIN_NAME = 'glint-tsserver-plugin-pack';
 const EMBER_TSC_SOURCE_SETTING = 'glint2.emberTscSource';
 const SELECT_EMBER_TSC_COMMAND = 'glint2.select-ember-tsc-source';
 
-type EmberTscSource = 'auto' | 'workspace' | 'bundled';
-
 export const { activate, deactivate } = defineExtension(() => {
   if (v1ExtensionPresent) {
     return;
@@ -78,17 +81,19 @@ export const { activate, deactivate } = defineExtension(() => {
   const updateEmberTscStatus = (
     resolution?: EmberTscResolution,
   ): EmberTscResolution | undefined => {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    const activeFile = getActiveGlintFileUri();
+    const workspaceFolder = getWorkspaceFolderForActiveFile(activeFile);
     if (!workspaceFolder) {
       emberTscStatus.hide();
       return resolution;
     }
 
-    resolution ??= (() => {
-      const emberTscSource = getEmberTscSourceSetting();
-      const libraryPath = getLibraryPathSetting();
-      return resolveEmberTscServerPath(workspaceFolder, emberTscSource, libraryPath);
-    })();
+    resolution ??= resolveEmberTscServerPath(
+      workspaceFolder,
+      getEmberTscSourceSetting(workspaceFolder),
+      getLibraryPathSetting(workspaceFolder),
+      activeFile,
+    );
 
     const label = resolution.path
       ? resolution.source === 'bundled'
@@ -96,28 +101,41 @@ export const { activate, deactivate } = defineExtension(() => {
         : 'Workspace'
       : 'Missing';
     const fallback = resolution.usedFallback ? ' (fallback)' : '';
-    emberTscStatus.text = `Ember TSC (${label}${fallback})`;
+    const auto = resolution.autoDiscovered ? ' (auto)' : '';
+    emberTscStatus.text = `Ember TSC (${label}${fallback}${auto})`;
     emberTscStatus.tooltip =
       `Configured: ${resolution.configuredSource}\n` +
       `Resolved: ${resolution.path ?? 'Not found'}\n` +
-      `Resolution dir: ${resolution.resolutionDir}`;
+      `Resolution dir: ${resolution.resolutionDir}` +
+      (resolution.autoDiscovered ? '\nAuto-discovered from active document.' : '');
     emberTscStatus.show();
 
     return resolution;
   };
 
   const configureTsserverPlugin = async (): Promise<void> => {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    const activeFile = getActiveGlintFileUri();
+    const workspaceFolder = getWorkspaceFolderForActiveFile(activeFile);
     if (!workspaceFolder) {
       return;
     }
 
-    const emberTscSource = getEmberTscSourceSetting();
-    const libraryPath = getLibraryPathSetting();
+    const emberTscSource = getEmberTscSourceSetting(workspaceFolder);
+    const libraryPath = getLibraryPathSetting(workspaceFolder);
+    const resolution = resolveEmberTscServerPath(
+      workspaceFolder,
+      emberTscSource,
+      libraryPath,
+      activeFile,
+    );
+    // Hand the TS plugin the same resolution dir so it sees the same
+    // `@glint/ember-tsc` install we picked for the language server.
+    const effectiveLibraryPath =
+      path.relative(workspaceFolder.uri.fsPath, resolution.resolutionDir) || '.';
     const configuration = {
       emberTscSource,
       workspaceRoot: workspaceFolder.uri.fsPath,
-      libraryPath,
+      libraryPath: effectiveLibraryPath,
     };
 
     try {
@@ -311,13 +329,14 @@ export const { activate, deactivate } = defineExtension(() => {
       return;
     }
 
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    const activeFile = getActiveGlintFileUri();
+    const workspaceFolder = getWorkspaceFolderForActiveFile(activeFile);
     const target = workspaceFolder
-      ? vscode.ConfigurationTarget.Workspace
+      ? vscode.ConfigurationTarget.WorkspaceFolder
       : vscode.ConfigurationTarget.Global;
 
     await vscode.workspace
-      .getConfiguration()
+      .getConfiguration(undefined, workspaceFolder)
       .update(EMBER_TSC_SOURCE_SETTING, selected.value, target);
 
     await updateEmberTscState(true);
@@ -334,16 +353,22 @@ function launch(
   _context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,
 ): { client: lsp.LanguageClient; resolution: EmberTscResolution } | undefined {
-  // Try to find the language server in the workspace
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  // Try to find the language server based on the active document.
+  const activeFile = getActiveGlintFileUri();
+  const workspaceFolder = getWorkspaceFolderForActiveFile(activeFile);
   if (!workspaceFolder) {
     outputChannel.appendLine('[Activation] No workspace folder available; not launching Glint.');
     return undefined;
   }
 
-  const emberTscSource = getEmberTscSourceSetting();
-  const libraryPath = getLibraryPathSetting();
-  const resolution = resolveEmberTscServerPath(workspaceFolder, emberTscSource, libraryPath);
+  const emberTscSource = getEmberTscSourceSetting(workspaceFolder);
+  const libraryPath = getLibraryPathSetting(workspaceFolder);
+  const resolution = resolveEmberTscServerPath(
+    workspaceFolder,
+    emberTscSource,
+    libraryPath,
+    activeFile,
+  );
 
   if (!resolution.path) {
     outputChannel.appendLine(
@@ -416,13 +441,7 @@ function launch(
   return { client, resolution };
 }
 
-interface EmberTscResolution {
-  path?: string;
-  source: EmberTscSource;
-  configuredSource: EmberTscSource;
-  usedFallback: boolean;
-  resolutionDir: string;
-}
+type EmberTscResolution = ResolveEmberTscResult;
 
 function normalizeEmberTscSource(value: unknown): EmberTscSource {
   if (value === 'workspace' || value === 'bundled' || value === 'auto') {
@@ -431,60 +450,53 @@ function normalizeEmberTscSource(value: unknown): EmberTscSource {
   return 'auto';
 }
 
-function getLibraryPathSetting(): string {
-  return vscode.workspace.getConfiguration().get('glint2.libraryPath', '.');
+function getLibraryPathSetting(scope?: vscode.WorkspaceFolder | vscode.Uri): string {
+  return vscode.workspace.getConfiguration(undefined, scope).get('glint2.libraryPath', '.');
 }
 
-function getEmberTscSourceSetting(): EmberTscSource {
-  const value = vscode.workspace.getConfiguration().get(EMBER_TSC_SOURCE_SETTING, 'auto');
+function getEmberTscSourceSetting(scope?: vscode.WorkspaceFolder | vscode.Uri): EmberTscSource {
+  const value = vscode.workspace
+    .getConfiguration(undefined, scope)
+    .get(EMBER_TSC_SOURCE_SETTING, 'auto');
   return normalizeEmberTscSource(value);
+}
+
+function getActiveGlintFileUri(): vscode.Uri | undefined {
+  const active = vscode.window.activeTextEditor;
+  if (active && languageIds.includes(active.document.languageId)) {
+    return active.document.uri;
+  }
+  const visible = vscode.window.visibleTextEditors.find((editor) =>
+    languageIds.includes(editor.document.languageId),
+  );
+  return visible?.document.uri;
+}
+
+function getWorkspaceFolderForActiveFile(
+  activeFile: vscode.Uri | undefined,
+): vscode.WorkspaceFolder | undefined {
+  if (activeFile) {
+    const folder = vscode.workspace.getWorkspaceFolder(activeFile);
+    if (folder) {
+      return folder;
+    }
+  }
+  return vscode.workspace.workspaceFolders?.[0];
 }
 
 function resolveEmberTscServerPath(
   workspaceFolder: vscode.WorkspaceFolder,
   emberTscSource: EmberTscSource,
   libraryPath: string,
+  activeFile: vscode.Uri | undefined,
 ): EmberTscResolution {
-  const resolutionDir = path.resolve(workspaceFolder.uri.fsPath, libraryPath);
-  const workspacePath = resolveWorkspaceEmberTscServerPath(resolutionDir);
-  const bundledPath = resolveBundledEmberTscServerPath();
-
-  if (emberTscSource === 'bundled') {
-    return {
-      path: bundledPath,
-      source: 'bundled',
-      configuredSource: 'bundled',
-      usedFallback: false,
-      resolutionDir,
-    };
-  }
-
-  if (workspacePath) {
-    return {
-      path: workspacePath,
-      source: 'workspace',
-      configuredSource: emberTscSource,
-      usedFallback: false,
-      resolutionDir,
-    };
-  }
-
-  return {
-    path: bundledPath,
-    source: 'bundled',
-    configuredSource: emberTscSource,
-    usedFallback: true,
-    resolutionDir,
-  };
-}
-
-function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | undefined {
-  try {
-    const customRequire = createRequire(path.join(resolutionDir, 'package.json'));
-    return customRequire.resolve('@glint/ember-tsc/bin/glint-language-server');
-  } catch {
-    return undefined;
-  }
+  return resolveEmberTscServerPathPure({
+    workspaceRoot: workspaceFolder.uri.fsPath,
+    libraryPath,
+    emberTscSource,
+    activeFileFsPath: activeFile && activeFile.scheme === 'file' ? activeFile.fsPath : undefined,
+    bundledServerPath: resolveBundledEmberTscServerPath(),
+  });
 }
 
 function resolveBundledEmberTscServerPath(): string | undefined {

--- a/packages/vscode/src/resolve-ember-tsc.ts
+++ b/packages/vscode/src/resolve-ember-tsc.ts
@@ -1,0 +1,176 @@
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+
+export type EmberTscSource = 'auto' | 'workspace' | 'bundled';
+
+export interface ResolveEmberTscInput {
+  /** Absolute path of the workspace folder containing the active document. */
+  workspaceRoot: string;
+  /** Raw value of the `glint2.libraryPath` setting. Defaults to `'.'`. */
+  libraryPath: string;
+  /** Raw value of the `glint2.emberTscSource` setting. */
+  emberTscSource: EmberTscSource;
+  /**
+   * Absolute path of the currently active glimmer-* document, if any. When set,
+   * `auto` mode walks up from this file looking for the closest
+   * `node_modules/@glint/ember-tsc/bin/glint-language-server`.
+   */
+  activeFileFsPath?: string;
+  /** Absolute path to the bundled `glint-language-server.js`, if available. */
+  bundledServerPath?: string;
+}
+
+export interface ResolveEmberTscResult {
+  /** Resolved path to the language-server entry point, if one was found. */
+  path?: string;
+  /** Which source was ultimately selected. */
+  source: EmberTscSource;
+  /** The user-facing configured source (unchanged from input). */
+  configuredSource: EmberTscSource;
+  /** True if we wanted workspace but had to fall back to bundled. */
+  usedFallback: boolean;
+  /** Directory used as the starting point for the workspace lookup. */
+  resolutionDir: string;
+  /**
+   * True when `auto` mode discovered the package by walking up from
+   * `activeFileFsPath` rather than from the configured library path.
+   */
+  autoDiscovered: boolean;
+}
+
+const EMBER_TSC_BIN = '@glint/ember-tsc/bin/glint-language-server';
+const EMBER_TSC_REL = path.join(
+  'node_modules',
+  '@glint',
+  'ember-tsc',
+  'bin',
+  'glint-language-server',
+);
+
+/**
+ * Resolve which `glint-language-server` binary should be launched for the
+ * current workspace + active file.
+ *
+ * Resolution order:
+ *  1. If `emberTscSource === 'bundled'`, always use the bundled server.
+ *  2. Try the configured library path (`workspaceRoot + libraryPath`).
+ *  3. In `auto` mode, walk up from the active document's directory toward
+ *     `workspaceRoot` looking for the nearest `@glint/ember-tsc` install.
+ *  4. Fall back to the bundled server.
+ */
+export function resolveEmberTscServerPath(input: ResolveEmberTscInput): ResolveEmberTscResult {
+  const { workspaceRoot, libraryPath, emberTscSource, activeFileFsPath, bundledServerPath } = input;
+
+  const resolutionDir = path.resolve(workspaceRoot, libraryPath);
+
+  if (emberTscSource === 'bundled') {
+    return {
+      path: bundledServerPath,
+      source: 'bundled',
+      configuredSource: 'bundled',
+      usedFallback: false,
+      resolutionDir,
+      autoDiscovered: false,
+    };
+  }
+
+  const workspacePath = resolveWorkspaceEmberTscServerPath(resolutionDir);
+  if (workspacePath) {
+    return {
+      path: workspacePath,
+      source: 'workspace',
+      configuredSource: emberTscSource,
+      usedFallback: false,
+      resolutionDir,
+      autoDiscovered: false,
+    };
+  }
+
+  if (emberTscSource === 'auto' && activeFileFsPath) {
+    const discovered = findEmberTscByWalkingUp(activeFileFsPath, workspaceRoot);
+    if (discovered) {
+      return {
+        path: discovered.serverPath,
+        source: 'workspace',
+        configuredSource: emberTscSource,
+        usedFallback: false,
+        resolutionDir: discovered.resolutionDir,
+        autoDiscovered: true,
+      };
+    }
+  }
+
+  return {
+    path: bundledServerPath,
+    source: 'bundled',
+    configuredSource: emberTscSource,
+    usedFallback: true,
+    resolutionDir,
+    autoDiscovered: false,
+  };
+}
+
+/**
+ * Try to resolve `@glint/ember-tsc/bin/glint-language-server` using Node's
+ * standard `require.resolve` algorithm rooted at `resolutionDir`.
+ */
+export function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | undefined {
+  try {
+    const customRequire = createRequire(path.join(resolutionDir, 'package.json'));
+    return customRequire.resolve(EMBER_TSC_BIN);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Walk upwards from the directory containing `startFsPath`, stopping at
+ * `stopDir` (inclusive), looking for the nearest
+ * `node_modules/@glint/ember-tsc/bin/glint-language-server`.
+ *
+ * Returns `undefined` if no install is found. Both `node` and `node.js`
+ * variants are accepted (the published package ships an extensionless bin).
+ */
+export function findEmberTscByWalkingUp(
+  startFsPath: string,
+  stopDir: string,
+): { serverPath: string; resolutionDir: string } | undefined {
+  const normalizedStop = path.resolve(stopDir);
+
+  let current = path.resolve(startFsPath);
+  // If we were handed a file path, start from its directory.
+  try {
+    if (fs.statSync(current).isFile()) {
+      current = path.dirname(current);
+    }
+  } catch {
+    current = path.dirname(current);
+  }
+
+  // Bail out if startFsPath is not under stopDir.
+  const rel = path.relative(normalizedStop, current);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return undefined;
+  }
+
+  for (;;) {
+    const candidate = path.join(current, EMBER_TSC_REL);
+    if (fs.existsSync(candidate) || fs.existsSync(`${candidate}.js`)) {
+      // Prefer the extensionless bin (matches what require.resolve returns),
+      // but accept the .js variant for robustness.
+      const finalPath = fs.existsSync(candidate) ? candidate : `${candidate}.js`;
+      return { serverPath: finalPath, resolutionDir: current };
+    }
+
+    if (current === normalizedStop) {
+      return undefined;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}


### PR DESCRIPTION
Resolve the workspace `@glint/ember-tsc` by walking up from the directory of the active `.gts/.gjs` document when no install is found from the configured library path. Bundled remains the final fallback.

This removes the need for monorepo consumers to either set glint2.libraryPath per workspace or to hoist `@glint/*` with publicHoistPattern just so the extension can find them.

- New pure module `packages/vscode/src/resolve-ember-tsc.ts` (with unit tests via node --test).
- Made `glint2.libraryPath` and `glint2.emberTscSource` resource-scoped so multi-root and per-folder settings work.
- Status-bar label shows `Ember TSC (Workspace (auto))` when the install
  was found by walking up from the active document rather than via the
  configured library path.