### PR TITLE
feat(on): allow narrowing event.currentTarget to match the modifier element

### DIFF
--- a/packages/ember-tsc/types/-private/intrinsics/on.d.ts
+++ b/packages/ember-tsc/types/-private/intrinsics/on.d.ts
@@ -10,12 +10,18 @@ export type EventForName<Name extends string> = Name extends keyof HTMLElementEv
   ? HTMLElementEventMap[Name]
   : Event;
 
-export type OnModifier = abstract new <Name extends string>() => InstanceType<
+export type OnModifier = abstract new <
+  Name extends string,
+  El extends Element = Element,
+>() => InstanceType<
   ModifierLike<{
-    Element: Element;
+    Element: El;
     Args: {
       Named: OnModifierArgs;
-      Positional: [name: Name, callback: (event: EventForName<Name>) => void];
+      Positional: [
+        name: Name,
+        callback: (event: EventForName<Name> & { currentTarget: El }) => void,
+      ];
     };
   }>
 >;

--- a/test-packages/package-test-core/__tests__/type-tests/intrinsics/on.test.ts
+++ b/test-packages/package-test-core/__tests__/type-tests/intrinsics/on.test.ts
@@ -19,16 +19,18 @@ on(el, 'click', () => {}, 'hello');
 
 on(el, 'scroll', () => {}, { capture: true, once: true, passive: true, ...NamedArgsMarker });
 
+// `event` is the intersection of the DOM event type and a narrowed
+// `currentTarget`; assignability to the base event type is preserved.
 on(el, 'unknown', (event) => {
-  expectTypeOf(event).toEqualTypeOf<Event>();
+  expectTypeOf(event).toExtend<Event>();
 });
 
 on(el, 'click', (event) => {
-  expectTypeOf(event).toEqualTypeOf<PointerEvent>();
+  expectTypeOf(event).toExtend<PointerEvent>();
 });
 
 on(el, 'keyup', (event) => {
-  expectTypeOf(event).toEqualTypeOf<KeyboardEvent>();
+  expectTypeOf(event).toExtend<KeyboardEvent>();
 });
 
 applyModifier(on(el, 'click', () => {}));
@@ -36,3 +38,29 @@ applyModifier(on(el, 'click', () => {}));
 applyModifier(on(new SVGRectElement(), 'click', () => {}));
 
 applyModifier(on(new Element(), 'click', () => {}));
+
+// A handler can be typed with a narrowed `currentTarget` so that property
+// accesses in the body need no `as` cast.
+const narrowedHandler = (event: SubmitEvent & { currentTarget: HTMLFormElement }): void => {
+  new FormData(event.currentTarget);
+};
+on(document.createElement('form'), 'submit', narrowedHandler);
+
+// With no handler annotation, `currentTarget` is inferred from the element.
+on(document.createElement('form'), 'submit', (event) => {
+  expectTypeOf(event.currentTarget).toExtend<HTMLFormElement>();
+});
+
+// A handler whose `currentTarget` claims an element type incompatible with
+// the element the modifier is on is rejected at the element argument.
+const wrongHandler = (event: SubmitEvent & { currentTarget: HTMLInputElement }): void => {
+  void event;
+};
+// @ts-expect-error: handler claims HTMLInputElement, modifier is on <form>
+on(document.createElement('form'), 'submit', wrongHandler);
+
+// Existing handlers typed with just the DOM event continue to type-check.
+const looseHandler = (event: SubmitEvent): void => {
+  void event;
+};
+on(document.createElement('form'), 'submit', looseHandler);


### PR DESCRIPTION
Today, reading form/input properties off `event.currentTarget` in an `{{on}}` handler requires a cast on every access:

```glimmer-ts
<template>
  <form {{on 'submit' this.handleSubmit}}>…</form>
</template>

handleSubmit = (event: SubmitEvent) => {
  const formData = new FormData(event.currentTarget as HTMLFormElement); // awkward cast
};
```

Typing the 'type checked' cast into the parameter is rejected:

```ts
handleSubmit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => { … };
// TS2345: Type 'EventTarget | null' is not assignable to type 'HTMLFormElement'.
```

After this change, the narrowed parameter is accepted (and type checked) and the body is cast-free:

```ts
handleSubmit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
  new FormData(event.currentTarget); // no cast
};
```

Handlers typed `(event: SubmitEvent) => void` continue to compile unchanged.

## Notes

- **No docs added.** No existing doc page covers `{{on}}` or DOM-event typing — the closest (`helper-and-modifier-signatures.md`) is about authoring custom helpers/modifiers. A new doc page for one paragraph felt like overkill. The pattern is discoverable from the TS error and the release-plan changelog will surface it.
- **Upstreaming?.** The change is entirely inside Glint's `OnModifier` type augmentation. `@ember/modifier` (in ember-source) doesn't ship generic typing for `on`, so there is nothing for ember-source to mirror, yet. I considered adding a type helper `OnEvent<Name, El>` that would have been a candidate for upstreaming. Skipped for more focused scope.