### PR TITLE
fix(ember-tsc): omit 7.1 keywords from Globals on ember-source < 7.1

### DIFF
--- a/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts
+++ b/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts
@@ -1,6 +1,40 @@
+import { createRequire } from 'node:module';
 import { GlintEnvironmentConfig, GlintSpecialFormConfig } from '@glint/ember-tsc/config-types';
 import { preprocess } from './preprocess.js';
 import { transform } from './transform.js';
+
+/**
+ * Probe for the ember-source >= 7.1 built-in keyword set at config-load time.
+ *
+ * The 7.1 keywords (and, or, eq, fn, hash, not, gt/gte/lt/lte/neq, on, element,
+ * array) ship with ember-source 7.1 (RFCs 389, 470, 560, 561, 562, 997, 998,
+ * 999, 1000). On older versions consumers must import them from
+ * `ember-truth-helpers` / `@ember/helper`. Including these names in the strict
+ * mode `globals` set unconditionally suppresses TypeScript's
+ * "Cannot find name 'X'" diagnostic on <7.1 (because the transform emits
+ * `__glintDSL__.Globals.X` instead of a bare `X`), which in turn disables the
+ * `Add import from '...'` quick-fix and IDE autocomplete from user imports.
+ *
+ * Resolving from this module's URL means the probe walks the consumer's
+ * `node_modules` tree, so it reflects the host project's installed
+ * `ember-source`. Any failure (missing package, unreadable JSON, malformed
+ * version) collapses to `false` so the safe default is to assume the
+ * consumer is on a pre-7.1 build and let users import explicitly.
+ */
+function hasEmber71BuiltIns(): boolean {
+  try {
+    const require_ = createRequire(import.meta.url);
+    const pkg = require_('ember-source/package.json') as { version?: unknown };
+    if (typeof pkg.version !== 'string') return false;
+    const [majorStr, minorStr] = pkg.version.split('.', 2);
+    const major = Number(majorStr);
+    const minor = Number(minorStr);
+    if (!Number.isFinite(major) || !Number.isFinite(minor)) return false;
+    return major > 7 || (major === 7 && minor >= 1);
+  } catch {
+    return false;
+  }
+}
 
 export default function emberTemplateImportsEnvironment(
   options: Record<string, unknown>,
@@ -88,7 +122,7 @@ export default function emberTemplateImportsEnvironment(
           },
           globals: [
             ...globalsForEmber,
-            ...globalsForEmber71,
+            ...(hasEmber71BuiltIns() ? globalsForEmber71 : []),
             ...Object.keys(additionalGlobalSpecialForms),
             ...additionalGlobals,
           ],

--- a/packages/ember-tsc/types/-private/dsl/globals.d.ts
+++ b/packages/ember-tsc/types/-private/dsl/globals.d.ts
@@ -31,9 +31,12 @@ import { UniqueIdHelper } from '../intrinsics/unique-id';
 // 389 are only available at runtime when consumers are on ember-source >= 7.1.
 // We probe for the `eq` value re-export added by RFC 561 to decide whether to
 // expose the new keyword types. On older versions the probe collapses to the
-// empty type, so referencing e.g. `{{eq}}` falls back to whatever the user
-// has imported (or surfaces as an "unknown identifier" diagnostic), keeping
-// behaviour identical to today.
+// empty type, so the 7.1 keyword members are entirely absent from `Globals` —
+// referencing e.g. `{{eq}}` then surfaces TypeScript's standard
+// "Property 'eq' does not exist on type 'Globals'" diagnostic, which triggers
+// auto-import quick-fixes (`import { eq } from 'ember-truth-helpers'`) and
+// lets user-scoped imports flow through completion and hover without being
+// shadowed by a `never`-typed builtin.
 //
 // We probe a value export (`eq`) rather than the matching `EqHelper`
 // interface because `typeof import(...)` only surfaces the module's value
@@ -48,9 +51,6 @@ import { UniqueIdHelper } from '../intrinsics/unique-id';
 type EmberHelperExports = typeof import('@ember/helper');
 
 type HasEmber71BuiltIns = [EmberHelperExports] extends [{ eq: unknown }] ? true : false;
-
-/** Resolves to `T` only when ember-source >= 7.1 ships the new keyword set. */
-type Ember71Only<T> = HasEmber71BuiltIns extends true ? T : never;
 
 // The keyword vs global breakdown here is loosely matched with
 // the listing in http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html
@@ -243,12 +243,16 @@ interface KeywordsForEmber {
 
 /**
  * Built-in template keywords introduced by ember-source 7.1
- * (RFCs 389, 470, 560, 561, 562, 997, 998, 999, 1000). Each entry is gated by
- * `Ember71Only<T>` so the keyword resolves to `never` (and is therefore
- * effectively absent) when the consumer is on ember-source < 7.1. See the
- * `HasEmber71BuiltIns` probe at the top of this file.
+ * (RFCs 389, 470, 560, 561, 562, 997, 998, 999, 1000). The whole member set is
+ * gated by `HasEmber71BuiltIns` at the `Globals` intersection below, so when
+ * the consumer is on ember-source < 7.1 these property keys are absent from
+ * `Globals` entirely (rather than present as `never`). That lets TypeScript
+ * report `{{eq}}` / `{{and}}` / etc. as unknown properties and offer the
+ * "Add import from 'ember-truth-helpers'" / `@ember/helper` quick-fix, and
+ * keeps user-imported helpers from being shadowed by a `never`-typed builtin
+ * in completion and hover.
  */
-interface KeywordsForEmber71 {
+interface KeywordsForEmber71Members {
   /**
    * The `{{and}}` helper evaluates arguments left to right, returning the first
    * falsy value (using Handlebars truthiness) or the right-most value if all
@@ -265,7 +269,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/and
    */
-  and: Ember71Only<AndHelper>;
+  and: AndHelper;
 
   /**
    * Using the `{{array}}` helper, you can pass arrays directly from the
@@ -286,7 +290,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/array
    */
-  array: Ember71Only<ArrayHelper>;
+  array: ArrayHelper;
 
   /**
    * The `{{element}}` helper lets you dynamically set the tag name of an
@@ -310,7 +314,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/element
    */
-  element: Ember71Only<ElementHelper>;
+  element: ElementHelper;
 
   /**
    * The `{{eq}}` helper returns `true` if its two arguments are strictly equal
@@ -327,7 +331,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/eq
    */
-  eq: Ember71Only<EqHelper>;
+  eq: EqHelper;
 
   /**
    * `{{fn}}` is a helper that receives a function and some arguments, and
@@ -351,7 +355,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/fn
    */
-  fn: Ember71Only<FnHelper>;
+  fn: FnHelper;
 
   /**
    * The `{{gt}}` helper returns `true` if the first argument is greater than
@@ -368,7 +372,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/gt
    */
-  gt: Ember71Only<GtHelper>;
+  gt: GtHelper;
 
   /**
    * The `{{gte}}` helper returns `true` if the first argument is greater than
@@ -385,7 +389,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/gte
    */
-  gte: Ember71Only<GteHelper>;
+  gte: GteHelper;
 
   /**
    * Using the `{{hash}}` helper, you can pass objects directly from the
@@ -404,7 +408,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/hash
    */
-  hash: Ember71Only<HashHelper>;
+  hash: HashHelper;
 
   /**
    * The `{{lt}}` helper returns `true` if the first argument is less than the
@@ -421,7 +425,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/lt
    */
-  lt: Ember71Only<LtHelper>;
+  lt: LtHelper;
 
   /**
    * The `{{lte}}` helper returns `true` if the first argument is less than or
@@ -438,7 +442,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/lte
    */
-  lte: Ember71Only<LteHelper>;
+  lte: LteHelper;
 
   /**
    * The `{{neq}}` helper returns `true` if its two arguments are strictly not
@@ -455,7 +459,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/neq
    */
-  neq: Ember71Only<NeqHelper>;
+  neq: NeqHelper;
 
   /**
    * The `{{not}}` helper returns the logical negation of its argument using
@@ -472,7 +476,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/not
    */
-  not: Ember71Only<NotHelper>;
+  not: NotHelper;
 
   /**
    * The `{{on}}` element modifier attaches an event listener to an element.
@@ -493,7 +497,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fmodifier/on
    */
-  on: Ember71Only<OnModifier>;
+  on: OnModifier;
 
   /**
    * The `{{or}}` helper evaluates arguments left to right, returning the first
@@ -511,7 +515,7 @@ interface KeywordsForEmber71 {
    *
    * @see https://api.emberjs.com/ember/release/functions/@ember%2Fhelper/or
    */
-  or: Ember71Only<OrHelper>;
+  or: OrHelper;
 }
 
 /**
@@ -576,6 +580,12 @@ interface KeywordAliasesForEmber {
   unique_id: UniqueIdHelper;
 }
 
-interface Keywords extends KeywordsForEmber, KeywordsForEmber71, KeywordAliasesForEmber {}
+interface Keywords extends KeywordsForEmber, KeywordAliasesForEmber {}
 
-export const Globals: Keywords & Globals;
+// When `HasEmber71BuiltIns` is `true`, the 7.1 keyword members are included on
+// `Globals`; otherwise the conditional collapses to `{}` and the keys are
+// absent so TypeScript surfaces "unknown identifier" diagnostics / auto-import
+// quick-fixes for `{{and}}`, `{{eq}}`, etc.
+type KeywordsForEmber71 = HasEmber71BuiltIns extends true ? KeywordsForEmber71Members : {};
+
+export const Globals: Keywords & KeywordsForEmber71 & Globals;

--- a/test-packages/ts-template-imports-app/src/globals/the-7-1-globals-are-not-present.gts
+++ b/test-packages/ts-template-imports-app/src/globals/the-7-1-globals-are-not-present.gts
@@ -1,22 +1,39 @@
-import { expectTypeOf, to } from '@glint/type-test';
-
 <template>
-  {{! these must not exist prior to 7.1 }}
-  {{expectTypeOf on to.beNever}}
-  {{expectTypeOf fn to.beNever}}
-  {{expectTypeOf array to.beNever}}
-  {{expectTypeOf hash to.beNever}}
+  {{! These names must not be present on `Globals` prior to ember-source 7.1.
+      Each `@glint-expect-error` below asserts TypeScript reports
+      "Cannot find name 'X'", which is the diagnostic that carries the
+      auto-import quick-fix (`ember-truth-helpers` / `@ember/helper`) in
+      consumer projects on < 7.1. See packages/ember-tsc/types/-private/dsl/globals.d.ts. }}
 
-  {{expectTypeOf and to.beNever}}
-  {{expectTypeOf or to.beNever}}
-  {{expectTypeOf not to.beNever}}
+  {{! @glint-expect-error -- `on` is not a global on ember-source < 7.1 }}
+  {{on}}
+  {{! @glint-expect-error -- `fn` is not a global on ember-source < 7.1 }}
+  {{fn}}
+  {{! @glint-expect-error -- `array` is not a global on ember-source < 7.1 }}
+  {{array}}
+  {{! @glint-expect-error -- `hash` is not a global on ember-source < 7.1 }}
+  {{hash}}
 
-  {{expectTypeOf eq to.beNever}}
-  {{expectTypeOf neq to.beNever}}
-  {{expectTypeOf gt to.beNever}}
-  {{expectTypeOf lt to.beNever}}
-  {{expectTypeOf gte to.beNever}}
-  {{expectTypeOf lte to.beNever}}
+  {{! @glint-expect-error -- `and` is not a global on ember-source < 7.1 }}
+  {{and}}
+  {{! @glint-expect-error -- `or` is not a global on ember-source < 7.1 }}
+  {{or}}
+  {{! @glint-expect-error -- `not` is not a global on ember-source < 7.1 }}
+  {{not}}
 
-  {{expectTypeOf element to.beNever}}
+  {{! @glint-expect-error -- `eq` is not a global on ember-source < 7.1 }}
+  {{eq}}
+  {{! @glint-expect-error -- `neq` is not a global on ember-source < 7.1 }}
+  {{neq}}
+  {{! @glint-expect-error -- `gt` is not a global on ember-source < 7.1 }}
+  {{gt}}
+  {{! @glint-expect-error -- `lt` is not a global on ember-source < 7.1 }}
+  {{lt}}
+  {{! @glint-expect-error -- `gte` is not a global on ember-source < 7.1 }}
+  {{gte}}
+  {{! @glint-expect-error -- `lte` is not a global on ember-source < 7.1 }}
+  {{lte}}
+
+  {{! @glint-expect-error -- `element` is not a global on ember-source < 7.1 }}
+  {{element}}
 </template>


### PR DESCRIPTION
Fixes #1138.

## Background

PR #1125 introduced `KeywordsForEmber71` to expose the ember-source 7.1 built-in
keyword set (`and`, `or`, `eq`, `fn`, `hash`, `not`, `gt`/`gte`/`lt`/`lte`/`neq`,
`on`, `element`, `array` — RFCs 389, 470, 560, 561, 562, 997, 998, 999, 1000) on
the template `Globals` interface, gated by a `HasEmber71BuiltIns` probe against
`@ember/helper`'s value exports. To keep behaviour identical on ember-source
< 7.1, each keyword type was wrapped in `Ember71Only<T>` so it resolved to
`never`. The keyword names were *also* added unconditionally to the runtime
`globals` array in the `ember-template-imports` environment config (so the
transform would emit `__glintDSL__.Globals.and` rather than a bare `and`).

That combination shadows user-imported helpers on ember-source < 7.1:

- The property keys remain present on `Globals`, so TypeScript reports no
  missing-property diagnostic for `{{and}}` / `{{eq}}` / etc.
- Because the diagnostic is absent and the names are in the strict-mode
  `globals` set, the transform emits `__glintDSL__.Globals.and` instead of a
  bare `and`. Even if a diagnostic *did* fire, it would be a property-access
  error on `Globals`, which TypeScript does not offer auto-import quick-fixes
  for.
- Completion in templates suggests the `never`-typed builtin instead of the
  user's scope-imported `and` from `ember-truth-helpers`, and hover shows
  `never`.

## Fix

Two-layer fix so consumers on ember-source < 7.1 get both a "Cannot find name"
diagnostic *and* the auto-import quick-fix that points at `ember-truth-helpers`
/ `@ember/helper`:

1. **Type layer (`packages/ember-tsc/types/-private/dsl/globals.d.ts`)** —
   rename `KeywordsForEmber71` to `KeywordsForEmber71Members`, unwrap each
   field (no more `Ember71Only<T>`), and gate the whole member set at the
   `Globals` intersection:

   ```ts
   type KeywordsForEmber71 = HasEmber71BuiltIns extends true
     ? KeywordsForEmber71Members
     : {};

   export const Globals: Keywords & KeywordsForEmber71 & Globals;
   ```

   On ember-source >= 7.1 behaviour is unchanged (the JSDoc and the dotted
   emit from #1125 keep working). On < 7.1 the keys are absent from `Globals`
   entirely, so TypeScript surfaces a property-access diagnostic.

2. **Runtime layer
   (`packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts`)**
   — add a `hasEmber71BuiltIns()` probe that does
   `createRequire(import.meta.url)('ember-source/package.json')` and parses
   `major.minor`. On < 7.1 the 7.1 names are omitted from the strict-mode
   `globals` set, so the transform emits a bare `and` instead of
   `__glintDSL__.Globals.and`. TypeScript then reports the standard
   `Cannot find name 'and'` diagnostic, which carries an auto-import
   quick-fix.

   Any probe failure (package missing, malformed JSON, unparseable version)
   collapses to `false` so the safe default is to assume pre-7.1 and let
   users import explicitly.

## Behaviour matrix

| ember-source       | `{{eq}}` with no import | Auto-import quick-fix |
| ------------------ | ----------------------- | --------------------- |
| < 7.1 (before fix) | no diagnostic, shadows user import | not offered           |
| < 7.1 (after fix)  | `Cannot find name 'eq'` | `ember-truth-helpers` / `@ember/helper` |
| >= 7.1 (before/after) | resolved as builtin     | n/a                   |

## Verification

- Built `@glint/ember-tsc` cleanly.
- `pnpm --filter @glint/type-test run test:typecheck` passes.
- Patched the build into a downstream consumer project on ember-source 6.x via
  pnpm `patchedDependencies` and confirmed:
  - `{{and …}}` / `{{or …}}` / `{{eq …}}` in `.gts` templates surface
    `Cannot find name 'and'` etc.
  - VS Code "Quick Fix" lightbulb offers `Add import { and } from
    'ember-truth-helpers'`.
  - User-scoped imports flow through completion and hover correctly.
- On ember-source >= 7.1 the original `#1125` behaviour (dotted emit and full
  keyword set on `Globals`) is preserved by the conditional-type intersection
  and the runtime probe returning `true`.
