### PR TITLE
fix(vscode): make TS-extension patches resilient to VSCode 1.110+ minification

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -567,27 +567,40 @@ if (!v1ExtensionPresent) {
       if (args[0] === extensionJsPath) {
         let text = readFileSync(...args) as string;
 
+        const concatLanguageIds = `.concat(${languageIds.map((lang) => `'${lang}'`).join(',')})`;
+
         // patch jsTsLanguageModes - this makes VSCode recognize our custom language IDs
-        // as valid TypeScript-like languages for features like refactoring
+        // as valid TypeScript-like languages for features like refactoring.
+        //
+        // VSCode 1.110 minified this differently: the array is no longer assigned to a
+        // `jsTsLanguageModes` property but to a local var preceded by the `"javascriptreact"`
+        // literal, e.g. `"javascriptreact",kh=[Ya,Va,Cl,Rs]`. Match either form (the
+        // identifiers are minified and change between releases) and append `.concat(...)`
+        // to the language-mode array. (See vuejs/language-tools for the same approach.)
         text = text.replace(
-          't.jsTsLanguageModes=[t.javascript,t.javascriptreact,t.typescript,t.typescriptreact]',
-          (s) => s + `.concat(${languageIds.map((lang) => `'${lang}'`).join(',')})`,
+          /t\.jsTsLanguageModes=\[t\.javascript,t\.javascriptreact,t\.typescript,t\.typescriptreact\]|"javascriptreact",[\w$]+=\[[\w$]+,[\w$]+,[\w$]+,[\w$]+\]/,
+          (s) => s + concatLanguageIds,
         );
 
         // patch isSupportedLanguageMode - this enables features like "Find All References"
-        // and "Go to Definition" to work across .gts/.gjs files
+        // and "Go to Definition" to work across .gts/.gjs files. Pre-1.110 the args were
+        // `t.typescript,...`; 1.110+ uses minified identifiers, e.g. `[Cl,Rs,Ya,Va]`.
         text = text.replace(
-          '.languages.match([t.typescript,t.typescriptreact,t.javascript,t.javascriptreact]',
-          (s) => s + `.concat(${languageIds.map((lang) => `'${lang}'`).join(',')})`,
+          /\.languages\.match\(\[(?:t\.typescript,t\.typescriptreact,t\.javascript,t\.javascriptreact|[\w$]+,[\w$]+,[\w$]+,[\w$]+)\]/,
+          (s) => s + concatLanguageIds,
         );
 
-        // Sort plugins to prioritize glint plugin (for compatibility with other TS plugins)
+        // Sort plugins to prioritize glint plugin (for compatibility with other TS plugins).
+        // Both pre-1.110 (`"--globalPlugins",i.plugins`) and 1.110+
+        // (`"--globalPlugins",o.plugins.map(m=>m.name).join(",")`) start with
+        // `"--globalPlugins",<ident>.plugins`; inserting `.slice().sort(...)` there works
+        // for both — the array is sorted before it is either passed through or mapped.
         const glintPluginName = '@glint/tsserver-plugin-pack';
         text = text.replace(
-          '"--globalPlugins",i.plugins',
+          /"--globalPlugins",[\w$]+\.plugins/,
           (s) =>
             s +
-            `.sort((a,b)=>(b.name==="${glintPluginName}"?-1:0)-(a.name==="${glintPluginName}"?-1:0))`,
+            `.slice().sort((a,b)=>(b.name==="${glintPluginName}"?-1:0)-(a.name==="${glintPluginName}"?-1:0))`,
         );
 
         return text;


### PR DESCRIPTION
VSCode 1.110 changed how its bundled `typescript-language-features` extension is minified, which broke the way this extension makes `.gts`/`.gjs` files visible to tsserver.

The extension patches that bundled extension at load time (the `readFileSync` hook in `packages/vscode/src/extension.ts`) by string-replacing three minified snippets:

```js
't.jsTsLanguageModes=[t.javascript,t.javascriptreact,t.typescript,t.typescriptreact]'
'.languages.match([t.typescript,t.typescriptreact,t.javascript,t.javascriptreact]'
'"--globalPlugins",i.plugins'
```

None of those strings exist since 1.110. In 1.122 the same spots look like this:

```js
a="javascriptreact",kh=[Ya,Va,Cl,Rs]
.languages.match([Cl,Rs,Ya,Va]
"--globalPlugins",o.plugins.map(m=>m.name).join(",")
```

`String.replace` finds nothing and returns the text unchanged, so the patches silently do nothing. tsserver never receives `.gts`/`.gjs` files, `@glint/tsserver-plugin` bails before registering its `_glint:projectInfo` handler, and the editor falls back to a syntax-only service with no diagnostics, hover, or go-to-definition. The output channel shows:

```
typescript.configurePlugin not available; falling back to tsserver request.
No tsserver project info for .../foo.gts; falling back to simple LS.
Using simple language service without a tsconfig/jsconfig.
```

The symptom is easy to misattribute, because selecting the workspace TypeScript version works around it: the plugin then loads through its `languages` contribution rather than the language-mode patch.

This change matches both the old and new shapes. The 1.110+ identifiers are minified and vary between releases, so they're matched by structure rather than by name:

- jsTsLanguageModes: `t.jsTsLanguageModes=[…]`, or `"javascriptreact",<id>=[<id>,<id>,<id>,<id>]`
- languages.match: the `t.typescript,…` args, or four bare identifiers
- global-plugins sort: both shapes start with `"--globalPlugins",<id>.plugins`, so `.slice().sort(...)` is appended there. The `.slice()` avoids mutating the shared array and works whether it's passed straight through (old) or run through `.map(...).join(...)` (new), since the sort happens first.

vuejs/language-tools handles this same 1.110 change the same way (their patch carries a `// before 1.110:` note), so this brings the Glint extension in line with that.

Testing: the regexes were checked mechanically against a real VSCode 1.122 `extension.js` and against hand-written pre-1.110 strings; both match, and the appended code is valid in each case. They have not been run end-to-end in an extension host.

`typescript.configurePlugin` was also renamed/made internal around the same time, but the existing `tsserverRequest` fallback in this file covers that. Adopting Vue's manifest-injection approach would remove the dependency entirely, but that's a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
