### PR TITLE
Fix pre-binding named args on components whose Args is a union

### DIFF
--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -9,7 +9,6 @@ import {
   TemplateContext,
   Invokable,
   NamedArgs,
-  UnwrapNamedArgs,
 } from '../integration';
 import {
   AttributesForElement,
@@ -17,7 +16,7 @@ import {
   MathMlElementForTagName,
   SVGElementForTagName,
 } from './types';
-import { MaybeNamed, PrebindArgs } from '../signature';
+import { MaybeNamed, PrebindArgs, UnionKeysOf } from '../signature';
 
 /**
  * Used during emit to denote an object literal that corresponds
@@ -189,18 +188,14 @@ type BindNamedResult<Args, T, GivenNamed> =
   // Named-only args (required or optional — handles double-currying)
   Args extends [NamedArgs<infer Named>?]
     ? (
-        ...named: MaybeNamed<
-          PrebindArgs<NonNullable<Named>, keyof GivenNamed & keyof UnwrapNamedArgs<Named>>
-        >
+        ...named: MaybeNamed<PrebindArgs<NonNullable<Named>, keyof GivenNamed & UnionKeysOf<Named>>>
       ) => T
     : // Positional + named args
       Args extends [...infer Positional, NamedArgs<infer Named>]
       ? (
           ...args: [
             ...Positional,
-            ...MaybeNamed<
-              PrebindArgs<NonNullable<Named>, keyof GivenNamed & keyof UnwrapNamedArgs<Named>>
-            >,
+            ...MaybeNamed<PrebindArgs<NonNullable<Named>, keyof GivenNamed & UnionKeysOf<Named>>>,
           ]
         ) => T
       : (...args: Args extends unknown[] ? Args : never) => T;

--- a/packages/template/-private/integration.d.ts
+++ b/packages/template/-private/integration.d.ts
@@ -74,10 +74,14 @@ export interface NamedArgsMarker {
   [NamedArgs]: true;
 }
 
+// Distributes so that a union type yields the keys of every constituent;
+// plain `keyof` over a union only sees keys common to all constituents.
+type KeysOfConstituents<T> = T extends unknown ? keyof T : never;
+
 export type NamedArgNames<T extends Invokable<AnyFunction>> =
   T extends Invokable<(...args: infer A) => any>
     ? A extends [...positional: infer _, named?: infer N]
-      ? Exclude<keyof NonNullable<N>, typeof NamedArgs>
+      ? Exclude<KeysOfConstituents<NonNullable<N>>, typeof NamedArgs>
       : never
     : never;
 

--- a/packages/template/-private/keywords/-bind-invokable.d.ts
+++ b/packages/template/-private/keywords/-bind-invokable.d.ts
@@ -1,5 +1,5 @@
-import { DirectInvokable, Invokable, NamedArgs, UnwrapNamedArgs } from '../integration';
-import { MaybeNamed, PrebindArgs, SliceFrom, SliceTo } from '../signature';
+import { DirectInvokable, Invokable, NamedArgs } from '../integration';
+import { MaybeNamed, PrebindArgs, SliceFrom, SliceTo, UnionKeysOf } from '../signature';
 
 type PrefixOf<T extends unknown[]> = T extends [arg: infer Arg, ...rest: infer Rest]
   ? [] | [Arg, ...PrefixOf<Rest>]
@@ -19,9 +19,7 @@ export type BindInvokableKeyword<Prefix extends number, Kind> = DirectInvokable<
     named: NamedArgs<Partial<Named> & GivenNamed>,
   ): Invokable<
     (
-      ...named: MaybeNamed<
-        PrebindArgs<NonNullable<Named>, keyof GivenNamed & keyof UnwrapNamedArgs<Named>>
-      >
+      ...named: MaybeNamed<PrebindArgs<NonNullable<Named>, keyof GivenNamed & UnionKeysOf<Named>>>
     ) => Return
   >;
   <Named, Return extends Kind, GivenNamed>(
@@ -29,9 +27,7 @@ export type BindInvokableKeyword<Prefix extends number, Kind> = DirectInvokable<
     named: NamedArgs<Partial<Named> & GivenNamed>,
   ): null | Invokable<
     (
-      ...named: MaybeNamed<
-        PrebindArgs<NonNullable<Named>, keyof GivenNamed & keyof UnwrapNamedArgs<Named>>
-      >
+      ...named: MaybeNamed<PrebindArgs<NonNullable<Named>, keyof GivenNamed & UnionKeysOf<Named>>>
     ) => Return
   >;
   // {{bind invokableWithNamedAndPositionalArgs name="foo"}}
@@ -42,9 +38,7 @@ export type BindInvokableKeyword<Prefix extends number, Kind> = DirectInvokable<
     (
       ...args: [
         ...Positional,
-        ...MaybeNamed<
-          PrebindArgs<NonNullable<Named>, keyof GivenNamed & keyof UnwrapNamedArgs<Named>>
-        >,
+        ...MaybeNamed<PrebindArgs<NonNullable<Named>, keyof GivenNamed & UnionKeysOf<Named>>>,
       ]
     ) => Return
   >;
@@ -55,9 +49,7 @@ export type BindInvokableKeyword<Prefix extends number, Kind> = DirectInvokable<
     (
       ...args: [
         ...Positional,
-        ...MaybeNamed<
-          PrebindArgs<NonNullable<Named>, keyof GivenNamed & keyof UnwrapNamedArgs<Named>>
-        >,
+        ...MaybeNamed<PrebindArgs<NonNullable<Named>, keyof GivenNamed & UnionKeysOf<Named>>>,
       ]
     ) => Return
   >;

--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -60,13 +60,23 @@ export type PrebindArgs<T, Args extends keyof UnwrapNamedArgs<T>> = NamedArgs<
   Omit<UnwrapNamedArgs<T>, Args> & Partial<Pick<UnwrapNamedArgs<T>, Args>>
 >;
 
-export type MaybeNamed<T> = T extends any
-  ? {} extends UnwrapNamedArgs<T>
-    ? keyof UnwrapNamedArgs<T> extends never
+// Keys across all constituents of a (possibly union) named-args type. Plain
+// `keyof UnwrapNamedArgs<T>` would only see keys common to every constituent.
+type UnionKeysOf<T> = T extends any ? keyof UnwrapNamedArgs<T> : never;
+
+// Note: this must produce a single parameter tuple rather than distributing a
+// union `T` into a union of tuples. A union of tuples breaks contravariant
+// assignability against the `(named: NamedArgs<Named>)` patterns used by
+// `{{component}}`/`{{helper}}`/`{{modifier}}` to pre-bind named args (#1144).
+// The checks below are still union-aware: `{} extends A | B` holds when any
+// constituent accepts an empty hash, and `UnionKeysOf` collects keys from all
+// constituents.
+export type MaybeNamed<T> =
+  {} extends UnwrapNamedArgs<T>
+    ? [UnionKeysOf<T>] extends [never]
       ? []
       : [named?: T]
-    : [named: T]
-  : never;
+    : [named: T];
 
 export type Get<T, K, Otherwise = unknown> = K extends keyof T ? T[K] : Otherwise;
 export type Constrain<T, Constraint, Otherwise = Constraint> = T extends Constraint ? T : Otherwise;

--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -56,13 +56,20 @@ export type ComponentSignatureElement<S> = S extends { Element: infer Element }
     : Element
   : unknown;
 
-export type PrebindArgs<T, Args extends keyof UnwrapNamedArgs<T>> = NamedArgs<
-  Omit<UnwrapNamedArgs<T>, Args> & Partial<Pick<UnwrapNamedArgs<T>, Args>>
+// This distributes over union `T` so that each constituent only has the bound
+// keys it actually declares omitted/made-optional. A non-distributive
+// `Omit<A | B, ...>` would collapse the union to its common keys, losing the
+// per-constituent shape (#1144).
+export type PrebindArgs<T, Args extends UnionKeysOf<T>> = NamedArgs<
+  T extends any
+    ? Omit<UnwrapNamedArgs<T>, Args & keyof UnwrapNamedArgs<T>> &
+        Partial<Pick<UnwrapNamedArgs<T>, Args & keyof UnwrapNamedArgs<T>>>
+    : never
 >;
 
 // Keys across all constituents of a (possibly union) named-args type. Plain
 // `keyof UnwrapNamedArgs<T>` would only see keys common to every constituent.
-type UnionKeysOf<T> = T extends any ? keyof UnwrapNamedArgs<T> : never;
+export type UnionKeysOf<T> = T extends any ? keyof UnwrapNamedArgs<T> : never;
 
 // Note: this must produce a single parameter tuple rather than distributing a
 // union `T` into a union of tuples. A union of tuples breaks contravariant

--- a/packages/template/__tests__/keywords/component.test.ts
+++ b/packages/template/__tests__/keywords/component.test.ts
@@ -124,6 +124,12 @@ class UnionArgsComponent extends TestComponent<{
     // @ts-expect-error: attempting to curry an arg with the wrong type
     { value: 'not a date', ...NamedArgsMarker },
   );
+
+  componentKeyword(
+    resolveForBind(UnionArgsComponent),
+    // @ts-expect-error: attempting to curry args from both union constituents
+    { value: someDate, range: [someDate, someDate] as [Date, Date], ...NamedArgsMarker },
+  );
 }
 
 // A union without `?: never` on the "other" keys — `keyof`/`Omit` over such a

--- a/packages/template/__tests__/keywords/component.test.ts
+++ b/packages/template/__tests__/keywords/component.test.ts
@@ -126,6 +126,63 @@ class UnionArgsComponent extends TestComponent<{
   );
 }
 
+// A union without `?: never` on the "other" keys — `keyof`/`Omit` over such a
+// union only see common keys (here: none), so a non-distributive `PrebindArgs`
+// collapsed the curried component's args to `{}`.
+class LooseUnionArgsComponent extends TestComponent<{
+  Args: { value?: Date } | { range?: [Date, Date] };
+}> {}
+
+{
+  const someDate = new Date();
+
+  const ValueCurriedLooseUnionComponent = componentKeyword(
+    resolveForBind(LooseUnionArgsComponent),
+    { value: someDate, ...NamedArgsMarker },
+  );
+
+  emitComponent(resolve(ValueCurriedLooseUnionComponent)({ ...NamedArgsMarker }));
+  emitComponent(resolve(ValueCurriedLooseUnionComponent)());
+  emitComponent(resolve(ValueCurriedLooseUnionComponent)({ value: someDate, ...NamedArgsMarker }));
+}
+
+// A union of constituents intersected with args common to both
+class IntersectedUnionArgsComponent extends TestComponent<{
+  Args: (
+    | { value?: Date; onChange?: (date: Date) => void }
+    | { range?: [Date, Date]; onRangeChange?: (range: [Date, Date]) => void }
+  ) & { otherArgument: boolean };
+}> {}
+
+{
+  const someDate = new Date();
+  const onChange = (_date: Date): void => {};
+
+  // Currying args from one constituent along with a common arg
+  const FullyCurriedIntersectedComponent = componentKeyword(
+    resolveForBind(IntersectedUnionArgsComponent),
+    { otherArgument: true, value: someDate, onChange, ...NamedArgsMarker },
+  );
+
+  emitComponent(resolve(FullyCurriedIntersectedComponent)({ ...NamedArgsMarker }));
+  emitComponent(resolve(FullyCurriedIntersectedComponent)());
+
+  // Currying only a constituent-specific arg leaves the common arg required
+  const ValueCurriedIntersectedComponent = componentKeyword(
+    resolveForBind(IntersectedUnionArgsComponent),
+    { value: someDate, ...NamedArgsMarker },
+  );
+
+  emitComponent(
+    resolve(ValueCurriedIntersectedComponent)({ otherArgument: false, ...NamedArgsMarker }),
+  );
+
+  resolve(ValueCurriedIntersectedComponent)(
+    // @ts-expect-error: missing required arg `otherArgument`
+    { ...NamedArgsMarker },
+  );
+}
+
 class ParametricComponent<T> extends TestComponent<{
   Args: { values: Array<T>; optional?: string };
   Blocks: { default?: [T, number] };

--- a/packages/template/__tests__/keywords/component.test.ts
+++ b/packages/template/__tests__/keywords/component.test.ts
@@ -84,6 +84,48 @@ componentKeyword(
   { value: 123, ...NamedArgsMarker },
 );
 
+// Issue #1144: pre-binding a named arg on a component whose `Args` type is a
+// union of all-optional constituents
+class UnionArgsComponent extends TestComponent<{
+  Args: { value?: Date; range?: never } | { value?: never; range?: [Date, Date] };
+}> {}
+
+{
+  const someDate = new Date();
+
+  const NoopCurriedUnionArgsComponent = componentKeyword(resolveForBind(UnionArgsComponent));
+
+  // Invoking the noop-curried component with either side of the union, or neither
+  emitComponent(resolve(NoopCurriedUnionArgsComponent)({ value: someDate, ...NamedArgsMarker }));
+  emitComponent(
+    resolve(NoopCurriedUnionArgsComponent)({ range: [someDate, someDate], ...NamedArgsMarker }),
+  );
+  emitComponent(resolve(NoopCurriedUnionArgsComponent)());
+
+  // Currying an arg from one constituent of the union
+  const ValueCurriedUnionArgsComponent = componentKeyword(resolveForBind(UnionArgsComponent), {
+    value: someDate,
+    ...NamedArgsMarker,
+  });
+
+  emitComponent(resolve(ValueCurriedUnionArgsComponent)({ ...NamedArgsMarker }));
+  emitComponent(resolve(ValueCurriedUnionArgsComponent)());
+
+  // Currying an arg from the other constituent
+  const RangeCurriedUnionArgsComponent = componentKeyword(resolveForBind(UnionArgsComponent), {
+    range: [someDate, someDate] as [Date, Date],
+    ...NamedArgsMarker,
+  });
+
+  emitComponent(resolve(RangeCurriedUnionArgsComponent)({ ...NamedArgsMarker }));
+
+  componentKeyword(
+    resolveForBind(UnionArgsComponent),
+    // @ts-expect-error: attempting to curry an arg with the wrong type
+    { value: 'not a date', ...NamedArgsMarker },
+  );
+}
+
 class ParametricComponent<T> extends TestComponent<{
   Args: { values: Array<T>; optional?: string };
   Blocks: { default?: [T, number] };

--- a/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -331,12 +331,12 @@ describe('Language Server: Diagnostic Augmentation', () => {
               "message": "The last overload is declared here.",
               "span": {
                 "end": {
-                  "line": 94,
+                  "line": 86,
                   "offset": 5,
                 },
                 "file": "\${repoRootPath}/packages/template/-private/keywords/-bind-invokable.d.ts",
                 "start": {
-                  "line": 80,
+                  "line": 72,
                   "offset": 3,
                 },
               },
@@ -367,12 +367,12 @@ describe('Language Server: Diagnostic Augmentation', () => {
               "message": "The last overload is declared here.",
               "span": {
                 "end": {
-                  "line": 94,
+                  "line": 86,
                   "offset": 5,
                 },
                 "file": "\${repoRootPath}/packages/template/-private/keywords/-bind-invokable.d.ts",
                 "start": {
-                  "line": 80,
+                  "line": 72,
                   "offset": 3,
                 },
               },
@@ -403,12 +403,12 @@ describe('Language Server: Diagnostic Augmentation', () => {
               "message": "The last overload is declared here.",
               "span": {
                 "end": {
-                  "line": 94,
+                  "line": 86,
                   "offset": 5,
                 },
                 "file": "\${repoRootPath}/packages/template/-private/keywords/-bind-invokable.d.ts",
                 "start": {
-                  "line": 80,
+                  "line": 72,
                   "offset": 3,
                 },
               },

--- a/test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts
@@ -170,6 +170,11 @@ const OptionalArgCurriedTest = <template>
     {{#let (component UnionArgsComponent value="not a date") as |C|}}
       <C />
     {{/let}}
+
+    {{! @glint-expect-error: attempting to curry args from both union constituents }}
+    {{#let (component UnionArgsComponent value=someDate range=someRange) as |C|}}
+      <C />
+    {{/let}}
   </template>;
 }
 

--- a/test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts
@@ -3,7 +3,7 @@ import { expectTypeOf, to } from '@glint/type-test';
 import { array } from '@ember/helper';
 import { hash } from '@ember/helper';
 import type { WithBoundArgs, ModifierLike } from '@glint/template';
-import type { TOC } from '@ember/component/template-only';
+import type { TOC, TemplateOnlyComponent } from '@ember/component/template-only';
 
 declare const formModifier: ModifierLike<{ Element: HTMLFormElement }>;
 
@@ -171,6 +171,70 @@ const OptionalArgCurriedTest = <template>
       <C />
     {{/let}}
   </template>;
+}
+
+// Issue #1144 (cont.): a union without `?: never` on the "other" keys. `keyof`
+// and `Omit` over such a union only see common keys (here: none), so the
+// curried component's remaining args used to collapse to `{}`.
+{
+  const LooseUnionComponent: TOC<{
+    Args: { value?: Date } | { range?: [Date, Date] };
+  }> = <template></template>;
+
+  const someDate = new Date();
+
+  const LooseUnionPrebindTest = <template>
+    {{#let (component LooseUnionComponent value=someDate) as |C|}}
+      <C />
+      <C @value={{someDate}} />
+    {{/let}}
+  </template>;
+}
+
+// Issue #1144 (cont.): a union of constituents intersected with common args,
+// yielded out as a WithBoundArgs-typed block param.
+{
+  const IntersectedUnionComponent: TOC<{
+    Args: (
+      | { value?: Date; onChange?: (date: Date) => void }
+      | { range?: [Date, Date]; onRangeChange?: (range: [Date, Date]) => void }
+    ) & {
+      otherArgument: boolean;
+    };
+  }> = <template></template>;
+
+  const someDate = new Date();
+
+  function onChange(date: Date): void {}
+
+  const IntersectedUnionPrebindTest = <template>
+    {{#let
+      (component IntersectedUnionComponent otherArgument=true value=someDate onChange=onChange)
+      as |C|
+    }}
+      <C />
+      {{yield (hash SomeComponent=C)}}
+    {{/let}}
+
+    {{! currying only a constituent-specific arg leaves the common arg required }}
+    {{#let (component IntersectedUnionComponent value=someDate) as |C|}}
+      <C @otherArgument={{false}} />
+
+      {{! @glint-expect-error: missing required arg `otherArgument` }}
+      <C />
+    {{/let}}
+  </template> satisfies TemplateOnlyComponent<{
+    Blocks: {
+      default: [
+        {
+          SomeComponent: WithBoundArgs<
+            typeof IntersectedUnionComponent,
+            'value' | 'onChange' | 'otherArgument'
+          >;
+        },
+      ];
+    };
+  }>;
 }
 
 // Issue #661: WithBoundArgs with ModifierLike arg — verified fixed.

--- a/test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts
@@ -3,6 +3,7 @@ import { expectTypeOf, to } from '@glint/type-test';
 import { array } from '@ember/helper';
 import { hash } from '@ember/helper';
 import type { WithBoundArgs, ModifierLike } from '@glint/template';
+import type { TOC } from '@ember/component/template-only';
 
 declare const formModifier: ModifierLike<{ Element: HTMLFormElement }>;
 
@@ -135,6 +136,42 @@ const OptionalArgCurriedTest = <template>
     </OptionalCurried>
   {{/let}}
 </template>;
+
+// Issue #1144: pre-binding an arg on a component whose `Args` is a union of
+// all-optional constituents picked the wrong union member and reported TS2769.
+{
+  const UnionArgsComponent: TOC<{
+    Args: { value?: Date; range?: never } | { value?: never; range?: [Date, Date] };
+  }> = <template></template>;
+
+  const someDate = new Date();
+  const someRange = [someDate, someDate] as [Date, Date];
+
+  const UnionArgsPrebindTest = <template>
+    {{#let (component UnionArgsComponent) as |C|}}
+      <C @value={{someDate}} />
+      <C @range={{someRange}} />
+      <C />
+
+      {{! @glint-expect-error: can't mix args from both union constituents }}
+      <C @value={{someDate}} @range={{someRange}} />
+    {{/let}}
+
+    {{#let (component UnionArgsComponent value=someDate) as |C|}}
+      <C />
+      <C @value={{someDate}} />
+    {{/let}}
+
+    {{#let (component UnionArgsComponent range=someRange) as |C|}}
+      <C />
+    {{/let}}
+
+    {{! @glint-expect-error: attempting to curry an arg with the wrong type }}
+    {{#let (component UnionArgsComponent value="not a date") as |C|}}
+      <C />
+    {{/let}}
+  </template>;
+}
 
 // Issue #661: WithBoundArgs with ModifierLike arg — verified fixed.
 // Currying named args including ModifierLike no longer causes TS2589.


### PR DESCRIPTION
Fixes #1144

## The bug

Pre-binding a named arg with the `(component)` helper failed with TS2769 when the component's `Args` is a union of all-optional constituents:

```ts
const MyComponent: TOC<{
  Args:
    | { value?: Date; range?: never }
    | { value?: never; range?: [Date, Date] };
}> = <template></template>;
```

```hbs
{{#let (component MyComponent value=someDate) as |C|}} {{! Type 'Date' is not assignable to type 'undefined' }}
```

## Root cause

`MaybeNamed<T>` (in `@glint/template`'s `signature.d.ts`) distributes a union `T` into a **union of parameter tuples**, so the component's invoke signature ends up as:

```ts
(...args: [named?: NamedArgs<A>] | [named?: NamedArgs<B>]) => ...
```

The named-args overloads of `BindInvokableKeyword` pattern-match the invokable as `(named: NamedArgs<Named>) => Return`. Checking that pattern against the invokable requires the single tuple `[named: NamedArgs<Named>]` to be contravariantly assignable to the union of tuples — which requires `NamedArgs<Named>` to fit *one* constituent entirely. No inference for `Named` can satisfy that (inferring the whole union fails both branches; inferring one constituent isn't what TS does here), so the named-args overloads can never match a union-args invokable. TypeScript then falls through to the last (positional) overload, producing the confusing `Type 'Date' is not assignable to type 'undefined'` against the `range?: never` constituent.

## The fix

The distribution was introduced in 59ded243 ("Ensure `MaybeNamed` distributes over unions correctly") because the naive non-distributive version got two things wrong for unions:

- `keyof UnwrapNamedArgs<A | B>` only sees keys **common** to every constituent (so disjoint-key unions collapsed to "no named args allowed"), and
- optionality needed to be per-constituent.

This PR keeps `MaybeNamed` producing a **single** parameter tuple (so contravariant matching in the bind keywords works) while staying union-aware:

- `{} extends UnwrapNamedArgs<T>` already holds when *any* constituent accepts an empty hash (assignability to a union), which is the correct condition for the named hash being omittable, and
- a new `UnionKeysOf<T>` helper distributes only the `keyof` so the "no named args at all" → `[]` branch considers keys across **all** constituents.

Since `BindInvokableKeyword` backs `{{component}}`, `{{helper}}`, and `{{modifier}}` alike, the fix covers all three.

## Tests

- `packages/template/__tests__/keywords/component.test.ts`: unit-level coverage for noop-currying, currying either constituent's arg, invoking with overrides, and a wrong-type curry still erroring.
- `test-packages/package-test-core/__tests__/type-tests/intrinsics/component.test.gts`: end-to-end `.gts` repro matching the issue, including `@glint-expect-error` assertions that mixing args from both constituents and currying a wrong-typed arg still fail.

Without the `signature.d.ts` change, both new test files fail with exactly the reported error (`TS2769 ... Type 'Date' is not assignable to type 'undefined'`); with it, the full monorepo suite passes. (The `ts-extensionless-app` watch test times out for me locally on a clean `main` checkout as well — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)