### PR TITLE
 Fix `tsc -b` / `ember-tsc --build` crash on `.gts` declaration emit ("Extension .gts is unsupported")

### DIFF
--- a/packages/ember-tsc/src/cli/run-volar-tsc.ts
+++ b/packages/ember-tsc/src/cli/run-volar-tsc.ts
@@ -13,7 +13,7 @@ const require = createRequire(import.meta.url);
 const fs = require('node:fs') as typeof import('node:fs');
 
 export function run(): void {
-  patchVolarProxyForExtensionlessImports();
+  patchCompilerSourcesForGts();
   patchVolarDecorateProgramForContentTagErrors();
 
   let cwd = process.cwd();
@@ -59,17 +59,28 @@ export function run(): void {
 // Upstream fix: https://github.com/volarjs/volar.js/pull/309 — once that ships
 // in a `@volar/typescript` release we depend on, this monkey-patch can go.
 // Tracking: https://github.com/typed-ember/glint/issues/806
-function patchVolarProxyForExtensionlessImports(): void {
+function patchCompilerSourcesForGts(): void {
   const originalReadFileSync = fs.readFileSync;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (fs as any).readFileSync = function (...args: unknown[]) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = (originalReadFileSync as any).apply(fs, args);
     const filePath = args[0];
-    if (typeof filePath === 'string' && filePath.endsWith('/proxyCreateProgram.js')) {
+    if (typeof filePath !== 'string') {
+      return result;
+    }
+    if (filePath.endsWith('/proxyCreateProgram.js')) {
       const text = typeof result === 'string' ? result : (result as Buffer).toString('utf8');
       const patched = applyProxyPatches(text);
       return typeof result === 'string' ? patched : Buffer.from(patched);
+    }
+    // The compiled tsc source (read here on its way to volar's runTsc).
+    if (/\/typescript\/lib\/[^/]+\.js$/.test(filePath)) {
+      const text = typeof result === 'string' ? result : (result as Buffer).toString('utf8');
+      if (text.includes('function tryGetJSExtensionForFile(')) {
+        const patched = patchTscJsExtensionForGts(text);
+        return typeof result === 'string' ? patched : Buffer.from(patched);
+      }
     }
     return result;
   };
@@ -92,6 +103,36 @@ function applyProxyPatches(source: string): string {
   }
 
   return source.replace(literalsPattern, `$1${guard}$2`).replace(namesPattern, `$1${guard}$2`);
+}
+
+// TypeScript's `tryGetJSExtensionForFile` maps a source file extension to the
+// JS extension it emits (`.ts` -> `.js`, `.tsx` -> `.jsx`/`.js`, ...). It has no
+// case for `.gts`/`.gjs`, even though we register them as supported TS
+// extensions (so `hasTSFileExtension` is true for them). In build mode
+// (`tsc -b`), declaration emit computes module specifiers for imported symbols;
+// when the preferred ending is "js" (e.g. a sibling `./x.js` import is preserved
+// in the emitted `.d.ts`) and the target is a `.gts`/`.gjs` file, tsc calls
+// `getJSExtensionForFile`, which `Debug.fail`s with
+// "Extension .gts is unsupported" and aborts the entire build. `.gts`/`.gjs`
+// compile to `.js` (like `.ts`), so teach the function that mapping by
+// short-circuiting at the top of the function. The proper home for this is
+// volar's `transformTscContent` (which already patches `changeExtension` and the
+// supported-extension lists); this monkey-patch can go once that lands upstream.
+function patchTscJsExtensionForGts(source: string): string {
+  const pattern = /function tryGetJSExtensionForFile\(([A-Za-z0-9_$]+),[^)]*\)\s*\{/;
+  const match = pattern.exec(source);
+  if (!match) {
+    throw new Error(
+      '[glint] failed to patch typescript `tryGetJSExtensionForFile`: ' +
+        'function signature not found in expected shape. ' +
+        'The typescript dep may have changed; update patchTscJsExtensionForGts() in run-volar-tsc.ts.',
+    );
+  }
+  const fileNameParam = match[1];
+  return source.replace(
+    pattern,
+    (m) => `${m}\n    if (/\\.g[jt]s$/.test(${fileNameParam})) return ".js";`,
+  );
 }
 
 // Volar's `runTsc` does not surface the content-tag parse errors that we attach

--- a/test-packages/ts-extensionless-app/.gitignore
+++ b/test-packages/ts-extensionless-app/.gitignore
@@ -1,1 +1,2 @@
 tsconfig.tsbuildinfo
+build-mode-declarations/

--- a/test-packages/ts-extensionless-app/__tests__/build-mode.test.ts
+++ b/test-packages/ts-extensionless-app/__tests__/build-mode.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { execa } from 'execa';
+import stripAnsi from 'strip-ansi';
+import { resolve } from 'node:path';
+import { readFileSync, rmSync } from 'node:fs';
+
+const PROJECT_ROOT = resolve(__dirname, '..');
+
+// Regression for build mode (`ember-tsc --build` / `tsc -b`) over a composite
+// project that emits declarations for `.gts`.
+//
+// `.gts` is registered as a supported TS extension (so `hasTSFileExtension` is
+// true), but TypeScript's JS-output-extension computation (`tryGetJSExtensionForFile`)
+// didn't know about it. When declaration emit synthesizes a module specifier to
+// a `.gts` file with a "js" ending preference, it calls `getJSExtensionForFile`,
+// which hit `Debug.fail("Extension .gts is unsupported")` and aborted the build.
+//
+// The `build-mode-fixture/` project is shaped to deterministically trigger that:
+//   - `outer.gts` keeps a `./util.js` (.js-extension) import in its emitted .d.ts
+//     → forces the module-specifier ending preference to JsExtension, and
+//   - its return type `Helper` comes transitively from `helper.gts` (not directly
+//     imported) → declaration emit must *synthesize* a specifier to `./helper.gts`.
+describe('ember-tsc --build: declaration emit for .gts in a composite project', () => {
+  test('computes .gts module specifiers without crashing', async () => {
+    // Force a fresh build so declaration emit (and specifier computation) runs.
+    rmSync(resolve(PROJECT_ROOT, 'build-mode-declarations'), { recursive: true, force: true });
+    rmSync(resolve(PROJECT_ROOT, 'tsconfig.build-mode.tsbuildinfo'), { force: true });
+
+    const result = await execa('pnpm', ['ember-tsc', '--build', 'tsconfig.build-mode.json'], {
+      cwd: PROJECT_ROOT,
+      reject: false,
+      all: true,
+    });
+    const output = stripAnsi(result.all ?? '');
+
+    expect(output, output).not.toMatch(/Extension \.gts is unsupported/);
+    expect(output, output).not.toMatch(/Debug Failure/);
+    expect(result.exitCode, output).toBe(0);
+
+    // And the emitted declaration must reference the .gts target with a `.js`
+    // ending (the same mapping tsc uses for `.ts` -> `.js`), not crash or drop it.
+    const outerDts = readFileSync(
+      resolve(PROJECT_ROOT, 'build-mode-declarations/outer.d.ts'),
+      'utf8',
+    );
+    expect(outerDts).toMatch(/import\(["']\.\/helper\.js["']\)\.Helper/);
+  });
+});

--- a/test-packages/ts-extensionless-app/build-mode-fixture/helper.gts
+++ b/test-packages/ts-extensionless-app/build-mode-fixture/helper.gts
@@ -1,0 +1,3 @@
+export class Helper {
+  x = 1;
+}

--- a/test-packages/ts-extensionless-app/build-mode-fixture/inner.gts
+++ b/test-packages/ts-extensionless-app/build-mode-fixture/inner.gts
@@ -1,0 +1,4 @@
+import { Helper } from './helper';
+export function make(): Helper {
+  return new Helper();
+}

--- a/test-packages/ts-extensionless-app/build-mode-fixture/outer.gts
+++ b/test-packages/ts-extensionless-app/build-mode-fixture/outer.gts
@@ -1,0 +1,5 @@
+import type { Util } from './util.js';
+import { make } from './inner';
+export function f(_u: Util) {
+  return make();
+}

--- a/test-packages/ts-extensionless-app/build-mode-fixture/util.ts
+++ b/test-packages/ts-extensionless-app/build-mode-fixture/util.ts
@@ -1,0 +1,3 @@
+export class Util {
+  v = 1;
+}

--- a/test-packages/ts-extensionless-app/tsconfig.build-mode.json
+++ b/test-packages/ts-extensionless-app/tsconfig.build-mode.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "build-mode-declarations",
+    "rootDir": "build-mode-fixture"
+  },
+  "include": ["build-mode-fixture"]
+}


### PR DESCRIPTION
`ember-tsc --build` errors during declaration emit with:

> Error: Debug Failure. Extension .gts is unsupported:: FileName:: app/components/usage.gts

Turns out `.gts`/`.gjs` are registered as supported TS extensions (so `hasTSFileExtension` is happy), but TS's internal
`tryGetJSExtensionForFile` never learned about them. When declaration emit synthesizes a module specifier with a `"js"`
ending preference pointing at a `.gts` file, it falls through to `getJSExtensionForFile` and `Debug.fail`s, killing the
whole build.

`--noEmit` checking doesn't compute those specifiers, so this only shows up in `--build`.

Fix is to teach `tryGetJSExtensionForFile` that `.gts`/`.gjs` emit `.js` (same as `.ts` -> `.js`), patched in through the
same compiled-tsc-source interception we already use in `run-volar-tsc.ts` for the `proxyCreateProgram` stuff.

> [!NOTE]
> This really belongs in volar's `transformTscContent` (it already patches `changeExtension` + the supported-extension
lists). Once it lands there this monkey-patch can go. The patcher throws a loud error if the tsc source shape changes so a
TS bump won't silently break it.

Test lives in `test-packages/ts-extensionless-app` — a composite `emitDeclarationOnly` config + a fixture shaped to actually
hit the path (one `./util.js` import kept in the `.d.ts` to force the `.js` ending, plus a return type that comes
transitively from another `.gts` so a specifier has to be synthesized). Fails without the fix, green with it.