### PR TITLE
Fix `{{hash}}` keyword to narrow named-arg values like the `@ember/helper` import

### DIFF
--- a/packages/ember-tsc/types/-private/intrinsics/array-hash.d.ts
+++ b/packages/ember-tsc/types/-private/intrinsics/array-hash.d.ts
@@ -13,5 +13,5 @@ export type ArrayHelper = DirectInvokable<{
  * Built-in keyword in ember-source >= 7.1 (RFC 999).
  */
 export type HashHelper = DirectInvokable<{
-  <T extends Record<string, unknown>>(args: T): T;
+  <const T extends Record<string, unknown>>(args: T): T;
 }>;

--- a/test-packages/ts-gts-7-1-app/src/globals/hash-keyword-vs-import.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/hash-keyword-vs-import.test.gts
@@ -1,0 +1,18 @@
+import { hash as emberHash } from '@ember/helper';
+import type { TOC } from '@ember/component/template-only';
+
+// The built-in 7.1 {{hash}} keyword infers a different type than the
+// `@ember/helper` import it replaces: contextual typing from the target narrows
+// `__typename` to the 'TimePeriod' literal through the import, but not through
+// the keyword (it stays `string`), so the keyword fails this literal-typed union
+// the import satisfies. (Stripping the NamedArgs brand does not change it.)
+type TimePeriod = { __typename: 'TimePeriod' };
+type IdTimePeriod = { __typename: 'IDTimePeriod'; id: string };
+
+const Period: TOC<{ Args: { period?: TimePeriod | IdTimePeriod } }> = <template></template>;
+
+<template>
+  <Period @period={{emberHash __typename="TimePeriod"}} />
+  {{! @glint-expect-error keyword should match the import; remove once fixed }}
+  <Period @period={{hash __typename="TimePeriod"}} />
+</template>

--- a/test-packages/ts-gts-7-1-app/src/globals/hash-keyword-vs-import.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/hash-keyword-vs-import.test.gts
@@ -1,11 +1,10 @@
 import { hash as emberHash } from '@ember/helper';
 import type { TOC } from '@ember/component/template-only';
 
-// The built-in 7.1 {{hash}} keyword infers a different type than the
-// `@ember/helper` import it replaces: contextual typing from the target narrows
-// `__typename` to the 'TimePeriod' literal through the import, but not through
-// the keyword (it stays `string`), so the keyword fails this literal-typed union
-// the import satisfies. (Stripping the NamedArgs brand does not change it.)
+// Regression guard: the built-in {{hash}} keyword must narrow its named-arg
+// values against the assignment target the same way the `@ember/helper` import
+// does — so a string-literal arg (`__typename`) matches this literal-typed union
+// instead of staying widened to `string`. Both invocations below must compile.
 type TimePeriod = { __typename: 'TimePeriod' };
 type IdTimePeriod = { __typename: 'IDTimePeriod'; id: string };
 
@@ -13,6 +12,5 @@ const Period: TOC<{ Args: { period?: TimePeriod | IdTimePeriod } }> = <template>
 
 <template>
   <Period @period={{emberHash __typename="TimePeriod"}} />
-  {{! @glint-expect-error keyword should match the import; remove once fixed }}
   <Period @period={{hash __typename="TimePeriod"}} />
 </template>


### PR DESCRIPTION
The built-in 7.1 `{{hash}}` keyword infers a different type than the `@ember/helper` import it replaces, so migrating import → keyword silently changes types.

### Commit a0b31289f98923ed012a32a229612690efef318d Failing test
`@period={{hash __typename="TimePeriod"}}` against a literal-typed union: the import narrows `__typename` to `'TimePeriod'` via contextual typing and compiles; the keyword leaves it `string` and fails. Documented with `@glint-expect-error`.

### Commit bb5bf5ea0e2ee0c744cc8c12e01a87d4f911e757 Fix
Add `const` to `HashHelper`'s type parameter so literal args are preserved, matching the import; removes the now-unused `@glint-expect-error`.