### PR TITLE
Make `{{array}}` keyword preserve literal element types

### DIFF
--- a/packages/ember-tsc/types/-private/intrinsics/array-hash.d.ts
+++ b/packages/ember-tsc/types/-private/intrinsics/array-hash.d.ts
@@ -5,7 +5,7 @@ import { DirectInvokable } from '@glint/template/-private/integration';
  * Built-in keyword in ember-source >= 7.1 (RFC 1000).
  */
 export type ArrayHelper = DirectInvokable<{
-  <T extends unknown[]>(...args: T): T;
+  <const T extends unknown[]>(...args: T): T;
 }>;
 
 /**

--- a/test-packages/ts-gts-7-1-app/src/globals/array-keyword-preserve-literals.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/array-keyword-preserve-literals.test.gts
@@ -1,0 +1,29 @@
+import type { TOC } from '@ember/component/template-only';
+
+// The built-in {{array}} keyword widens literal elements (e.g. "case" -> string)
+// wherever contextual typing is unavailable — a {{#let}} binding, or {{array}}
+// nested inside another helper whose result is bound by {{#let}}. That widening
+// stops it from satisfying a literal-first tuple target, e.g. a maplibre-gl
+// expression spec like ["case", ...] | ["interpolate", ...].
+type Expr = ['case', ...unknown[]] | ['interpolate', ...unknown[]];
+const Layer: TOC<{ Args: { op: Expr } }> = <template></template>;
+
+// Generic pass-through helper, used to exercise the nested-in-a-helper call shape.
+const identity = <T,>(value: T): T => value;
+
+<template>
+  {{! ---- {{array}} bound directly via {{#let}} ---- }}
+  {{#let (array "case" 1 2) as |op|}}
+    {{! "case" widens to `string`, so this fails the literal-operator union.
+        Remove the @glint-expect-error once {{array}} preserves literals. }}
+    {{! @glint-expect-error }}
+    <Layer @op={{op}} />
+  {{/let}}
+
+  {{! ---- {{array}} nested inside another helper, result bound via {{#let}} ---- }}
+  {{#let (identity (array "case" 1 2)) as |op|}}
+    {{! same widening, reached through the nested helper }}
+    {{! @glint-expect-error }}
+    <Layer @op={{op}} />
+  {{/let}}
+</template>

--- a/test-packages/ts-gts-7-1-app/src/globals/array-keyword-preserve-literals.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/array-keyword-preserve-literals.test.gts
@@ -1,10 +1,13 @@
 import type { TOC } from '@ember/component/template-only';
 
-// The built-in {{array}} keyword widens literal elements (e.g. "case" -> string)
-// wherever contextual typing is unavailable — a {{#let}} binding, or {{array}}
-// nested inside another helper whose result is bound by {{#let}}. That widening
-// stops it from satisfying a literal-first tuple target, e.g. a maplibre-gl
-// expression spec like ["case", ...] | ["interpolate", ...].
+// Regression guard: the built-in {{array}} keyword must preserve literal elements
+// (e.g. "case") so it satisfies a literal-first tuple target such as a maplibre-gl
+// expression spec (["case", ...] | ["interpolate", ...]). The `const` on ArrayHelper
+// is what preserves them whenever no literal-first contextual target is in scope —
+// i.e. wherever the array's type is finalized at a {{#let}} binding rather than
+// directly at the argument position. Both cases below fail (literal widening) if the
+// `const` is removed; a plain `<Layer @op={{helper (array ...)}} />` would NOT, since
+// the `Expr` target flows back through the helper into the array.
 type Expr = ['case', ...unknown[]] | ['interpolate', ...unknown[]];
 const Layer: TOC<{ Args: { op: Expr } }> = <template></template>;
 
@@ -14,16 +17,11 @@ const identity = <T,>(value: T): T => value;
 <template>
   {{! ---- {{array}} bound directly via {{#let}} ---- }}
   {{#let (array "case" 1 2) as |op|}}
-    {{! "case" widens to `string`, so this fails the literal-operator union.
-        Remove the @glint-expect-error once {{array}} preserves literals. }}
-    {{! @glint-expect-error }}
     <Layer @op={{op}} />
   {{/let}}
 
   {{! ---- {{array}} nested inside another helper, result bound via {{#let}} ---- }}
   {{#let (identity (array "case" 1 2)) as |op|}}
-    {{! same widening, reached through the nested helper }}
-    {{! @glint-expect-error }}
     <Layer @op={{op}} />
   {{/let}}
 </template>


### PR DESCRIPTION
Sibling to the `{{hash}}` fix in #1158.

The 7.1 `{{array}}` keyword widens literal element types where contextual typing is unavailable (e.g. a `{{#let}}` binding), so it can't satisfy a literal-first tuple target like a maplibre-gl expression spec.

### Commit 1ba83baf failing test
`{{#let (array "case" …) as |op|}}` (and the same nested inside a helper) against `['case', …] | ['interpolate', …]`, documented with `@glint-expect-error`.

### Commit 34d101a0 fix
add `const` to `ArrayHelper`. Result stays a mutable tuple (`const` only narrows elements). 
