### PR TITLE
Guard against torn-down workspace in shared tsserver bridge

### DIFF
--- a/test-packages/test-utils/src/shared-test-workspace.ts
+++ b/test-packages/test-utils/src/shared-test-workspace.ts
@@ -94,7 +94,12 @@ export async function getSharedTestWorkspaceHelper(): Promise<{
         command: command,
         arguments: args,
       });
-      serverHandle!.connection.sendNotification('tsserver/response', [id, res.body]);
+      // The shared workspace may have been torn down (`serverHandle` reset to
+      // `undefined`) while this async tsserver round-trip was in flight. Guard
+      // against dereferencing it so a late response doesn't reject unhandled.
+      if (serverHandle) {
+        serverHandle.connection.sendNotification('tsserver/response', [id, res.body]);
+      }
     });
 
     await serverHandle.initialize(


### PR DESCRIPTION
## Problem

Seen in [this run](https://github.com/typed-ember/glint/actions/runs/28087813202/job/83158012176?pr=1159) — all `209 passed | 10 skipped`, but the job exited non-zero solely because of this rejection (the `imports.test.ts` attribution is incidental; the log notes "it doesn't mean the error was thrown inside the file itself").

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
TypeError: Cannot read properties of undefined (reading 'connection')
 ❯ ../test-utils/src/shared-test-workspace.ts:97:21
This error originated in "__tests__/language-server/imports.test.ts" test file.
```



## Fix

Guard the late send with `if (serverHandle)` so a response arriving after teardown is dropped instead of throwing. Test-harness only; no production code affected.