### PR TITLE
Report missing-argument errors on helper/component invocations (#1168)

### DIFF
--- a/packages/ember-tsc/src/transform/template/glimmer-ast-mapping-tree.ts
+++ b/packages/ember-tsc/src/transform/template/glimmer-ast-mapping-tree.ts
@@ -58,6 +58,14 @@ export default class GlimmerASTMappingTree {
     public children: Array<GlimmerASTMappingTree> = [],
     public sourceNode: MappingSource,
     public codeInformation?: CodeInformation,
+    /**
+     * When set, `toVolarMappings` emits an additional verification-only mapping
+     * covering this node's entire generated span (even when it differs in length
+     * from the source span). This lets diagnostics that TS anchors on synthetic
+     * generated boilerplate — e.g. the `__glintDSL__.resolve(foo)` callee, where
+     * a missing-positional-arg error lands — map back to the template (#1168).
+     */
+    public wideVerification: boolean = false,
   ) {
     children.forEach((child) => (child.parent = this));
   }

--- a/packages/ember-tsc/src/transform/template/map-template-contents.ts
+++ b/packages/ember-tsc/src/transform/template/map-template-contents.ts
@@ -93,8 +93,18 @@ export type Mapper = {
   /**
    * Map all content emitted in the given callback to the span
    * corresponding to the given AST node in the original source.
+   *
+   * When `wideVerification` is set, an extra verification-only mapping covering
+   * the callback's entire generated span is emitted so that diagnostics anchored
+   * on synthetic generated boilerplate within it still map back to the node
+   * (see `GlimmerASTMappingTree#wideVerification`).
    */
-  forNode(node: AST.Node, callback: () => void, codeFeaturesForNode?: CodeInformation): void;
+  forNode(
+    node: AST.Node,
+    callback: () => void,
+    codeFeaturesForNode?: CodeInformation,
+    wideVerification?: boolean,
+  ): void;
   forNodeWithSpan(
     node: AST.Node,
     span: AST.Node['loc'],
@@ -193,6 +203,7 @@ export function mapTemplateContents(
     allowEmpty: boolean,
     callback: () => void,
     codeFeaturesForNode?: CodeInformation,
+    wideVerification = false,
   ): void => {
     let start = offset;
     let mappings: GlimmerASTMappingTree[] = [];
@@ -229,6 +240,7 @@ export function mapTemplateContents(
           // point in the future but by default tends to make the highlighting in gts files look wrong.
           codeFeaturesForNode ??
             augmentCodeFeaturesWithIgnoreDirectivesSupport(codeFeatures.withoutHighlight, hbsRange),
+          wideVerification,
         ),
       );
       segmentsStack[0].push(...segments);
@@ -327,8 +339,20 @@ export function mapTemplateContents(
       let source = new Identifier(value);
       captureMapping(hbsRange, source, true, () => mapper.text(value));
     },
-    forNode(node: AST.Node, callback: () => void, codeFeaturesForNode?: CodeInformation) {
-      captureMapping(mapper.rangeForNode(node), node, false, callback, codeFeaturesForNode);
+    forNode(
+      node: AST.Node,
+      callback: () => void,
+      codeFeaturesForNode?: CodeInformation,
+      wideVerification?: boolean,
+    ) {
+      captureMapping(
+        mapper.rangeForNode(node),
+        node,
+        false,
+        callback,
+        codeFeaturesForNode,
+        wideVerification,
+      );
     },
 
     forNodeWithSpan(

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -1061,10 +1061,12 @@ export function templateToTypescript(
         } else if (position === 'top-level') {
           // e.g. top-level mustache `{{someValue}}`
           mapper.text('__glintDSL__.emitContent(');
-          emitResolve(node, hasParams ? 'resolve' : 'resolveOrReturn');
+          // Direct mustache invocations opt into wide verification so a missing
+          // required argument is reported (#1168); see `emitResolve`.
+          emitResolve(node, hasParams ? 'resolve' : 'resolveOrReturn', true);
           mapper.text(')');
         } else {
-          emitResolve(node, hasParams ? 'resolve' : 'resolveOrReturn');
+          emitResolve(node, hasParams ? 'resolve' : 'resolveOrReturn', true);
         }
       });
     }
@@ -1328,17 +1330,45 @@ export function templateToTypescript(
       | AST.BlockStatement
       | AST.ElementModifierStatement;
 
-    function emitResolve(node: CurlyInvocationNode, resolveType: string): void {
+    function emitResolve(
+      node: CurlyInvocationNode,
+      resolveType: string,
+      wideVerification = false,
+    ): void {
       // We use forNode here to wrap the emitted resolve expression here so that when
       // we convert to Volar mappings, we can create a boundary around
       // e.g. "__glintDSL__.resolveOrReturn(expectsAtLeastOneArg)()", which is required because
       // this is where TS might generate a diagnostic error.
       mapper.forNode(node, () => {
-        mapper.text('__glintDSL__.');
-        mapper.text(resolveType);
-        mapper.text('(');
-        emitExpression(node.path);
-        mapper.text(')(');
+        if (wideVerification) {
+          // Wrap just the synthetic callee `__glintDSL__.resolve(<path>)` and
+          // map its whole generated span back to the path. TS anchors an
+          // "Expected N arguments, but got M" diagnostic (raised when a required
+          // positional arg is missing) on this callee rather than on the args;
+          // without a covering mapping Volar drops it and the missing-arg goes
+          // unreported (#1168). Mapping to the tight `path` node (rather than the
+          // whole invocation) keeps `@glint-expect-error` suppression scoped
+          // correctly.
+          mapper.forNode(
+            node.path,
+            () => {
+              mapper.text('__glintDSL__.');
+              mapper.text(resolveType);
+              mapper.text('(');
+              emitExpression(node.path);
+              mapper.text(')');
+            },
+            undefined,
+            true,
+          );
+          mapper.text('(');
+        } else {
+          mapper.text('__glintDSL__.');
+          mapper.text(resolveType);
+          mapper.text('(');
+          emitExpression(node.path);
+          mapper.text(')(');
+        }
         emitArgs(node.params, node.hash);
         mapper.text(')');
       });

--- a/packages/ember-tsc/src/transform/template/transformed-module.ts
+++ b/packages/ember-tsc/src/transform/template/transformed-module.ts
@@ -307,6 +307,28 @@ export default class TransformedModule {
       });
     };
 
+    // Push a mapping that covers a generated span whose length differs from the
+    // source span it maps back to (via Volar's `generatedLengths`). This lets a
+    // diagnostic anchored anywhere within the generated span translate back to
+    // the source region even though the two aren't the same length. We restrict
+    // it to `verification` so that navigation/completion/hover features (which
+    // are served by the narrower, length-aligned mappings) are unaffected.
+    const pushWide = (
+      sourceOffset: number,
+      sourceLength: number,
+      generatedOffset: number,
+      generatedLength: number,
+      codeInformation: CodeInformation | undefined,
+    ): void => {
+      codeMappings.push({
+        sourceOffsets: [sourceOffset],
+        generatedOffsets: [generatedOffset],
+        lengths: [sourceLength],
+        generatedLengths: [generatedLength],
+        data: { verification: codeInformation?.verification ?? true },
+      });
+    };
+
     let recurse = (span: CorrelatedSpan, mapping: GlimmerASTMappingTree): void => {
       const children = mapping.children;
       let { originalRange, transformedRange } = mapping;
@@ -359,6 +381,26 @@ export default class TransformedModule {
         // Disregard the "null zone" mappings, i.e. cases where TS code maps to empty HBS code
         if (isNonNullMapping) {
           push(hbsEnd, tsEnd, 0, mapping.codeInformation);
+
+          // The boundary mappings above only mark the start/end of this node's
+          // generated output; the synthetic boilerplate in between (e.g. the
+          // `__glintDSL__.resolve(foo)` callee emitted for `{{foo ...}}`) has no
+          // covering mapping. Some TS diagnostics anchor on exactly that span —
+          // notably "Expected N arguments, but got M" for a missing positional
+          // arg, which points at the callee rather than the args. Without a
+          // covering verification mapping, Volar can't translate such a
+          // diagnostic back to the template and silently drops it (#1168).
+          //
+          // Only nodes explicitly flagged for this opt in (see `forNode`'s
+          // `wideVerification` option): a blanket wide mapping on every parent
+          // would re-expose diagnostics suppressed by a narrower
+          // `@glint-expect-error`, since an ancestor spanning multiple directive
+          // regions carries its own (unsuppressed) verification. We push it
+          // *after* the children so the narrower leaf mappings still win for
+          // diagnostics that fall squarely within them.
+          if (mapping.wideVerification) {
+            pushWide(hbsStart, hbsLength, tsStart, tsLength, mapping.codeInformation);
+          }
         }
       } else {
         if (hbsLength === tsLength) {

--- a/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -72,6 +72,37 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "category": "error",
           "code": 2554,
           "end": {
+            "line": 20,
+            "offset": 21,
+          },
+          "relatedInformation": [
+            {
+              "category": "message",
+              "code": 6210,
+              "message": "An argument for 'b' was not provided.",
+              "span": {
+                "end": {
+                  "line": 10,
+                  "offset": 45,
+                },
+                "file": "\${repoRootPath}/test-packages/ts-template-imports-app/src/empty-fixture.gts",
+                "start": {
+                  "line": 10,
+                  "offset": 36,
+                },
+              },
+            },
+          ],
+          "start": {
+            "line": 20,
+            "offset": 7,
+          },
+          "text": "Expected 2 arguments, but got 1.",
+        },
+        {
+          "category": "error",
+          "code": 2554,
+          "end": {
             "line": 21,
             "offset": 37,
           },
@@ -93,6 +124,37 @@ describe('Language Server: Diagnostic Augmentation', () => {
             "offset": 30,
           },
           "text": "Expected 2 arguments, but got 3. Note that named args are passed together as a final argument, so they collectively increase the given arg count by 1.",
+        },
+        {
+          "category": "error",
+          "code": 2555,
+          "end": {
+            "line": 23,
+            "offset": 27,
+          },
+          "relatedInformation": [
+            {
+              "category": "message",
+              "code": 6210,
+              "message": "An argument for 'a' was not provided.",
+              "span": {
+                "end": {
+                  "line": 14,
+                  "offset": 40,
+                },
+                "file": "\${repoRootPath}/test-packages/ts-template-imports-app/src/empty-fixture.gts",
+                "start": {
+                  "line": 14,
+                  "offset": 31,
+                },
+              },
+            },
+          ],
+          "start": {
+            "line": 23,
+            "offset": 7,
+          },
+          "text": "Expected at least 1 arguments, but got 0.",
         },
         {
           "category": "error",

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -285,15 +285,20 @@ describe('Transform: rewriteModule', () => {
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(46:57):   this.target
-        | | | | |  ts(257:281):  __glintRef__.this.target
+        | | | | |  ts(228:282):  __glintDSL__.resolveOrReturn(__glintRef__.this.target)
         | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(46:50):   this
-        | | | | | |  ts(270:274):  this
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(46:57):   this.target
+        | | | | | |  ts(257:281):  __glintRef__.this.target
         | | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(51:57):   target
-        | | | | | |  ts(275:281):  target
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(46:50):   this
+        | | | | | | |  ts(270:274):  this
+        | | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(51:57):   target
+        | | | | | | |  ts(275:281):  target
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | |
@@ -347,11 +352,16 @@ describe('Transform: rewriteModule', () => {
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(22:29):   @target
-        | | | | |  ts(230:254):  __glintRef__.args.target
+        | | | | |  ts(201:255):  __glintDSL__.resolveOrReturn(__glintRef__.args.target)
         | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(23:29):   target
-        | | | | | |  ts(248:254):  target
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(22:29):   @target
+        | | | | | |  ts(230:254):  __glintRef__.args.target
+        | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(23:29):   target
+        | | | | | | |  ts(248:254):  target
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | |
@@ -405,11 +415,16 @@ describe('Transform: rewriteModule', () => {
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(68:76):   @message
-        | | | | |  ts(271:296):  __glintRef__.args.message
+        | | | | |  ts(242:297):  __glintDSL__.resolveOrReturn(__glintRef__.args.message)
         | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(69:76):   message
-        | | | | | |  ts(289:296):  message
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(68:76):   @message
+        | | | | | |  ts(271:296):  __glintRef__.args.message
+        | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(69:76):   message
+        | | | | | | |  ts(289:296):  message
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | |
@@ -439,15 +454,20 @@ describe('Transform: rewriteModule', () => {
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(151:161): this.title
-        | | | | |  ts(617:640):  __glintRef__.this.title
+        | | | | |  ts(588:641):  __glintDSL__.resolveOrReturn(__glintRef__.this.title)
         | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(151:155): this
-        | | | | | |  ts(630:634):  this
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(151:161): this.title
+        | | | | | |  ts(617:640):  __glintRef__.this.title
         | | | | | |
-        | | | | | | Mapping: Identifier
-        | | | | | |  hbs(156:161): title
-        | | | | | |  ts(635:640):  title
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(151:155): this
+        | | | | | | |  ts(630:634):  this
+        | | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(156:161): title
+        | | | | | | |  ts(635:640):  title
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | |
@@ -581,11 +601,16 @@ describe('Transform: rewriteModule', () => {
         | | | | |
         | | | | | | Mapping: PathExpression
         | | | | | |  hbs(164:167): arr
-        | | | | | |  ts(517:520):  arr
+        | | | | | |  ts(488:521):  __glintDSL__.resolveOrReturn(arr)
         | | | | | |
-        | | | | | | | Mapping: Identifier
+        | | | | | | | Mapping: PathExpression
         | | | | | | |  hbs(164:167): arr
         | | | | | | |  ts(517:520):  arr
+        | | | | | | |
+        | | | | | | | | Mapping: Identifier
+        | | | | | | | |  hbs(164:167): arr
+        | | | | | | | |  ts(517:520):  arr
+        | | | | | | | |
         | | | | | | |
         | | | | | |
         | | | | |
@@ -604,11 +629,16 @@ describe('Transform: rewriteModule', () => {
         | | | | |
         | | | | | | Mapping: PathExpression
         | | | | | |  hbs(184:185): h
-        | | | | | |  ts(580:581):  h
+        | | | | | |  ts(551:582):  __glintDSL__.resolveOrReturn(h)
         | | | | | |
-        | | | | | | | Mapping: Identifier
+        | | | | | | | Mapping: PathExpression
         | | | | | | |  hbs(184:185): h
         | | | | | | |  ts(580:581):  h
+        | | | | | | |
+        | | | | | | | | Mapping: Identifier
+        | | | | | | | |  hbs(184:185): h
+        | | | | | | | |  ts(580:581):  h
+        | | | | | | | |
         | | | | | | |
         | | | | | |
         | | | | |

--- a/test-packages/package-test-core/__tests__/type-tests/intrinsics/helper-invocation-args.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/intrinsics/helper-invocation-args.test.gts
@@ -1,0 +1,56 @@
+import Helper, { helper } from '@ember/component/helper';
+
+// Regression test for https://github.com/typed-ember/glint/issues/1168.
+//
+// A plain (non-curried) helper invocation must type-check its arguments. In
+// particular, a missing required positional argument surfaces TypeScript's
+// "Expected N arguments, but got M" diagnostic. That diagnostic anchors on the
+// synthetic `resolve(...)` callee rather than on the args, and its mapping was
+// previously dropped — so these invocations type-checked clean when they should
+// have errored. The issue reproduced across all three ways of authoring a
+// helper, so each is covered below.
+
+// 1. Class-based helper
+class ClassHelper extends Helper<{
+  Args: {
+    Positional: [count: number];
+    Named: { str: string };
+  };
+  Return: number;
+}> {}
+
+// 2. Functional helper
+const functionalHelper = helper(
+  (_positional: [count: number], _named: { str: string }): number => 1,
+);
+
+// 3. Plain function helper
+const plainFunctionHelper = (_count: number, _named: { str: string }): number => 1;
+
+<template>
+  {{! Valid invocations type-check cleanly. }}
+  {{ClassHelper 1 str="ok"}}
+  {{functionalHelper 1 str="ok"}}
+  {{plainFunctionHelper 1 str="ok"}}
+
+  {{! @glint-expect-error: missing required positional arg }}
+  {{ClassHelper str="ok"}}
+  {{! @glint-expect-error: missing required positional arg }}
+  {{functionalHelper str="ok"}}
+  {{! @glint-expect-error: missing required positional arg }}
+  {{plainFunctionHelper str="ok"}}
+
+  {{! @glint-expect-error: positional arg is the wrong type }}
+  {{ClassHelper "nope" str="ok"}}
+  {{! @glint-expect-error: positional arg is the wrong type }}
+  {{functionalHelper "nope" str="ok"}}
+  {{! @glint-expect-error: positional arg is the wrong type }}
+  {{plainFunctionHelper "nope" str="ok"}}
+
+  {{! @glint-expect-error: named arg is the wrong type }}
+  {{ClassHelper 1 str=123}}
+  {{! @glint-expect-error: named arg is the wrong type }}
+  {{functionalHelper 1 str=123}}
+  {{! @glint-expect-error: named arg is the wrong type }}
+  {{plainFunctionHelper 1 str=123}}
+</template>;

--- a/test-packages/package-test-core/__tests__/type-tests/intrinsics/helper-invocation-optional-args.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/intrinsics/helper-invocation-optional-args.test.gts
@@ -1,0 +1,69 @@
+import Helper from '@ember/component/helper';
+
+// Companion to helper-invocation-args.test.gts (#1168): exercises OPTIONAL
+// args. Omitting an optional arg must be allowed, while wrong types and missing
+// *required* args are still reported now that the "Expected N arguments"
+// diagnostic maps back to the template.
+
+// Optional named arg (`str?`), alongside a required positional.
+class OptionalNamedHelper extends Helper<{
+  Args: {
+    Positional: [count: number];
+    Named: { str?: string };
+  };
+  Return: number;
+}> {}
+
+// Optional trailing positional arg (`second?`), no named args.
+class OptionalPositionalHelper extends Helper<{
+  Args: {
+    Positional: [first: string, second?: number];
+  };
+  Return: number;
+}> {}
+
+// Optional positional arg (`label?`) sitting *before* a required named-args
+// hash (`flag`).
+class OptionalPositionalThenNamedHelper extends Helper<{
+  Args: {
+    Positional: [count: number, label?: string];
+    Named: { flag: boolean };
+  };
+  Return: number;
+}> {}
+
+<template>
+  {{! An optional named arg may be omitted or provided. }}
+  {{OptionalNamedHelper 1}}
+  {{OptionalNamedHelper 1 str="ok"}}
+
+  {{! ...but it is still type-checked when provided. }}
+  {{! @glint-expect-error: optional named arg has the wrong type }}
+  {{OptionalNamedHelper 1 str=123}}
+
+  {{! The required positional is still required. }}
+  {{! @glint-expect-error: missing required positional arg }}
+  {{OptionalNamedHelper str="ok"}}
+
+  {{! An optional trailing positional arg may be omitted or provided. }}
+  {{OptionalPositionalHelper "a"}}
+  {{OptionalPositionalHelper "a" 2}}
+
+  {{! ...but it is still type-checked when provided. }}
+  {{! @glint-expect-error: optional positional arg has the wrong type }}
+  {{OptionalPositionalHelper "a" "two"}}
+
+  {{! The required positional is still required. }}
+  {{! @glint-expect-error: missing required positional arg }}
+  {{OptionalPositionalHelper}}
+
+  {{! Providing every arg works. }}
+  {{OptionalPositionalThenNamedHelper 1 "label" flag=true}}
+
+  {{! KNOWN LIMITATION: an optional positional arg that sits *before* a required
+      named-args hash cannot currently be omitted. Glint models the named args
+      as the final positional parameter, so dropping the optional positional
+      shifts the hash into its slot and the arg count no longer lines up. }}
+  {{! @glint-expect-error: optional positional cannot be skipped before named args }}
+  {{OptionalPositionalThenNamedHelper 1 flag=true}}
+</template>;


### PR DESCRIPTION
Fixes #1168.

## Problem

Glint 2 fails to report a missing required positional argument on a template invocation. Given a helper that takes one positional `number` and a named `str: string`, all three of these type-check clean when they should error:

```gts
class Foo extends Helper<{ Args: { Positional: [number]; Named: { readonly str: string } }; Return: number }> {}
const bar = helper((_positional: [number], _named: { readonly str: string }): number => 1);
const baz = (_positional: number, _named: { readonly str: string }): number => 1;

<template>
  {{Foo str=123}}
  {{bar str=123}}
  {{baz str=123}}
</template>
```

## Root cause

The error *is* present in the generated TypeScript — `resolve(Foo)({ str: 123, ...marker })` passes one argument where two are required. But TypeScript anchors the `TS2554 "Expected 2 arguments, but got 1"` diagnostic on the **callee** (`__glintDSL__.resolve(Foo)`), which is synthetic boilerplate, rather than on the args.

`toVolarMappings` only emitted **zero-length boundary** mappings around a node's synthetic output, plus full-length mappings for leaf identifiers. The arity diagnostic's span (`__glintDSL__.resolve(Foo)`) starts and ends in synthetic text that no verification mapping covers, so Volar can't translate it back to the template and silently drops it. (Type errors on *named* args still surfaced, because those map to a real `str` leaf — which is why the bug looked like "helpers don't type-check at all".)

## Fix

Introduce an opt-in `wideVerification` mapping. `forNode` can request an extra **verification-only** Volar mapping (via `generatedLengths`) that covers a node's entire generated span, so a diagnostic anchored anywhere within it — including the synthetic callee — maps back to source.

`emitResolve` flags the `resolve(<path>)` callee and maps it to the tight `path` node. Keeping it narrow (the path, not the whole invocation, which for a block could span unrelated statements) means:

- `@glint-expect-error` suppression stays correctly scoped — a blanket wide mapping on every parent would re-expose diagnostics that a narrower directive suppressed, because an ancestor spanning multiple directive regions carries its own unsuppressed verification.
- Narrower leaf mappings still win for diagnostics that fall squarely within them (the wide mapping is pushed *after* children), so precise squiggles (e.g. a wrong-typed named arg) are unchanged.

The error now reports on the helper name:

```
repro.gts(6,5): error TS2554: Expected 2 arguments, but got 1.
```

## Fixture fallout

Surfacing these previously-dropped diagnostics exposed latent issues in existing fixtures (the emitted TypeScript is byte-for-byte unchanged — only whether the error maps back changed):

- `ts-gts-7-1-app/src/globals/fn.gts` — `(fn handler greet)` bound `greet` (a `(string, string) => string`) to `handler`'s `MouseEvent` parameter; no `fn` overload matches. Reworked into a valid binding.
- `ts-gts-7-1-app/src/globals/array.gts` — `(hash)` with zero args violates `HashHelper`'s required args parameter. Changed to `(hash a=1)`.
- `package-test-core/.../helper.test.gts` — revealed that currying a **generic** positional arg via `{{helper}}` doesn't produce a correctly-typed bound helper (the bound helper is still invalid to call). Documented as a known limitation with `@glint-expect-error`; the underlying generic-currying gap is orthogonal to this change.

A regression test for plain (non-curried) helper-invocation arg checking is added to `helper.test.gts`.

## Testing

- `pnpm --filter '*' run test:typecheck` — pass
- `pnpm --filter '*' run test:tsc` — pass
- `pnpm --filter glint2-vscode test` — pass (4/4)
- `pnpm lint` — pass