### PR TITLE
Handle `''` specially in the `element` helper

### DIFF
--- a/packages/ember-tsc/types/-private/intrinsics/element.d.ts
+++ b/packages/ember-tsc/types/-private/intrinsics/element.d.ts
@@ -14,24 +14,38 @@ export type ElementHelper = DirectInvokable<{
   <const K extends keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap | (string & {})>(
     tagName: K,
   ): ComponentLike<{
-    // - A known HTML or SVG tag name narrows to the corresponding element type.
-    // When a name exists in both maps (e.g. `a`, `script`, `style`, `title`)
-    // the HTML element wins, matching the default (non-SVG) namespace at
-    // runtime.
-    // - An empty string renders the block without a wrapping element, so there
-    // is no element to receive attributes (`null`, which makes applying any
-    // attribute a type error).
-    // - An empty string OR something else, however, narrows down to that
-    // something - as the user might want to use the tag.
-    // - Any other (dynamic) tag name falls back to the base `Element`, covering
-    // both HTML and SVG.
-    Element: [K] extends ['']
+    // Resolve the tag name `K` to the element type it produces, from the
+    // most-specific case to the least. Each branch is explained below.
+    //
+    //   ┌─ K is exactly ''      → null     (no wrapping element)
+    //   ├─ K is `'tag' | ''`    → Element  (ambiguous: may or may not render)
+    //   ├─ K is a known HTML tag → HTMLElementTagNameMap[K]
+    //   ├─ K is a known SVG tag  → SVGElementTagNameMap[K]
+    //   └─ K is a dynamic string → Element  (unknown tag)
+    //
+    Element: [K] extends [''] // // `'video' | ''` falls through to Case 2. // attributes. Tuple-wrapping keeps this non-distributive, so a union like // Case 1: exactly `''` — no wrapping element renders, so it can't receive //
       ? null
-      : Exclude<K, ''> extends keyof HTMLElementTagNameMap
-        ? HTMLElementTagNameMap[Exclude<K, ''>]
-        : Exclude<K, ''> extends keyof SVGElementTagNameMap
-          ? SVGElementTagNameMap[Exclude<K, ''>]
-          : Element;
+      : //
+        // Case 2: a union containing `''` (e.g. `'video' | ''`) is ambiguous —
+        // it may or may not render — so fall back to base `Element`.
+        //
+        '' extends K
+        ? Element
+        : //
+          // Case 3: a known HTML tag. Names in both maps (e.g. `"a"`) match
+          // HTML first — the default, non-SVG namespace.
+          //
+          K extends keyof HTMLElementTagNameMap
+          ? HTMLElementTagNameMap[K]
+          : //
+            // Case 4: a known SVG tag.
+            //
+            K extends keyof SVGElementTagNameMap
+            ? SVGElementTagNameMap[K]
+            : //
+              // We could not determine what type the user wants
+              //
+              Element;
     Args: Record<string, unknown>;
     Blocks: { default: [] };
   }>;

--- a/packages/ember-tsc/types/-private/intrinsics/element.d.ts
+++ b/packages/ember-tsc/types/-private/intrinsics/element.d.ts
@@ -14,19 +14,23 @@ export type ElementHelper = DirectInvokable<{
   <const K extends keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap | (string & {})>(
     tagName: K,
   ): ComponentLike<{
-    // A known HTML or SVG tag name narrows to the corresponding element type.
+    // - A known HTML or SVG tag name narrows to the corresponding element type.
     // When a name exists in both maps (e.g. `a`, `script`, `style`, `title`)
     // the HTML element wins, matching the default (non-SVG) namespace at
-    // runtime. An empty string renders the block without a wrapping element, so
-    // there is no element to receive attributes (`null`, which makes applying
-    // any attribute a type error). Any other (dynamic) tag name falls back to
-    // the base `Element`, covering both HTML and SVG.
-    Element: K extends keyof HTMLElementTagNameMap
-      ? HTMLElementTagNameMap[K]
-      : K extends keyof SVGElementTagNameMap
-        ? SVGElementTagNameMap[K]
-        : K extends ''
-          ? null
+    // runtime.
+    // - An empty string renders the block without a wrapping element, so there
+    // is no element to receive attributes (`null`, which makes applying any
+    // attribute a type error).
+    // - An empty string OR something else, however, narrows down to that
+    // something - as the user might want to use the tag.
+    // - Any other (dynamic) tag name falls back to the base `Element`, covering
+    // both HTML and SVG.
+    Element: [K] extends ['']
+      ? null
+      : Exclude<K, ''> extends keyof HTMLElementTagNameMap
+        ? HTMLElementTagNameMap[Exclude<K, ''>]
+        : Exclude<K, ''> extends keyof SVGElementTagNameMap
+          ? SVGElementTagNameMap[Exclude<K, ''>]
           : Element;
     Args: Record<string, unknown>;
     Blocks: { default: [] };

--- a/test-packages/ts-gts-7-1-app/src/globals/element.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/element.gts
@@ -15,6 +15,8 @@ const rect = null as unknown as ElementComponent<SVGRectElement>;
 const empty = null as unknown as ElementComponent<null>;
 const anyElement = null as unknown as ElementComponent<Element>;
 
+const videoOrNot = null as unknown as 'video' | '';
+
 const dynamicTag: string = 'div';
 
 <template>
@@ -34,6 +36,9 @@ const dynamicTag: string = 'div';
 
   {{! Empty string renders no wrapping element -> `null` (no element) }}
   {{expectTypeOf (element "") to.equalTypeOf empty}}
+
+  {{! A tag or empty is typed as the tag }}
+  {{expectTypeOf (element videoOrNot) to.equalTypeOf video}}
 
   {{! A dynamic (non-literal) tag name falls back to the base `Element` }}
   {{expectTypeOf (element dynamicTag) to.equalTypeOf anyElement}}

--- a/test-packages/ts-gts-7-1-app/src/globals/element.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/element.gts
@@ -40,8 +40,8 @@ declare function narrow(loose: string): loose is 'input' | 'button';
   {{! Empty string renders no wrapping element -> `null` (no element) }}
   {{expectTypeOf (element "") to.equalTypeOf empty}}
 
-  {{! A tag or empty is typed as the tag }}
-  {{expectTypeOf (element videoOrNot) to.equalTypeOf video}}
+  {{! A tag or empty -- because element can't know which will be received }}
+  {{expectTypeOf (element videoOrNot) to.equalTypeOf anyElement}}
 
   {{! A dynamic (non-literal) tag name falls back to the base `Element` }}
   {{expectTypeOf (element dynamicTag) to.equalTypeOf anyElement}}
@@ -84,7 +84,7 @@ declare function narrow(loose: string): loose is 'input' | 'button';
       no element for attributes to apply to }}
   {{#let (element "") as |Tag|}}
     <Tag>hello</Tag>
-    {{! @glint-expect-error: a tagless element has no attributes }}
+    {{! @glint-expect-error: a tagless element has no attributes (no element rendered) }}
     <Tag id="foo" />
   {{/let}}
 </template>

--- a/test-packages/ts-gts-7-1-app/src/globals/element.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/element.gts
@@ -9,6 +9,7 @@ type ElementComponent<El> = ComponentLike<{
 }>;
 
 const video = null as unknown as ElementComponent<HTMLVideoElement>;
+const inputOrButton = null as unknown as ElementComponent<HTMLInputElement | HTMLButtonElement>;
 const anchor = null as unknown as ElementComponent<HTMLAnchorElement>;
 const svg = null as unknown as ElementComponent<SVGSVGElement>;
 const rect = null as unknown as ElementComponent<SVGRectElement>;
@@ -18,6 +19,8 @@ const anyElement = null as unknown as ElementComponent<Element>;
 const videoOrNot = null as unknown as 'video' | '';
 
 const dynamicTag: string = 'div';
+
+declare function narrow(loose: string): loose is 'input' | 'button';
 
 <template>
   {{! ---- (RFC 389) element ---- }}
@@ -46,6 +49,10 @@ const dynamicTag: string = 'div';
   {{! A known tag is not assignable to the wrong element type }}
   {{! @glint-expect-error: a video is not an anchor }}
   {{expectTypeOf (element "video") to.equalTypeOf anchor}}
+
+  {{#if (narrow dynamicTag)}}
+    {{expectTypeOf (element dynamicTag) to.equalTypeOf inputOrButton}}
+  {{/if}}
 
   {{! ---- Narrowing flows through to attribute checking ---- }}
 

--- a/test-packages/ts-gts-7-1-app/src/globals/narrowing.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/narrowing.test.gts
@@ -171,4 +171,4 @@ const barLit = 'bar' as const;
   {{else}}
     {{expectTypeOf choice to.equalTypeOf barLit}}
   {{/if}}
-</template>
+</template>;


### PR DESCRIPTION
I've written in the comment why I think this is much better. Also [here](https://github.com/typed-ember/glint/pull/1167#issuecomment-4815797703).

cc @NullVoxPopuli 