### PR TITLE
Fix `lt`, `lte`, `gt` and `gte` not accepting strings and dates

### DIFF
--- a/packages/ember-tsc/types/-private/intrinsics/comparison.d.ts
+++ b/packages/ember-tsc/types/-private/intrinsics/comparison.d.ts
@@ -8,22 +8,22 @@ import { DirectInvokable } from '@glint/template/-private/integration';
 // `lt`/`lte`/`gt`/`gte` keywords below have no narrowing benefit and remain
 // ordinary helpers.
 
-/** `(lt a b)` — numeric less-than. Built-in keyword in ember-source >= 7.1. */
+/** `(lt a b)` — less-than. Built-in keyword in ember-source >= 7.1. */
 export type LtHelper = DirectInvokable<{
-  (a: number, b: number): boolean;
+  <T extends number | string | Date>(a: T, b: T): boolean;
 }>;
 
-/** `(lte a b)` — numeric less-than-or-equal. Built-in keyword in ember-source >= 7.1. */
+/** `(lte a b)` — less-than-or-equal. Built-in keyword in ember-source >= 7.1. */
 export type LteHelper = DirectInvokable<{
-  (a: number, b: number): boolean;
+  <T extends number | string | Date>(a: T, b: T): boolean;
 }>;
 
-/** `(gt a b)` — numeric greater-than. Built-in keyword in ember-source >= 7.1. */
+/** `(gt a b)` — greater-than. Built-in keyword in ember-source >= 7.1. */
 export type GtHelper = DirectInvokable<{
-  (a: number, b: number): boolean;
+  <T extends number | string | Date>(a: T, b: T): boolean;
 }>;
 
-/** `(gte a b)` — numeric greater-than-or-equal. Built-in keyword in ember-source >= 7.1. */
+/** `(gte a b)` — greater-than-or-equal. Built-in keyword in ember-source >= 7.1. */
 export type GteHelper = DirectInvokable<{
-  (a: number, b: number): boolean;
+  <T extends number | string | Date>(a: T, b: T): boolean;
 }>;

--- a/test-packages/ts-gts-7-1-app/src/globals/comparison.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/comparison.gts
@@ -5,12 +5,30 @@
 const a = 1 as number;
 const b = 2 as number;
 
+const date = new Date();
+
 <template>
   {{! ---- (RFC 561) eq / neq / lt / lte / gt / gte ---- }}
   {{#if (eq a b)}}eq{{/if}}
   {{#if (neq a b)}}neq{{/if}}
   {{#if (lt 1 2)}}lt{{/if}}
+  {{#if (lt "1" "2")}}lt{{/if}}
+  {{#if (lt date date)}}lt{{/if}}
+  {{! @glint-expect-error }}
+  {{#if (lt 1 "2")}}lt{{/if}}
   {{#if (lte 1 2)}}lte{{/if}}
+  {{#if (lte "1" "2")}}lte{{/if}}
+  {{#if (lte date date)}}lte{{/if}}
+  {{! @glint-expect-error }}
+  {{#if (lte 1 "2")}}lt{{/if}}
   {{#if (gt 2 1)}}gt{{/if}}
+  {{#if (gt "2" "1")}}gt{{/if}}
+  {{#if (gt date date)}}gt{{/if}}
+  {{! @glint-expect-error }}
+  {{#if (gt 1 "2")}}lt{{/if}}
   {{#if (gte 2 2)}}gte{{/if}}
+  {{#if (gte "2" "2")}}gte{{/if}}
+  {{#if (gte date date)}}gte{{/if}}
+  {{! @glint-expect-error }}
+  {{#if (gte 1 "2")}}lt{{/if}}
 </template>


### PR DESCRIPTION
cc @NullVoxPopuli 