### PR TITLE
Fix control-flow narrowing through operator special forms (#1169)

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -243,7 +243,16 @@ export function templateToTypescript(
       node: AST.MustacheStatement | AST.SubExpression,
       position: InvokePosition,
     ): void {
-      if (formInfo.requiresConsumption) {
+      // Operator special forms (`===`/`!==`/`&&`/`||`/`!`) emit the discarded
+      // keyword reference (kept for hover/go-to-definition) attached to their
+      // first operand rather than wrapping the whole expression — see
+      // `emitConsumedOperand`. Wrapping the whole operator expression in the
+      // `(__glintDSL__.noop(keyword), <expr>)` comma expression severs
+      // TypeScript's control-flow narrowing of the operands inside `{{#if}}`
+      // (e.g. `{{#if (and (isNumber x) (isNumber y))}}`), so they handle their
+      // own consumption below. (#1169)
+      let consumeAroundWholeExpression = formInfo.requiresConsumption && !isOperatorForm(formInfo);
+      if (consumeAroundWholeExpression) {
         mapper.text('(__glintDSL__.noop(');
         emitExpression(node.path);
         mapper.text('), ');
@@ -293,8 +302,42 @@ export function templateToTypescript(
           mapper.text('undefined');
       }
 
-      if (formInfo.requiresConsumption) {
+      if (consumeAroundWholeExpression) {
         mapper.text(')');
+      }
+    }
+
+    // `===`/`!==`/`&&`/`||`/`!`: these emit the native operator (never a keyword
+    // call), so TypeScript can narrow their operands as a condition.
+    function isOperatorForm(formInfo: Pick<SpecialFormInfo, 'form'>): boolean {
+      return (
+        formInfo.form === '===' ||
+        formInfo.form === '!==' ||
+        formInfo.form === '&&' ||
+        formInfo.form === '||' ||
+        formInfo.form === '!'
+      );
+    }
+
+    // Emit a single operand as `(__glintDSL__.noop(keyword), <operand>)` when the
+    // form requires consumption, so the discarded keyword reference (which
+    // preserves hover/go-to-definition on e.g. `eq`/`neq`) rides along with the
+    // operand instead of wrapping the whole operator expression. Because the
+    // operator itself stays at the top level of the emitted condition,
+    // TypeScript's control-flow analysis still narrows every operand. (#1169)
+    function emitConsumedOperand(
+      formInfo: SpecialFormInfo,
+      node: AST.MustacheStatement | AST.SubExpression,
+      emitOperand: () => void,
+    ): void {
+      if (formInfo.requiresConsumption) {
+        mapper.text('(__glintDSL__.noop(');
+        emitExpression(node.path);
+        mapper.text('), ');
+        emitOperand();
+        mapper.text(')');
+      } else {
+        emitOperand();
       }
     }
 
@@ -482,7 +525,7 @@ export function templateToTypescript(
         const [left, right] = node.params;
 
         mapper.text('(');
-        emitExpression(left);
+        emitConsumedOperand(formInfo, node, () => emitExpression(left));
         mapper.text(` ${formInfo.form} `);
         emitExpression(right);
         mapper.text(')');
@@ -505,7 +548,11 @@ export function templateToTypescript(
 
         mapper.text('(');
         for (const [index, param] of node.params.entries()) {
-          emitExpression(param);
+          if (index === 0) {
+            emitConsumedOperand(formInfo, node, () => emitExpression(param));
+          } else {
+            emitExpression(param);
+          }
 
           if (index < node.params.length - 1) {
             mapper.text(` ${formInfo.form} `);
@@ -532,7 +579,7 @@ export function templateToTypescript(
         const [param] = node.params;
 
         mapper.text(formInfo.form);
-        emitExpression(param);
+        emitConsumedOperand(formInfo, node, () => emitExpression(param));
       });
     }
 
@@ -557,13 +604,10 @@ export function templateToTypescript(
           // operator expression — never a reference to the keyword itself. For a
           // documented global keyword (e.g. `eq`/`neq`) that would drop hover
           // docs and go-to-definition, so we still emit a discarded reference to
-          // it. Narrowing is preserved: the keyword is emitted as the throwaway
-          // first operand of a comma expression whose value is the operator
-          // expression (`(noop(eq), (a === b))`).
-          let isOperatorForm =
-            form === '===' || form === '!==' || form === '&&' || form === '||' || form === '!';
-
-          return { name, form, requiresConsumption: !isGlobal || isOperatorForm };
+          // it. Narrowing is preserved by attaching that reference to the first
+          // operand rather than wrapping the whole expression — see
+          // `emitConsumedOperand` (`((noop(eq), a) === b)`). (#1169)
+          return { name, form, requiresConsumption: !isGlobal || isOperatorForm({ form }) };
         }
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,6 +621,74 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  test-packages/ts-special-forms-app:
+    dependenciesMeta:
+      '@glint/ember-tsc':
+        injected: true
+      '@glint/template':
+        injected: true
+      '@glint/tsserver-plugin':
+        injected: true
+    devDependencies:
+      '@glimmer/component':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@glint/ember-tsc':
+        specifier: workspace:*
+        version: file:packages/ember-tsc(671831d5ef01bb1c4e55e2727bcae909)
+      '@glint/template':
+        specifier: workspace:*
+        version: file:packages/template
+      '@glint/tsserver-plugin':
+        specifier: workspace:*
+        version: file:packages/tsserver-plugin
+      '@glint/type-test':
+        specifier: workspace:*
+        version: link:../../packages/type-test
+      '@tsconfig/ember':
+        specifier: ^3.0.9
+        version: 3.0.9
+      ember-source:
+        specifier: ~7.1.0-beta.1
+        version: 7.1.0-beta.1(@glimmer/component@2.0.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  test-packages/ts-special-forms-pre-7-1-app:
+    dependenciesMeta:
+      '@glint/ember-tsc':
+        injected: true
+      '@glint/template':
+        injected: true
+      '@glint/tsserver-plugin':
+        injected: true
+    devDependencies:
+      '@glimmer/component':
+        specifier: ^2.0.0
+        version: 2.0.0
+      '@glint/ember-tsc':
+        specifier: workspace:*
+        version: file:packages/ember-tsc(ea5fe0a69289ce36b0caa09bb31a58c2)
+      '@glint/template':
+        specifier: workspace:*
+        version: file:packages/template
+      '@glint/tsserver-plugin':
+        specifier: workspace:*
+        version: file:packages/tsserver-plugin
+      '@glint/type-test':
+        specifier: workspace:*
+        version: link:../../packages/type-test
+      '@tsconfig/ember':
+        specifier: ^3.0.9
+        version: 3.0.9
+      ember-source:
+        specifier: ^6.2.0
+        version: 6.11.0(@glimmer/component@2.0.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   test-packages/ts-template-imports-app:
     dependenciesMeta:
       '@glint/ember-tsc':

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -479,7 +479,7 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testEq'], specialForms: { testEq: '===' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testEq), (1 === 2))));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(((__glintDSL__.noop(__glintDSL__.Globals.testEq), 1) === 2)));"`,
         );
       });
     });
@@ -493,7 +493,7 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testNeq'], specialForms: { testNeq: '!==' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testNeq), (1 !== 2))));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(((__glintDSL__.noop(__glintDSL__.Globals.testNeq), 1) !== 2)));"`,
         );
       });
     });
@@ -507,7 +507,7 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testAnd'], specialForms: { testAnd: '&&' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testAnd), (1 && 2))));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(((__glintDSL__.noop(__glintDSL__.Globals.testAnd), 1) && 2)));"`,
         );
       });
 
@@ -519,7 +519,7 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testAnd'], specialForms: { testAnd: '&&' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testAnd), (1 && 2 && 3))));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(((__glintDSL__.noop(__glintDSL__.Globals.testAnd), 1) && 2 && 3)));"`,
         );
       });
     });
@@ -533,7 +533,7 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testOr'], specialForms: { testOr: '||' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testOr), (1 || 2))));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(((__glintDSL__.noop(__glintDSL__.Globals.testOr), 1) || 2)));"`,
         );
       });
 
@@ -545,7 +545,7 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testOr'], specialForms: { testOr: '||' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testOr), (1 || 2 || 3))));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(((__glintDSL__.noop(__glintDSL__.Globals.testOr), 1) || 2 || 3)));"`,
         );
       });
     });
@@ -559,8 +559,83 @@ describe('Transform: rewriteTemplate', () => {
         expect(
           templateBody(template, { globals: ['testNot'], specialForms: { testNot: '!' } }),
         ).toMatchInlineSnapshot(
-          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testNot), !1)));"`,
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(log)(!(__glintDSL__.noop(__glintDSL__.Globals.testNot), 1)));"`,
         );
+      });
+    });
+
+    // The discarded keyword reference (kept for hover/go-to-definition) is
+    // attached to the operator's *first operand* rather than wrapping the whole
+    // expression, so the operator stays at the top level of the emitted `if (…)`
+    // condition and TypeScript's control-flow analysis still narrows the
+    // operands inside the block. (#1169)
+    describe('operator special forms keep narrowing in a condition', () => {
+      test('{{#if (and …)}} emits `((noop(and), a) && b)` as the condition', () => {
+        let template = stripIndent`
+          {{#testIf (testAnd @a @b)}}{{@ok}}{{/testIf}}
+        `;
+
+        expect(
+          templateBody(template, {
+            globals: ['testIf', 'testAnd'],
+            specialForms: { testIf: 'if', testAnd: '&&' },
+          }),
+        ).toMatchInlineSnapshot(`
+          "if (((__glintDSL__.noop(__glintDSL__.Globals.testAnd), __glintRef__.args.a) && __glintRef__.args.b)) {
+          __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.ok)());
+          }"
+        `);
+      });
+
+      test('{{#if (or …)}} emits `((noop(or), a) || b)` as the condition', () => {
+        let template = stripIndent`
+          {{#testIf (testOr @a @b)}}{{@ok}}{{/testIf}}
+        `;
+
+        expect(
+          templateBody(template, {
+            globals: ['testIf', 'testOr'],
+            specialForms: { testIf: 'if', testOr: '||' },
+          }),
+        ).toMatchInlineSnapshot(`
+          "if (((__glintDSL__.noop(__glintDSL__.Globals.testOr), __glintRef__.args.a) || __glintRef__.args.b)) {
+          __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.ok)());
+          }"
+        `);
+      });
+
+      test('{{#if (eq …)}} emits `((noop(eq), a) === b)` as the condition', () => {
+        let template = stripIndent`
+          {{#testIf (testEq @a @b)}}{{@ok}}{{/testIf}}
+        `;
+
+        expect(
+          templateBody(template, {
+            globals: ['testIf', 'testEq'],
+            specialForms: { testIf: 'if', testEq: '===' },
+          }),
+        ).toMatchInlineSnapshot(`
+          "if (((__glintDSL__.noop(__glintDSL__.Globals.testEq), __glintRef__.args.a) === __glintRef__.args.b)) {
+          __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.ok)());
+          }"
+        `);
+      });
+
+      test('{{#if (not …)}} emits `!(noop(not), a)` as the condition', () => {
+        let template = stripIndent`
+          {{#testIf (testNot @a)}}{{@ok}}{{/testIf}}
+        `;
+
+        expect(
+          templateBody(template, {
+            globals: ['testIf', 'testNot'],
+            specialForms: { testIf: 'if', testNot: '!' },
+          }),
+        ).toMatchInlineSnapshot(`
+          "if (!(__glintDSL__.noop(__glintDSL__.Globals.testNot), __glintRef__.args.a)) {
+          __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.ok)());
+          }"
+        `);
       });
     });
   });

--- a/test-packages/ts-special-forms-app/.gitignore
+++ b/test-packages/ts-special-forms-app/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.tsbuildinfo

--- a/test-packages/ts-special-forms-app/package.json
+++ b/test-packages/ts-special-forms-app/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ts-special-forms-app",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "test": "echo 'no standalone test within this project'",
+    "test:typecheck": "ember-tsc --noEmit",
+    "test:tsc": "echo 'no standalone tsc within this project'"
+  },
+  "dependenciesMeta": {
+    "@glint/template": {
+      "injected": true
+    },
+    "@glint/ember-tsc": {
+      "injected": true
+    },
+    "@glint/tsserver-plugin": {
+      "injected": true
+    }
+  },
+  "devDependencies": {
+    "@glimmer/component": "^2.0.0",
+    "@glint/ember-tsc": "workspace:*",
+    "@glint/template": "workspace:*",
+    "@glint/tsserver-plugin": "workspace:*",
+    "@glint/type-test": "workspace:*",
+    "@tsconfig/ember": "^3.0.9",
+    "ember-source": "~7.1.0-beta.1",
+    "typescript": "^5.9.3"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/test-packages/ts-special-forms-app/src/narrowing.test.gts
+++ b/test-packages/ts-special-forms-app/src/narrowing.test.gts
@@ -1,0 +1,103 @@
+import { expectTypeOf, to } from '@glint/type-test';
+
+// This project maps `and`/`or`/`not`/`eq`/`neq` to the `&&`/`||`/`!`/`===`/`!==`
+// operator special forms via `glint.additionalSpecialForms` in tsconfig.json.
+// Because they compile to the native operators (rather than a boolean-returning
+// helper call), TypeScript's control-flow analysis can narrow their operands
+// inside `{{#if}}` — exactly the behavior reported missing in
+// https://github.com/typed-ember/glint/issues/1169.
+//
+// `expectTypeOf <value> to.<expectation>` asserts the *exact* type at that
+// point in the template. `to.be*` uses strict equality, so each assertion only
+// type-checks because the narrowing it describes actually happened.
+
+function isNumber(x: unknown): x is number {
+  return typeof x === 'number';
+}
+
+// Object members of a union; objects are always truthy, so `{{#if}}` can narrow
+// them to exactly `undefined` in the negative branch.
+type User = { kind: 'user'; name: string };
+type Admin = { kind: 'admin'; level: number };
+const user = { kind: 'user', name: 'a' } as User;
+const admin = { kind: 'admin', level: 1 } as Admin;
+const maybeUser = undefined as User | undefined;
+const maybeAdmin = undefined as Admin | undefined;
+
+// `unknown` properties refined only by an explicit type guard.
+type Box = { x: unknown; y: unknown };
+const box = { x: 1, y: 2 } as Box;
+
+// Discriminated union with a string-literal discriminant, for eq/neq narrowing.
+type Circle = { kind: 'circle'; radius: number };
+type Square = { kind: 'square'; side: number };
+const shape = { kind: 'circle', radius: 1 } as Circle | Square;
+const circle = { kind: 'circle', radius: 1 } as Circle;
+const square = { kind: 'square', side: 1 } as Square;
+
+<template>
+  {{! ===== `and` (&&) ===== }}
+
+  {{! ---- (1) the issue #1169 scenario: each type-guard operand narrows in the
+      truthy branch, so both `box.x` and `box.y` refine to `number`. ---- }}
+  {{#if (and (isNumber box.x) (isNumber box.y))}}
+    {{expectTypeOf box.x to.beNumber}}
+    {{expectTypeOf box.y to.beNumber}}
+  {{/if}}
+
+  {{! ---- (2) truthiness narrowing: optional objects are excluded of their
+      `undefined` member in the truthy branch. ---- }}
+  {{#if (and maybeUser maybeAdmin)}}
+    {{expectTypeOf maybeUser to.equalTypeOf user}}
+    {{expectTypeOf maybeAdmin to.equalTypeOf admin}}
+  {{/if}}
+
+  {{! ===== `or` (||) ===== }}
+
+  {{! ---- the else branch narrows *every* operand to its falsy member; for
+      object unions that is exactly `undefined`. ---- }}
+  {{#if (or maybeUser maybeAdmin)}}
+    {{! truthy branch: either operand may be the set one, so neither narrows }}
+  {{else}}
+    {{expectTypeOf maybeUser to.beUndefined}}
+    {{expectTypeOf maybeAdmin to.beUndefined}}
+  {{/if}}
+
+  {{! ===== `not` (!) ===== }}
+
+  {{! ---- negation flips the branches: the truthy-negation branch keeps the
+      falsy members and the else branch keeps the truthy ones. For an optional
+      object the else branch narrows to exactly the object type. ---- }}
+  {{#if (not maybeUser)}}
+    {{expectTypeOf maybeUser to.beUndefined}}
+  {{else}}
+    {{expectTypeOf maybeUser to.equalTypeOf user}}
+  {{/if}}
+
+  {{! ===== `eq` / `neq` (=== / !==) ===== }}
+
+  {{! ---- `eq` narrows the *parent* discriminated union on a string-literal
+      discriminant — something a boolean-returning helper cannot do. ---- }}
+  {{#if (eq shape.kind "circle")}}
+    {{expectTypeOf shape to.equalTypeOf circle}}
+    {{expectTypeOf shape.radius to.beNumber}}
+  {{else}}
+    {{expectTypeOf shape to.equalTypeOf square}}
+  {{/if}}
+
+  {{! ---- `neq` narrows the opposite direction. ---- }}
+  {{#if (neq shape.kind "circle")}}
+    {{expectTypeOf shape to.equalTypeOf square}}
+  {{else}}
+    {{expectTypeOf shape to.equalTypeOf circle}}
+  {{/if}}
+
+  {{! ===== combined: `and` of an `eq` discriminant and a type guard ===== }}
+
+  {{! ---- both the discriminated union and the `unknown` property narrow
+      together inside the one block. ---- }}
+  {{#if (and (eq shape.kind "circle") (isNumber box.x))}}
+    {{expectTypeOf shape to.equalTypeOf circle}}
+    {{expectTypeOf box.x to.beNumber}}
+  {{/if}}
+</template>

--- a/test-packages/ts-special-forms-app/tsconfig.json
+++ b/test-packages/ts-special-forms-app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@tsconfig/ember",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["ember-source/types", "@glint/ember-tsc/types"]
+  },
+  "glint": {
+    "additionalSpecialForms": {
+      "globals": {
+        "and": "&&",
+        "or": "||",
+        "not": "!",
+        "eq": "===",
+        "neq": "!=="
+      }
+    }
+  }
+}

--- a/test-packages/ts-special-forms-pre-7-1-app/.gitignore
+++ b/test-packages/ts-special-forms-pre-7-1-app/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.tsbuildinfo

--- a/test-packages/ts-special-forms-pre-7-1-app/package.json
+++ b/test-packages/ts-special-forms-pre-7-1-app/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ts-special-forms-pre-7-1-app",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "test": "echo 'no standalone test within this project'",
+    "test:typecheck": "ember-tsc --noEmit",
+    "test:tsc": "echo 'no standalone tsc within this project'"
+  },
+  "dependenciesMeta": {
+    "@glint/template": {
+      "injected": true
+    },
+    "@glint/ember-tsc": {
+      "injected": true
+    },
+    "@glint/tsserver-plugin": {
+      "injected": true
+    }
+  },
+  "devDependencies": {
+    "@glimmer/component": "^2.0.0",
+    "@glint/ember-tsc": "workspace:*",
+    "@glint/template": "workspace:*",
+    "@glint/tsserver-plugin": "workspace:*",
+    "@glint/type-test": "workspace:*",
+    "@tsconfig/ember": "^3.0.9",
+    "ember-source": "^6.2.0",
+    "typescript": "^5.9.3"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/test-packages/ts-special-forms-pre-7-1-app/src/narrowing.test.gts
+++ b/test-packages/ts-special-forms-pre-7-1-app/src/narrowing.test.gts
@@ -1,0 +1,103 @@
+import { expectTypeOf, to } from '@glint/type-test';
+
+// This project maps `and`/`or`/`not`/`eq`/`neq` to the `&&`/`||`/`!`/`===`/`!==`
+// operator special forms via `glint.additionalSpecialForms` in tsconfig.json.
+// Because they compile to the native operators (rather than a boolean-returning
+// helper call), TypeScript's control-flow analysis can narrow their operands
+// inside `{{#if}}` — exactly the behavior reported missing in
+// https://github.com/typed-ember/glint/issues/1169.
+//
+// `expectTypeOf <value> to.<expectation>` asserts the *exact* type at that
+// point in the template. `to.be*` uses strict equality, so each assertion only
+// type-checks because the narrowing it describes actually happened.
+
+function isNumber(x: unknown): x is number {
+  return typeof x === 'number';
+}
+
+// Object members of a union; objects are always truthy, so `{{#if}}` can narrow
+// them to exactly `undefined` in the negative branch.
+type User = { kind: 'user'; name: string };
+type Admin = { kind: 'admin'; level: number };
+const user = { kind: 'user', name: 'a' } as User;
+const admin = { kind: 'admin', level: 1 } as Admin;
+const maybeUser = undefined as User | undefined;
+const maybeAdmin = undefined as Admin | undefined;
+
+// `unknown` properties refined only by an explicit type guard.
+type Box = { x: unknown; y: unknown };
+const box = { x: 1, y: 2 } as Box;
+
+// Discriminated union with a string-literal discriminant, for eq/neq narrowing.
+type Circle = { kind: 'circle'; radius: number };
+type Square = { kind: 'square'; side: number };
+const shape = { kind: 'circle', radius: 1 } as Circle | Square;
+const circle = { kind: 'circle', radius: 1 } as Circle;
+const square = { kind: 'square', side: 1 } as Square;
+
+<template>
+  {{! ===== `and` (&&) ===== }}
+
+  {{! ---- (1) the issue #1169 scenario: each type-guard operand narrows in the
+      truthy branch, so both `box.x` and `box.y` refine to `number`. ---- }}
+  {{#if (and (isNumber box.x) (isNumber box.y))}}
+    {{expectTypeOf box.x to.beNumber}}
+    {{expectTypeOf box.y to.beNumber}}
+  {{/if}}
+
+  {{! ---- (2) truthiness narrowing: optional objects are excluded of their
+      `undefined` member in the truthy branch. ---- }}
+  {{#if (and maybeUser maybeAdmin)}}
+    {{expectTypeOf maybeUser to.equalTypeOf user}}
+    {{expectTypeOf maybeAdmin to.equalTypeOf admin}}
+  {{/if}}
+
+  {{! ===== `or` (||) ===== }}
+
+  {{! ---- the else branch narrows *every* operand to its falsy member; for
+      object unions that is exactly `undefined`. ---- }}
+  {{#if (or maybeUser maybeAdmin)}}
+    {{! truthy branch: either operand may be the set one, so neither narrows }}
+  {{else}}
+    {{expectTypeOf maybeUser to.beUndefined}}
+    {{expectTypeOf maybeAdmin to.beUndefined}}
+  {{/if}}
+
+  {{! ===== `not` (!) ===== }}
+
+  {{! ---- negation flips the branches: the truthy-negation branch keeps the
+      falsy members and the else branch keeps the truthy ones. For an optional
+      object the else branch narrows to exactly the object type. ---- }}
+  {{#if (not maybeUser)}}
+    {{expectTypeOf maybeUser to.beUndefined}}
+  {{else}}
+    {{expectTypeOf maybeUser to.equalTypeOf user}}
+  {{/if}}
+
+  {{! ===== `eq` / `neq` (=== / !==) ===== }}
+
+  {{! ---- `eq` narrows the *parent* discriminated union on a string-literal
+      discriminant — something a boolean-returning helper cannot do. ---- }}
+  {{#if (eq shape.kind "circle")}}
+    {{expectTypeOf shape to.equalTypeOf circle}}
+    {{expectTypeOf shape.radius to.beNumber}}
+  {{else}}
+    {{expectTypeOf shape to.equalTypeOf square}}
+  {{/if}}
+
+  {{! ---- `neq` narrows the opposite direction. ---- }}
+  {{#if (neq shape.kind "circle")}}
+    {{expectTypeOf shape to.equalTypeOf square}}
+  {{else}}
+    {{expectTypeOf shape to.equalTypeOf circle}}
+  {{/if}}
+
+  {{! ===== combined: `and` of an `eq` discriminant and a type guard ===== }}
+
+  {{! ---- both the discriminated union and the `unknown` property narrow
+      together inside the one block. ---- }}
+  {{#if (and (eq shape.kind "circle") (isNumber box.x))}}
+    {{expectTypeOf shape to.equalTypeOf circle}}
+    {{expectTypeOf box.x to.beNumber}}
+  {{/if}}
+</template>

--- a/test-packages/ts-special-forms-pre-7-1-app/tsconfig.json
+++ b/test-packages/ts-special-forms-pre-7-1-app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/ember",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["ember-source/types", "@glint/ember-tsc/types"]
+  },
+  "include": ["src", "types"],
+  "glint": {
+    "additionalSpecialForms": {
+      "globals": {
+        "and": "&&",
+        "or": "||",
+        "not": "!",
+        "eq": "===",
+        "neq": "!=="
+      }
+    }
+  }
+}

--- a/test-packages/ts-special-forms-pre-7-1-app/types/index.d.ts
+++ b/test-packages/ts-special-forms-pre-7-1-app/types/index.d.ts
@@ -1,0 +1,19 @@
+import '@glint/ember-tsc/types';
+
+// On ember-source < 7.1, `and`/`or`/`not`/`eq`/`neq` are NOT built-in template
+// keywords, so they are not members of Glint's `Globals` type. When they are
+// configured as operator special forms (see tsconfig.json
+// `additionalSpecialForms`), the transform still emits a *discarded* reference
+// to the keyword — `__glintDSL__.noop(Globals.<name>)` — purely to preserve
+// hover and go-to-definition on it. Declaring the names here satisfies that
+// reference. The narrowing under test comes entirely from the emitted
+// `&&`/`||`/`===`/`!==`/`!` operators and is independent of these types.
+declare module '@glint/ember-tsc/globals' {
+  export default interface Globals {
+    and: unknown;
+    or: unknown;
+    not: unknown;
+    eq: unknown;
+    neq: unknown;
+  }
+}


### PR DESCRIPTION
Fixes #1169.

## Problem

Operator special forms (`&&`/`||`/`===`/`!==`/`!` — e.g. `and`/`or`/`eq`/`neq` configured via `additionalSpecialForms`) emitted the *discarded keyword reference* (kept for hover/go-to-definition) by wrapping the **whole** operator expression in a comma expression:

```ts
if ((__glintDSL__.noop(Globals.and), (isNumber(x.x) && isNumber(x.y)))) { … }
```

A comma expression severs TypeScript's control-flow analysis, so `{{#if (and (isNumber x.x) (isNumber x.y))}}` left `x.x`/`x.y` as `unknown` inside the block. (A single `eq`/`===` happened to still narrow, which is why only `and`/`or` looked broken in the report.)

## Fix

Attach the discarded reference to the operator's **first operand** instead, so the operator stays at the top level of the emitted condition and every operand still narrows:

```ts
if (((__glintDSL__.noop(Globals.and), isNumber(x.x)) && isNumber(x.y))) { … }
//   └── reference rides the first operand ──┘   └─ && stays top-level ─┘
```

- `&&`/`||`: `((noop(and), a) && b && c)`
- `===`/`!==`: `((noop(eq), a) === b)`
- `!`: `!(noop(not), a)`

Hover and go-to-definition on the keyword are preserved (the reference is still emitted, just repositioned).

## Tests

- **Transform snapshots** for operator forms in `{{#if}}` conditions (`and`/`or`/`eq`/`not`), plus the updated inline-form snapshots.
- **Two new typecheck fixture apps** exercising `and`/`or`/`not`/`eq`/`neq` narrowing through `additionalSpecialForms`, using `@glint/type-test` strict assertions (type-guard operands, truthiness narrowing, `or` else-branch, discriminated-union narrowing via `eq`/`neq`, and a combined `and` of an `eq` discriminant + a type guard):
  - `test-packages/ts-special-forms-app` — Ember 7.1
  - `test-packages/ts-special-forms-pre-7-1-app` — Ember 6.2. Pre-7.1, `and`/`or`/… are not built-in globals, so the discarded `noop(Globals.<name>)` reference has nothing to resolve against; the app augments `Globals` (the documented `additionalGlobals` mechanism) to type the names. The narrowing itself is independent of those types.

Full `pnpm test:typecheck` and the `package-test-core` unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)