### PR TITLE
Fix #1180, improve types for hash

### DIFF
--- a/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts
+++ b/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts
@@ -113,8 +113,22 @@ export default function emberTemplateImportsEnvironment(
           // discriminated unions — e.g. `{{#if (eq foo.kind "a")}}` narrows
           // `foo` to the matching variant inside the block, which a
           // boolean-returning helper type cannot do.
+          //
+          // The RFC 999 `hash` keyword emits as an object literal, matching the
+          // `@ember/helper` import below. Emitting it as a helper call instead
+          // loses the literal's "freshness": TypeScript's overload resolution
+          // rejects a non-fresh argument that omits an optional property during
+          // its subtype pass, so `{{x "A" (hash a=1)}}` would pick a catch-all
+          // overload that the equivalent inline literal `x('A', { a: 1 })`
+          // does not (#1180). `array` intentionally stays a helper call: its
+          // `const` signature preserves literal element types at non-contextual
+          // positions (see `array-keyword-preserve-literals.test.gts`).
           ...(hasEmber71BuiltIns()
-            ? ({ eq: '===', neq: '!==' } satisfies GlintSpecialFormConfig['globals'])
+            ? ({
+                eq: '===',
+                neq: '!==',
+                hash: 'object-literal',
+              } satisfies GlintSpecialFormConfig['globals'])
             : {}),
           ...additionalGlobalSpecialForms,
         },

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -319,6 +319,14 @@ export function templateToTypescript(
       );
     }
 
+    // `object-literal`/`array-literal`: these emit a native literal (never a
+    // keyword call), so TypeScript treats the result as a fresh literal —
+    // contextual typing, excess property checking, and overload resolution all
+    // behave exactly as they would for a hand-written literal. (#1180)
+    function isLiteralForm(formInfo: Pick<SpecialFormInfo, 'form'>): boolean {
+      return formInfo.form === 'object-literal' || formInfo.form === 'array-literal';
+    }
+
     // Emit a single operand as `(__glintDSL__.noop(keyword), <operand>)` when the
     // form requires consumption, so the discarded keyword reference (which
     // preserves hover/go-to-definition on e.g. `eq`/`neq`) rides along with the
@@ -600,14 +608,20 @@ export function templateToTypescript(
           let isGlobal = globals ? globals.includes(name) : true;
           let form = specialForms[name];
 
-          // Operator special forms (`===`, `!==`, `&&`, `||`, `!`) emit only the
-          // operator expression — never a reference to the keyword itself. For a
-          // documented global keyword (e.g. `eq`/`neq`) that would drop hover
-          // docs and go-to-definition, so we still emit a discarded reference to
-          // it. Narrowing is preserved by attaching that reference to the first
-          // operand rather than wrapping the whole expression — see
-          // `emitConsumedOperand` (`((noop(eq), a) === b)`). (#1169)
-          return { name, form, requiresConsumption: !isGlobal || isOperatorForm({ form }) };
+          // Operator special forms (`===`, `!==`, `&&`, `||`, `!`) and literal
+          // forms (`object-literal`, `array-literal`) emit only the resulting
+          // expression — never a reference to the keyword itself. For a
+          // documented global keyword (e.g. `eq`/`neq`, `hash`) that would drop
+          // hover docs and go-to-definition, so we still emit a discarded
+          // reference to it. For operator forms, narrowing is preserved by
+          // attaching that reference to the first operand rather than wrapping
+          // the whole expression — see `emitConsumedOperand`
+          // (`((noop(eq), a) === b)`). (#1169)
+          return {
+            name,
+            form,
+            requiresConsumption: !isGlobal || isOperatorForm({ form }) || isLiteralForm({ form }),
+          };
         }
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       ember-source:
         specifier: ~7.1.0-beta.1
         version: 7.1.0-beta.1(@glimmer/component@2.0.0)
+      expect-type:
+        specifier: ^1.2.1
+        version: 1.3.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -99,15 +99,18 @@ describe('Transform: rewriteTemplate', () => {
         `);
       });
 
-      test('implicit globals are ignored in expression position', () => {
+      // Global literal forms still emit a discarded reference to the keyword,
+      // preserving hover docs and go-to-definition (as `eq`/`neq` do — #1169)
+      // while the literal itself stays fresh for TypeScript. (#1180)
+      test('implicit globals emit a discarded reference in expression position', () => {
         let body = templateBody(`{{obj x=123}}`, {
           specialForms: { obj: 'object-literal' },
         });
 
         expect(body).toMatchInlineSnapshot(`
-          "({
+          "(__glintDSL__.noop(__glintDSL__.Globals.obj), ({
           x: 123,
-          });"
+          }));"
         `);
       });
 
@@ -123,16 +126,16 @@ describe('Transform: rewriteTemplate', () => {
         `);
       });
 
-      test('explicit globals are ignored in expression position', () => {
+      test('explicit globals emit a discarded reference in expression position', () => {
         let body = templateBody(`{{obj x=123}}`, {
           specialForms: { obj: 'object-literal' },
           globals: ['obj'],
         });
 
         expect(body).toMatchInlineSnapshot(`
-          "({
+          "(__glintDSL__.noop(__glintDSL__.Globals.obj), ({
           x: 123,
-          });"
+          }));"
         `);
       });
 
@@ -463,6 +466,27 @@ describe('Transform: rewriteTemplate', () => {
 
         expect(templateBody(template, { globals: [], specialForms })).toMatchInlineSnapshot(`
           "__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(testHash), ({
+          a: 1,
+          b: "ok",
+          }))));"
+        `);
+      });
+
+      // The 7.1 built-in `hash` keyword is a global object-literal special
+      // form. It still emits a discarded reference to the keyword (preserving
+      // hover docs and go-to-definition on `Globals`), followed by a fresh
+      // object literal. (#1180)
+      test('as a global keyword', () => {
+        let template = stripIndent`
+          {{log (testHash a=1 b="ok")}}
+        `;
+
+        let specialForms = { testHash: 'object-literal' } as const;
+
+        expect(
+          templateBody(template, { globals: ['testHash'], specialForms }),
+        ).toMatchInlineSnapshot(`
+          "__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testHash), ({
           a: 1,
           b: "ok",
           }))));"

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -483,9 +483,8 @@ describe('Transform: rewriteTemplate', () => {
 
         let specialForms = { testHash: 'object-literal' } as const;
 
-        expect(
-          templateBody(template, { globals: ['testHash'], specialForms }),
-        ).toMatchInlineSnapshot(`
+        expect(templateBody(template, { globals: ['testHash'], specialForms }))
+          .toMatchInlineSnapshot(`
           "__glintDSL__.emitContent(__glintDSL__.resolve(log)((__glintDSL__.noop(__glintDSL__.Globals.testHash), ({
           a: 1,
           b: "ok",

--- a/test-packages/ts-gts-7-1-app/package.json
+++ b/test-packages/ts-gts-7-1-app/package.json
@@ -27,6 +27,7 @@
     "@glint/type-test": "workspace:*",
     "@tsconfig/ember": "^3.0.9",
     "ember-source": "~7.1.0-beta.1",
+    "expect-type": "^1.2.1",
     "typescript": "^5.9.3"
   },
   "volta": {

--- a/test-packages/ts-gts-7-1-app/src/globals/overload-resolution.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/overload-resolution.test.gts
@@ -1,0 +1,39 @@
+import { hash as emberHash } from '@ember/helper';
+import { expectTypeOf, to } from '@glint/type-test';
+import { expectTypeOf as tsExpectTypeOf } from 'expect-type';
+import { noop, Globals } from '@glint/ember-tsc/-private/dsl';
+
+// Regression guard for https://github.com/typed-ember/glint/issues/1180
+// An overloaded function invoked from a template must resolve to the same
+// overload plain TypeScript would pick for an inline object literal. The
+// keyword `hash` therefore emits as an object-literal special form (like the
+// `@ember/helper` import), keeping the literal fresh. Emitting it as a helper
+// call instead loses freshness, and TypeScript's overload resolution rejects a
+// non-fresh argument that omits an optional property during its subtype pass —
+// so `{{x "A" (hash a=1)}}` picked the catch-all overload, whose `object`
+// return type is not renderable as content.
+declare function x(
+  type: 'A',
+  value: { readonly a: number; readonly b?: string | undefined },
+): number;
+declare function x(type: string, value?: object): object;
+
+// Plain TypeScript picks the first overload for inline (fresh) object
+// literals, with or without the optional `b`.
+tsExpectTypeOf(x('A', { a: 1 })).toEqualTypeOf<number>();
+tsExpectTypeOf(x('A', { a: 1, b: '2' })).toEqualTypeOf<number>();
+
+// The same invocations as glint emits them for the `hash` keyword: a discarded
+// reference to the keyword (for hover docs), then a fresh object literal.
+tsExpectTypeOf(x('A', (noop(Globals.hash), { a: 1 }))).toEqualTypeOf<number>();
+tsExpectTypeOf(x('A', (noop(Globals.hash), { a: 1, b: '2' }))).toEqualTypeOf<number>();
+
+<template>
+  {{x "A" (hash a=1)}}
+  {{x "A" (hash a=1 b="2")}}
+  {{x "A" (emberHash a=1)}}
+  {{x "A" (emberHash a=1 b="2")}}
+
+  {{expectTypeOf (x "A" (hash a=1)) to.beNumber}}
+  {{expectTypeOf (x "A" (emberHash a=1)) to.beNumber}}
+</template>


### PR DESCRIPTION
Fixes #1180, improved types for hash so that narrowing function calls can work