### PR TITLE
Fix #1186: restore context-based `this` for expression templates outside classes

### DIFF
--- a/packages/ember-tsc/src/transform/template/inlining/index.ts
+++ b/packages/ember-tsc/src/transform/template/inlining/index.ts
@@ -11,32 +11,50 @@ export type CorrelatedSpansResult = {
 };
 
 /**
- * Given an AST node for an embedded template, determines whether it's embedded
- * within a class in such a way that that class should be treated as its backing
- * value.
+ * How the `{{this}}` of an embedded template should be bound, based on where
+ * the template sits in the surrounding module:
  *
- * Only a class-member `<template>` (the class's own template) is backed by the
- * class; the environment transform rewrites that form into a static block, so
- * we look for one on the way up. A template anywhere else inside a class —
- * a field initializer, a method body, a heritage clause — is an expression
- * template (RFC 931 implicit form): a template-only component whose `this` is
- * the *lexical* `this` of its position, captured like an arrow function's.
- * Treating those as class-backed emitted `templateForBackingValue(this, ...)`
- * into positions where `this` is not the class constructor, which broke
- * `Context` inference and silently typed the template's `{{this}}` as `any`
- * (#1182). Expression templates instead emit an arrow whose body references
- * `this` directly — see `templateExpression` in `template-to-typescript.ts`.
+ * - `'backing-class'`: a class-member `<template>` (the class's own template).
+ *   The environment transform rewrites that form into a static block, so we
+ *   look for one on the way up. Emitted as `templateForBackingValue(this, ...)`;
+ *   `{{this}}` is the class instance, reached through the template context.
+ *
+ * - `'lexical'`: an expression template (RFC 931 implicit form) inside a class
+ *   member — a field initializer or method body. Its `this` is the *lexical*
+ *   `this` of its position, captured like an arrow function's, so `{{this}}`
+ *   in a field initializer sees the enclosing instance. Treating these as
+ *   class-backed emitted `templateForBackingValue(this, ...)` into positions
+ *   where `this` is not the class constructor, which broke `Context` inference
+ *   and silently typed the template's `{{this}}` as `any` (#1182).
+ *
+ * - `'context'`: an expression template anywhere else — module scope, a call
+ *   argument, a heritage clause. `{{this}}` stays on the template context
+ *   (`__glintRef__.this`) so that consumers which assign a context type to a
+ *   template-only value keep working: `typeTest(context, <template>...)` from
+ *   `@glint/type-test` contextually types `Context['this']` through the
+ *   expected type of the `templateExpression(...)` expression, and emitting
+ *   the module's lexical `this` (type `undefined`) instead severed that and
+ *   broke every such type test (#1186).
  */
-export function isEmbeddedInClass(ts: TSLib, node: ts.Node): boolean {
+export type TemplateThisBinding = 'backing-class' | 'lexical' | 'context';
+
+/**
+ * Given an AST node for an embedded template, determines how the template's
+ * `{{this}}` should be bound. See {@link TemplateThisBinding}.
+ */
+export function templateThisBinding(ts: TSLib, node: ts.Node): TemplateThisBinding {
   let current: ts.Node | null = node;
   do {
     if (ts.isClassStaticBlockDeclaration(current)) {
-      return true;
+      return 'backing-class';
     }
-    if (ts.isClassLike(current) || ts.isHeritageClause(current)) {
-      return false;
+    if (ts.isHeritageClause(current)) {
+      return 'context';
+    }
+    if (ts.isClassLike(current)) {
+      return 'lexical';
     }
   } while ((current = current.parent));
 
-  return false;
+  return 'context';
 }

--- a/packages/ember-tsc/src/transform/template/inlining/tagged-strings.ts
+++ b/packages/ember-tsc/src/transform/template/inlining/tagged-strings.ts
@@ -9,7 +9,7 @@ import { GlintEnvironment } from '../../../config/index.js';
 import { assert, TSLib } from '../../util.js';
 import { templateToTypescript } from '../template-to-typescript.js';
 import { Directive, Range, SourceFile, TransformError } from '../transformed-module.js';
-import { CorrelatedSpansResult, isEmbeddedInClass, PartialCorrelatedSpan } from './index.js';
+import { CorrelatedSpansResult, templateThisBinding, PartialCorrelatedSpan } from './index.js';
 
 export function calculateTaggedTemplateSpans(
   ts: TSLib,
@@ -92,6 +92,8 @@ export function calculateTaggedTemplateSpans(
       (name) => name in keywordSpecialForms || !(name in importedBindings),
     );
 
+    let thisBinding = templateThisBinding(ts, node);
+
     let transformedTemplate = templateToTypescript(template, {
       typesModule: typesModule,
       meta,
@@ -99,7 +101,8 @@ export function calculateTaggedTemplateSpans(
       globals: effectiveGlobals,
       embeddingSyntax,
       specialForms,
-      backingValue: isEmbeddedInClass(ts, node) ? 'this' : undefined,
+      backingValue: thisBinding === 'backing-class' ? 'this' : undefined,
+      lexicalThis: thisBinding === 'lexical',
       useJsDoc: environment.isUntypedScript(script.filename),
     });
 

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -32,6 +32,7 @@ export type TemplateToTypescriptOptions = {
   meta?: GlintEmitMetadata | undefined;
   globals?: Array<string> | undefined;
   backingValue?: string;
+  lexicalThis?: boolean;
   preamble?: Array<string>;
   embeddingSyntax?: EmbeddingSyntax;
   useJsDoc?: boolean;
@@ -66,6 +67,7 @@ export function templateToTypescript(
     globals,
     meta,
     backingValue,
+    lexicalThis = false,
     preamble = [],
     embeddingSyntax = { prefix: '', suffix: '' },
     specialForms = {},
@@ -150,12 +152,12 @@ export function templateToTypescript(
       if (backingValue) {
         mapper.text(`.templateForBackingValue(${backingValue}, function(__glintRef__`);
       } else {
-        // An expression template (RFC 931 implicit form) captures the lexical
-        // `this` of the position it appears in, the way an arrow function
-        // does — a class field initializer sees the enclosing instance, module
-        // scope sees `undefined`. Emitting an arrow (and raw `this` for
-        // `{{this.*}}` paths — see `emitPathContents`) lets TypeScript apply
-        // exactly those semantics. (#1182)
+        // An expression template (RFC 931 implicit form) inside a class member
+        // captures the lexical `this` of its position, the way an arrow
+        // function does — a class field initializer sees the enclosing
+        // instance. Emitting an arrow (and, when `lexicalThis` is set, raw
+        // `this` for `{{this.*}}` paths — see `emitPathContents`) lets
+        // TypeScript apply exactly those semantics. (#1182)
         mapper.text(`.templateExpression((__glintRef__`);
       }
 
@@ -1503,11 +1505,17 @@ export function templateToTypescript(
     function emitPathContents(parts: string[], start: number, kind: PathKind): void {
       if (kind === 'this') {
         let thisStart = template.indexOf('this', start);
-        // A class-member template's `this` is the backing class instance,
-        // reached through the template context. An expression template's
-        // `this` is the *lexical* `this` of the template's position (its body
-        // is emitted as an arrow function), so we reference it directly.
-        if (backingValue) {
+        // An expression template inside a class member (`lexicalThis`) sees
+        // the *lexical* `this` of its position (its body is emitted as an
+        // arrow function), so we reference it directly (#1182). Everywhere
+        // else `this` comes from the template context: a class-member
+        // template's context holds the backing class instance, and an
+        // expression template elsewhere (module scope, a call argument) gets
+        // its context from contextual typing — e.g. `typeTest` from
+        // `@glint/type-test` assigns `Context['this']` through the expected
+        // type of the expression, which raw lexical `this` (type `undefined`
+        // at module scope) would sever (#1186).
+        if (!lexicalThis) {
           mapper.text('__glintRef__.');
         }
         mapper.identifier('this', thisStart);

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -36,14 +36,18 @@ describe('Transform: rewriteModule', () => {
     // (the authoring format compiles it to a template-only component), so it
     // must emit `templateExpression` — NOT `templateForBackingValue(this)`,
     // which breaks context inference in field position and silently types the
-    // template's `{{this}}` as `any`. (#1182)
+    // template's `{{this}}` as `any`. (#1182) Its `{{this.*}}` paths reference
+    // the lexical `this` of the field position (the enclosing instance)
+    // directly rather than going through the template context.
     test('with a class field template', () => {
       let script = {
         filename: 'test.gts',
         contents: stripIndent`
           import Component from '@glimmer/component';
           export default class MyComponent extends Component {
-            private readonly X = <template>hi</template>;
+            private readonly index = 10;
+
+            private readonly X = <template>{{this.index}}</template>;
 
             <template><this.X /></template>
           }
@@ -56,7 +60,10 @@ describe('Transform: rewriteModule', () => {
       expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
         "import Component from '@glimmer/component';
         export default class MyComponent extends Component {
+          private readonly index = 10;
+
           private readonly X = ({} as typeof import("@glint/ember-tsc/-private/dsl")).templateExpression((__glintRef__, __glintDSL__: typeof import("@glint/ember-tsc/-private/dsl")) => {
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(this.index)());
         __glintRef__; __glintDSL__;
         });
 
@@ -67,6 +74,31 @@ describe('Transform: rewriteModule', () => {
         __glintRef__; __glintDSL__;
         }) }
         }"
+      `);
+    });
+
+    // An expression template at module scope has no meaningful lexical `this`,
+    // so `{{this.*}}` stays on the template context (`__glintRef__.this`).
+    // That's what lets consumers assign a context type to the template through
+    // contextual typing — `typeTest(context, <template>...)` from
+    // `@glint/type-test` types `{{this}}` as the given context. Emitting the
+    // module's lexical `this` (type `undefined`) instead broke that. (#1186)
+    test('with a module-scope expression template referencing {{this}}', () => {
+      let script = {
+        filename: 'test.gts',
+        contents: stripIndent`
+          const ModuleScoped = <template>{{this.message}}</template>;
+        `,
+      };
+
+      let transformedModule = rewriteModule(ts, { script }, env);
+
+      expect(transformedModule?.errors).toEqual([]);
+      expect(transformedModule?.transformedContents).toMatchInlineSnapshot(`
+        "const ModuleScoped = ({} as typeof import("@glint/ember-tsc/-private/dsl")).templateExpression((__glintRef__, __glintDSL__: typeof import("@glint/ember-tsc/-private/dsl")) => {
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.this.message)());
+        __glintRef__; __glintDSL__;
+        });"
       `);
     });
 

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -350,7 +350,7 @@ describe('Transform: rewriteTemplate', () => {
         let specialForms = { testYield: 'yield' } as const;
 
         expect(templateBody(template, { specialForms })).toMatchInlineSnapshot(
-          `"__glintDSL__.yieldToBlock(__glintRef__, "default")(123, this.message);"`,
+          `"__glintDSL__.yieldToBlock(__glintRef__, "default")(123, __glintRef__.this.message);"`,
         );
       });
 
@@ -710,7 +710,7 @@ describe('Transform: rewriteTemplate', () => {
           let template = '{{this}}';
 
           expect(templateBody(template)).toMatchInlineSnapshot(
-            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(this)());"`,
+            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.this)());"`,
           );
         });
 
@@ -718,7 +718,7 @@ describe('Transform: rewriteTemplate', () => {
           let template = '{{this.foo.bar}}';
 
           expect(templateBody(template)).toMatchInlineSnapshot(
-            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(this.foo?.bar)());"`,
+            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.this.foo?.bar)());"`,
           );
         });
 
@@ -726,7 +726,20 @@ describe('Transform: rewriteTemplate', () => {
           let template = '{{this.foo-bar}}';
 
           expect(templateBody(template)).toMatchInlineSnapshot(
-            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(this["foo-bar"])());"`,
+            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.this["foo-bar"])());"`,
+          );
+        });
+
+        // An expression template inside a class member (e.g. a field
+        // initializer) sees the lexical `this` of its position, so `{{this.*}}`
+        // references `this` directly rather than the template context (#1182).
+        // Everywhere else, `this` must stay on `__glintRef__` so contextual
+        // typing (e.g. `typeTest` from `@glint/type-test`) can supply it (#1186).
+        test('`this` path with lexicalThis', () => {
+          let template = '{{this.foo}}';
+
+          expect(templateBody(template, { lexicalThis: true })).toMatchInlineSnapshot(
+            `"__glintDSL__.emitContent(__glintDSL__.resolveOrReturn(this.foo)());"`,
           );
         });
 
@@ -1206,7 +1219,7 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
-        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(this.foo)({ 
+        const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(__glintRef__.this.foo)({ 
         arg: "hello", ...__glintDSL__.NamedArgsMarker }));
         }"
       `);

--- a/test-packages/ts-gts-7-1-app/src/class-field-template.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/class-field-template.test.gts
@@ -2,13 +2,13 @@ import Component from '@glimmer/component';
 import { expectTypeOf, to } from '@glint/type-test';
 
 // Regression guard for https://github.com/typed-ember/glint/issues/1182
-// A `<template>` in expression position (RFC 931 implicit form) captures the
-// lexical `this` of wherever it appears, the way an arrow function does. In a
-// class field initializer that's the enclosing instance, so `{{this.index}}`
-// inside `X` refers to MyComponent's `index`. Glint used to emit these as if
-// they were the class's own template (`templateForBackingValue(this, ...)`),
-// which broke context inference in field position and silently typed the
-// template's `this` as `any`.
+// A `<template>` in expression position (RFC 931 implicit form) inside a class
+// member captures the lexical `this` of its position, the way an arrow
+// function does. In a class field initializer that's the enclosing instance,
+// so `{{this.index}}` inside `X` refers to MyComponent's `index`. Glint used
+// to emit these as if they were the class's own template
+// (`templateForBackingValue(this, ...)`), which broke context inference in
+// field position and silently typed the template's `this` as `any`.
 export default class MyComponent extends Component {
   private readonly index = 10;
 
@@ -23,10 +23,12 @@ export default class MyComponent extends Component {
   </template>
 }
 
-// At module scope the lexical `this` of an ES module is `undefined`, and
-// property access on it must be an error rather than silently `any`.
+// At module scope there is no meaningful lexical `this`, so an expression
+// template's `this` comes from the template context instead: `void` unless a
+// consumer assigns one through contextual typing, the way `typeTest` from
+// `@glint/type-test` does (#1186). Property access on the unassigned context
+// must be an error rather than silently `any`.
 export const ModuleScoped = <template>
-  {{expectTypeOf this to.beUndefined}}
-  {{! @glint-expect-error -- module-scope `this` is `undefined`, so it has no properties }}
+  {{! @glint-expect-error -- module-scope `this` has no assigned context, so it has no properties }}
   {{this.index}}
 </template>;

--- a/test-packages/ts-gts-7-1-app/src/type-test-context.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/type-test-context.test.gts
@@ -1,0 +1,31 @@
+import { typeTest } from '@glint/type-test';
+
+// Regression guard for https://github.com/typed-ember/glint/issues/1186
+//
+// `typeTest(context, template)` assigns the given context as the template's
+// `this` type: the expected type of the `<template>` argument contextually
+// types the `Context` of the emitted `templateExpression(...)` call, so
+// `{{this.*}}` paths (emitted as `__glintRef__.this.*`) see the context type.
+// Glint 1.8.7 briefly emitted the module's lexical `this` (type `undefined`)
+// for module-scope expression templates instead, which severed that link and
+// broke every context-driven type test with `Object is possibly 'undefined'`.
+typeTest(
+  {
+    int: undefined as unknown as number,
+    message: 'hello',
+  },
+  <template>
+    {{@expectTypeOf this.int @to.beNumber}}
+    {{@expectTypeOf this.message @to.beString}}
+
+    {{! @glint-expect-error: no such property on the given context }}
+    {{@expectTypeOf this.missing @to.beAny}}
+  </template>,
+);
+
+// The context-less overload types `this` as `null`.
+typeTest(
+  <template>
+    {{@expectTypeOf this @to.beNull}}
+  </template>,
+);


### PR DESCRIPTION
Fixes #1186

## What broke

#1185 (shipped in `@glint/ember-tsc` 1.8.7) made **all** expression templates emit their `{{this.*}}` paths as the raw lexical `this` of their position. That's correct inside a class member — a field initializer's `this` is the enclosing instance, which is what #1182 needed — but at module scope an ES module's `this` has type `undefined`.

`typeTest(context, <template>...)` from `@glint/type-test` works by contextual typing: the expected `TypeTestTemplate<T>` parameter type flows into the `Context` type argument of the emitted `templateExpression(...)` call, so `__glintRef__.this` picks up `T`. Emitting the module's lexical `this` instead severed that link, so every context-driven type test failed with `Object is possibly 'undefined'`.

## The fix

Classify template placement three ways instead of two (`templateThisBinding`, replacing `isEmbeddedInClass`):

- **`backing-class`** — a class-member `<template>` (rewritten into a static block): `templateForBackingValue(this, ...)`, `{{this}}` via `__glintRef__.this`. Unchanged.
- **`lexical`** — an expression template inside a class member (field initializer, method body): `{{this.*}}` emits raw lexical `this`, preserving the #1182 fix.
- **`context`** — an expression template anywhere else (module scope, call arguments, heritage clauses): `{{this}}` stays on `__glintRef__.this` so contextual typing can supply the context type, restoring the pre-1.8.7 behavior that `typeTest` depends on.

## Tests

- Transform unit tests for both emit shapes (`lexicalThis` option), plus a `rewriteModule` snapshot for a module-scope `{{this.*}}` template.
- The issue's repro added as `test-packages/ts-gts-7-1-app/src/type-test-context.test.gts`, covering both `typeTest` overloads. Verified it reproduces the exact `Object is possibly 'undefined'` errors against current `main` and passes with this fix.
- Updated the `ModuleScoped` assertions in `class-field-template.test.gts` to the restored semantics (`this` is the unassigned template context rather than `undefined`; property access on it is still an error, not silently `any`).

Why no existing test caught this: `packages/type-test/__tests__/classic.test.ts` uses `hbs`, which the transform no longer processes at all, and `fccts.test.gts` never uses `typeTest` with a context. (The type-test package's own `__tests__` also can't host a `<template>` test — it has no `ember-source`, so `@ember/component/template-only` doesn't resolve and the DSL's return type degrades to `any` — hence the regression test living in `ts-gts-7-1-app`.)

The one CI-adjacent failure I saw locally — the VS Code smoke test "basic diagnostics for gts file" timing out waiting for the TS plugin to activate — fails identically on a clean `main` checkout, so it's unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)