### PR TITLE
Fix #1147: emit `fn` as a comma pair so inline `(fn ...)` survives nested inference

### DIFF
--- a/packages/ember-tsc/src/config/types.cts
+++ b/packages/ember-tsc/src/config/types.cts
@@ -46,6 +46,7 @@ export type GlintSpecialForm =
   | 'object-literal'
   | 'array-literal'
   | 'bind-invokable'
+  | 'bind-positional'
   | '==='
   | '!=='
   | '&&'

--- a/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts
+++ b/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/index.ts
@@ -123,11 +123,26 @@ export default function emberTemplateImportsEnvironment(
           // does not (#1180). `array` intentionally stays a helper call: its
           // `const` signature preserves literal element types at non-contextual
           // positions (see `array-keyword-preserve-literals.test.gts`).
+          //
+          // The RFC 470 `fn` keyword needs a special form for a subtler
+          // reason: its `FnHelper` type is overloaded (one overload per
+          // bound-argument arity), and TypeScript's nested-call re-inference
+          // only handles single-signature callees, so an inline `(fn ...)`
+          // inside another invocation's arguments (most visibly
+          // `{{component Foo onChange=(fn ...)}}`) collapsed the outer call's
+          // entire inference (#1147). The `bind-positional` form emits a
+          // comma pair — the real `fn` call for validation, single-signature
+          // `bindPositional` for the resulting type. See `bindPositional` in
+          // `types/-private/dsl/index.d.ts`. (The `@ember/helper` import
+          // below gets the same treatment unconditionally; this entry is
+          // gated with the other built-in globals so a pre-7.1 project's own
+          // `fn` import from elsewhere isn't hijacked.)
           ...(hasEmber71BuiltIns()
             ? ({
                 eq: '===',
                 neq: '!==',
                 hash: 'object-literal',
+                fn: 'bind-positional',
               } satisfies GlintSpecialFormConfig['globals'])
             : {}),
           ...additionalGlobalSpecialForms,
@@ -136,6 +151,7 @@ export default function emberTemplateImportsEnvironment(
           '@ember/helper': {
             array: 'array-literal',
             hash: 'object-literal',
+            fn: 'bind-positional',
             ...additionalSpecialForms.imports?.['@ember/helper'],
           },
           ...additionalSpecialForms.imports,

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -293,6 +293,10 @@ export function templateToTypescript(
           emitBindInvokableExpression(formInfo, node, position);
           break;
 
+        case 'bind-positional':
+          emitBindPositionalExpression(formInfo, node, position);
+          break;
+
         case '===':
         case '!==':
           emitBinaryOperatorExpression(formInfo, node);
@@ -414,6 +418,51 @@ export function templateToTypescript(
           mapper.text(')');
         }
       });
+    }
+
+    function emitBindPositionalExpression(
+      formInfo: SpecialFormInfo,
+      node: AST.MustacheStatement | AST.SubExpression,
+      position: InvokePosition,
+    ): void {
+      // `wideVerification` (see #1168): several of the diagnostics this emit
+      // exists to surface anchor on synthetic generated text — arity errors
+      // point at the emitted callee, and assignability errors at the whole
+      // comma expression — and would otherwise be silently dropped by Volar
+      // for want of a covering verification mapping.
+      const wideVerification = true;
+      mapper.forNode(
+        node,
+        () => {
+          if (position === 'top-level') {
+            mapper.text('__glintDSL__.emitContent(');
+          }
+
+          // Two-stage comma expression, like `bind-invokable` above: the real
+          // helper call validates the arguments against the helper's arity
+          // overloads (result discarded, errors mapped) — including misuse
+          // like zero arguments or named arguments, which is why there are no
+          // arity asserts here — while the single-signature `bindPositional`
+          // computes the partially-applied type (result used). The single
+          // signature is what lets the result survive when this expression
+          // sits inside another generic call's arguments — TypeScript's
+          // nested-call re-inference gives up on overloaded callees,
+          // collapsing the outer call's inference (#1147).
+          mapper.text('(__glintDSL__.resolve(');
+          emitExpression(node.path);
+          mapper.text(')(');
+          emitArgs(node.params, node.hash);
+          mapper.text('), __glintDSL__.bindPositional(');
+          emitArgs(node.params, node.hash);
+          mapper.text('))');
+
+          if (position === 'top-level') {
+            mapper.text(')');
+          }
+        },
+        undefined,
+        wideVerification,
+      );
     }
 
     function emitObjectExpression(

--- a/packages/ember-tsc/types/-private/dsl/index.d.ts
+++ b/packages/ember-tsc/types/-private/dsl/index.d.ts
@@ -48,3 +48,48 @@ export declare function templateExpression<
   f: (__glintRef__: Context, __glintDSL__: never) => void,
 ): TemplateOnlyComponent<never> &
   (abstract new () => InvokableInstance<Signature> & HasContext<Context>);
+
+import { Mut } from '../intrinsics/mut';
+
+/*
+ * Computes the type of `{{fn ...}}` in a way that survives nested inference
+ * (#1147). The transform emits the `fn` keyword as a comma expression,
+ * mirroring the `bindInvokable` treatment of `{{component}}` (#1068):
+ *
+ *     {{foo bar=(fn f a)}}
+ *
+ * becomes
+ *
+ *     foo({ bar: (resolve(fn)(f, a), bindPositional(f, a)) })
+ *
+ * The real `resolve(fn)(...)` call validates the arguments against
+ * `FnHelper`'s arity overloads (with errors mapped into the template), while
+ * `bindPositional` — whose result the comma expression forwards — computes the
+ * partially-applied type from a SINGLE call signature.
+ *
+ * The single signature is what matters: when a call to an *overloaded* generic
+ * function appears inside another generic call's arguments, TypeScript's
+ * nested-call re-inference (`SkipGenericFunctions`) only handles callees with
+ * exactly one call signature. `FnHelper`'s nine overloads made TypeScript
+ * give up on ALL of the outer call's type parameters, so anything like
+ * `{{component Foo onChange=(fn ...)}}` collapsed to
+ * `Invokable<(...args: unknown[]) => unknown>`.
+ *
+ * Because argument validation is the keyword call's job, this signature is
+ * deliberately lenient: a mismatched bind yields `never` here and a real,
+ * mapped error from the keyword call. The trade-off relative to invoking
+ * `FnHelper` directly is that a generic `f` is instantiated rather than kept
+ * generic (`fn identity "hi"` types as `() => unknown`, not `() => string`)
+ * — the conditional return can't propagate signature genericity the way the
+ * overloads' direct decomposition can.
+ */
+export declare function bindPositional<F, Bound extends unknown[]>(
+  f: F,
+  ...bound: Bound
+): F extends Mut<infer T>
+  ? Bound extends []
+    ? (value: T) => void
+    : () => void
+  : F extends (...args: [...Bound, ...infer Rest]) => infer Ret
+    ? (...rest: Rest) => Ret
+    : never;

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -166,6 +166,42 @@ describe('Transform: rewriteTemplate', () => {
       });
     });
 
+    // The `fn` keyword emits as a two-stage comma expression: the real
+    // (overloaded) helper call validates the arguments, while the
+    // single-signature `bindPositional` supplies the resulting type. Emitting
+    // the overloaded call alone made any inline `(fn ...)` inside another
+    // generic call's arguments collapse that call's entire inference —
+    // TypeScript's nested-call re-inference only handles single-signature
+    // callees. (#1147)
+    describe('{{fn}} (bind-positional)', () => {
+      test('in top-level position', () => {
+        let template = '{{testFn foo 123}}';
+        let specialForms = { testFn: 'bind-positional' } as const;
+
+        expect(templateBody(template, { specialForms, globals: ['testFn'] })).toMatchInlineSnapshot(
+          `"__glintDSL__.emitContent((__glintDSL__.resolve(__glintDSL__.Globals.testFn)(foo, 123), __glintDSL__.bindPositional(foo, 123)));"`,
+        );
+      });
+
+      test('in a subexpression inside another invocation', () => {
+        let template = '{{someHelper (testFn foo 123)}}';
+        let specialForms = { testFn: 'bind-positional' } as const;
+
+        expect(templateBody(template, { specialForms, globals: ['testFn'] })).toMatchInlineSnapshot(
+          `"__glintDSL__.emitContent(__glintDSL__.resolve(someHelper)((__glintDSL__.resolve(__glintDSL__.Globals.testFn)(foo, 123), __glintDSL__.bindPositional(foo, 123))));"`,
+        );
+      });
+
+      test('as an imported (non-global) binding', () => {
+        let template = '{{testFn foo}}';
+        let specialForms = { testFn: 'bind-positional' } as const;
+
+        expect(templateBody(template, { specialForms, globals: [] })).toMatchInlineSnapshot(
+          `"(__glintDSL__.noop(testFn), __glintDSL__.emitContent((__glintDSL__.resolve(testFn)(foo), __glintDSL__.bindPositional(foo))));"`,
+        );
+      });
+    });
+
     describe('{{if}}', () => {
       test('without an alternate', () => {
         let template = '{{testIf @foo "ok"}}';

--- a/test-packages/ts-gts-7-1-app/src/fn-in-nested-args.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/fn-in-nested-args.test.gts
@@ -1,0 +1,75 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TOC } from '@ember/component/template-only';
+import { fn } from '@ember/helper';
+import { hash } from '@ember/helper';
+import type { WithBoundArgs } from '@glint/template';
+import { expectTypeOf, to } from '@glint/type-test';
+
+// Regression guard for https://github.com/typed-ember/glint/issues/1147
+//
+// An inline `(fn ...)` call inside another invocation's arguments used to
+// collapse the outer call's entire type inference: `FnHelper` is overloaded
+// (one overload per bound-argument arity), and TypeScript's nested-call
+// re-inference only handles single-signature callees, so
+// `{{component Foo onChange=(fn ...)}}` produced
+// `Invokable<(...args: unknown[]) => unknown>` instead of the bound component
+// type. The transform now emits `fn` as a comma pair — the real (overloaded)
+// call for argument validation, single-signature `bindPositional` for the
+// resulting type — so the outer inference sees only a resolved value.
+
+const MyComponent: TOC<{
+  Args: (
+    | { value?: Date | null; onChange?: (date: Date) => void }
+    | { range?: [Date, Date]; onRangeChange?: (range: [Date, Date]) => void }
+  ) & {
+    otherArgument: boolean;
+  };
+}> = <template></template>;
+
+const someDate: Date | null | undefined = new Date();
+
+function onChangeWith(cb: () => void, date: Date): void {
+  void cb;
+  void date;
+}
+
+function noop(): void {}
+
+<template>
+  {{#let
+    (component
+      MyComponent
+      otherArgument=true
+      value=someDate
+      onChange=(fn onChangeWith noop)
+    )
+    as |CwithFn|
+  }}
+    {{yield (hash SomeComponent=CwithFn)}}
+  {{/let}}
+</template> satisfies TemplateOnlyComponent<{
+  Blocks: {
+    default: [
+      {
+        SomeComponent: WithBoundArgs<typeof MyComponent, 'value' | 'onChange'>;
+      },
+    ];
+  };
+}>;
+
+// Direct `{{fn}}` type behavior away from nested-argument positions, plus the
+// `(fn (mut ...))` forms that FnHelper's Mut overloads validate and
+// `bindPositional`'s Mut branch types.
+const state = { count: 0 };
+
+const directForms = <template>
+  {{expectTypeOf (fn onChangeWith) to.equalTypeOf onChangeWith}}
+  {{expectTypeOf (fn onChangeWith noop) to.beAssignableToTypeOf someDateHandler}}
+  {{expectTypeOf (fn (mut state.count)) to.equalTypeOf numberSetter}}
+  {{expectTypeOf (fn (mut state.count) 5) to.equalTypeOf thunk}}
+</template>;
+void directForms;
+
+declare const someDateHandler: (date: Date) => void;
+declare const numberSetter: (value: number) => void;
+declare const thunk: () => void;

--- a/test-packages/ts-gts-7-1-app/src/globals/fn.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/fn.gts
@@ -3,12 +3,22 @@ const handler = (event: MouseEvent): void => {
   void event;
 };
 
+const greetOnClick = (name: string, event: MouseEvent): void => {
+  void name;
+  void event;
+};
+
 const greet = (name: string, exclamation: string): string =>
   `Hello, ${name}${exclamation}`;
 void greet;
 
 <template>
   {{! ---- (RFC 470) fn helper---- }}
+  <button {{on "click" (fn greetOnClick "world")}} type="button">noop</button>
+
+  {{! @glint-expect-error -- binds a two-string function where the bound value must be a MouseEvent.
+      This mismatch used to be silently swallowed when the fn call sat inside another call's
+      arguments; the bind-positional emit surfaces it. (#1147) }}
   <button {{on "click" (fn handler greet)}} type="button">noop</button>
 
   {{! @glint-expect-error -- requires two arguments}}


### PR DESCRIPTION
Fixes #1147

## Root cause

`FnHelper` is overloaded — one overload per bound-argument arity, plus two `Mut` overloads. When a call to an **overloaded** generic function appears inside another generic call's arguments, TypeScript's nested-call re-inference (`checkExpression`'s `SkipGenericFunctions` path) only handles callees with exactly one call signature. With `fn` it gives up, and **all** of the outer call's type parameters lose inference. That's why `{{component Foo onChange=(fn ...)}}` collapsed to `Invokable<(...args: unknown[]) => unknown>` — `bindInvokable`'s `Args`/`T`/`GivenNamed` all fell back to their constraints.

Notably this is **not** union-Args-specific (plain signatures collapse the same way), and it isn't caused by the issue's particular `fn` usage — valid `fn` calls collapse identically. A single-signature generic callee (e.g. an `identity` helper) inline in the same position works fine, which pins the blame on the overloads.

## The fix

`fn` gets a `bind-positional` special form that emits a two-stage comma expression, directly mirroring `bind-invokable`'s treatment of the `{{component}}`/`{{helper}}`/`{{modifier}}` keywords from #1068:

```ts
// {{foo bar=(fn f a)}}
foo({ bar: (resolve(fn)(f, a), bindPositional(f, a)) })
```

- The real `resolve(fn)(...)` call validates the arguments against `FnHelper`'s overloads (result discarded, errors mapped into the template). `FnHelper` and `Mut` are untouched, so direct consumers see no change.
- The new single-signature `bindPositional` computes the partially-applied type via variadic-tuple decomposition (`F extends (...args: [...Bound, ...infer Rest]) => infer Ret`), with a `Mut<T>` branch covering `(fn (mut x))` / `(fn (mut x) val)`. Being a single signature, it survives the nested re-inference, so the outer call sees a resolved value.

The global keyword entry is gated with the other 7.1 built-ins (`eq`/`neq`/`hash`) so a pre-7.1 project's own `fn` import from elsewhere isn't hijacked; the `@ember/helper` import mapping is unconditional.

### `wideVerification`

The emit opts into `wideVerification` (#1168): the diagnostics this form exists to surface anchor on synthetic generated text — arity errors point at the emitted callee, assignability errors at the whole comma expression — and were otherwise silently dropped by Volar for want of a covering verification mapping.

This newly surfaces some previously-swallowed errors. The existing smoke usage in `globals/fn.gts` — `{{on "click" (fn handler greet)}}` — turns out to bind a two-string function to a `MouseEvent` parameter and was only passing because the error was swallowed; it's now covered by a `@glint-expect-error` documenting exactly that. (The same swallowing is why the workaround in #1147 "worked" despite binding `noop` to a `Date` parameter — worth an eye when reviewing.)

## Trade-off

In template positions, a generic `f` is instantiated rather than kept generic: `(fn identity \"hi\")` types as `() => unknown`, not `() => string` — a conditional return type can't propagate signature genericity the way the overloads' direct decomposition can. I tried the alternatives first: a single-signature `FnHelper` rewrite loses call-site validation *and* the generic preservation that `fn.test.ts` locks in for direct consumers, and a tuple-split signature (`(...args: [...Bound, ...Rest]) => Ret` as the helper itself) doesn't survive nested inference at all. The comma pair keeps direct/`resolve(fn)` behavior byte-identical and only trades generic propagation inside templates, where the status quo for the affected positions was total collapse.

## Tests

- `fn-in-nested-args.test.gts`: the issue's repro (adjusted to a *valid* `fn` bind) asserted against `WithBoundArgs<typeof MyComponent, 'value' | 'onChange'>` — this exact assertion produces `Invokable<(...args: unknown[]) => unknown>` on `main` — plus direct-position `expectTypeOf` checks and both `(fn (mut ...))` forms.
- Transform unit tests for the comma-pair emit in top-level, subexpression, and imported-binding positions.
- `globals/fn.gts` updated as described above, with a valid RFC 470 usage added.

All package typechecks, vitest suites, and lint pass. The VS Code smoke test ("Timed out waiting for TS Plugin to activate") fails identically on a clean `main` checkout in my environment — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)