### PR TITLE
Report usage of named blocks missing from a component's signature

### DIFF
--- a/packages/ember-tsc/src/transform/template/map-template-contents.ts
+++ b/packages/ember-tsc/src/transform/template/map-template-contents.ts
@@ -111,6 +111,20 @@ export type Mapper = {
     callback: () => void,
     codeFeaturesForNode?: CodeInformation,
   ): void;
+
+  /**
+   * Like `forNode`, but anchored to an explicit range in the original source
+   * rather than an AST node's own span. Useful when the natural anchor is a
+   * sub-token that @glimmer/syntax doesn't model as a node, such as a named
+   * block's name.
+   */
+  forRange(
+    range: Range,
+    source: MappingSource,
+    callback: () => void,
+    codeFeaturesForNode?: CodeInformation,
+    wideVerification?: boolean,
+  ): void;
 };
 
 type LocalDirective = Omit<Directive, 'source'>;
@@ -362,6 +376,16 @@ export function mapTemplateContents(
       codeFeaturesForNode?: CodeInformation,
     ) {
       captureMapping(mapper.rangeForNode(node, span), node, false, callback, codeFeaturesForNode);
+    },
+
+    forRange(
+      range: Range,
+      source: MappingSource,
+      callback: () => void,
+      codeFeaturesForNode?: CodeInformation,
+      wideVerification?: boolean,
+    ) {
+      captureMapping(range, source, false, callback, codeFeaturesForNode, wideVerification);
     },
 
     error(message: string, location: Range) {

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -2,7 +2,12 @@ import { AST } from '@glimmer/syntax';
 import { GlintEmitMetadata, GlintSpecialForm } from '@glint/ember-tsc/config-types';
 import { assert, unreachable } from '../util.js';
 import { TextContent } from './glimmer-ast-mapping-tree.js';
-import { EmbeddingSyntax, mapTemplateContents, RewriteResult } from './map-template-contents.js';
+import {
+  EmbeddingSyntax,
+  Identifier,
+  mapTemplateContents,
+  RewriteResult,
+} from './map-template-contents.js';
 import ScopeStack from './scope-stack.js';
 
 const SPLATTRIBUTES = '...attributes';
@@ -964,11 +969,13 @@ export function templateToTypescript(
         return {
           type: 'named',
           children: node.children.filter(
-            // Filter out ignorable content between named blocks
-            (child): child is NamedBlockChild => child.type === 'ElementNode',
-            //  ||
-            //   child.type === 'CommentStatement' ||
-            //   child.type === 'MustacheCommentStatement',
+            // Filter out ignorable content between named blocks, but keep
+            // comments: they may carry `@glint-expect-error`/`@glint-ignore`
+            // directives that apply to the named block that follows them.
+            (child): child is NamedBlockChild =>
+              child.type === 'ElementNode' ||
+              child.type === 'CommentStatement' ||
+              child.type === 'MustacheCommentStatement',
           ),
         };
       } else {
@@ -1413,8 +1420,31 @@ export function templateToTypescript(
         mapper.identifier(makeJSSafe(param), start, param.length);
       }
 
-      mapper.text('] = __glintY__.blockParams');
-      emitPropertyAccesss(name, { offset: nameOffset, synthetic: true });
+      mapper.text('] = ');
+
+      // When a block name isn't declared in the component's signature, TS
+      // anchors its "Property 'foo' does not exist" diagnostic on the whole
+      // `__glintY__.blockParams["foo"]` element access, whose start is
+      // synthetic text with no covering mapping — so Volar would silently
+      // drop it (#1132). Wrapping the access in a `wideVerification` mapping
+      // (see #1168) anchored to the block name lets the diagnostic map back.
+      const emitBlockParamsAccess = (): void => {
+        mapper.text('__glintY__.blockParams');
+        emitPropertyAccesss(name, { offset: nameOffset, synthetic: true });
+      };
+
+      if (nameOffset !== undefined) {
+        mapper.forRange(
+          { start: nameOffset, end: nameOffset + name.length },
+          new Identifier(name),
+          emitBlockParamsAccess,
+          undefined,
+          true,
+        );
+      } else {
+        emitBlockParamsAccess();
+      }
+
       mapper.text(';');
       mapper.newline();
 

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -1060,4 +1060,90 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
 
     expect(diagnostics).toMatchInlineSnapshot(`[]`);
   });
+
+  test('using a named block not declared in the signature should be an error (#1132)', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface ProviderSignature {
+        Blocks: {
+          pending: [];
+          success: [value: string];
+        };
+      }
+
+      class Provider extends Component<ProviderSignature> {
+        <template>{{yield to="pending"}}</template>
+      }
+
+      export default class Consumer extends Component {
+        <template>
+          <Provider>
+            <:loading>...</:loading>
+            <:success as |value|>{{value}}</:success>
+          </Provider>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "error",
+          "code": 7053,
+          "end": {
+            "line": 17,
+            "offset": 16,
+          },
+          "start": {
+            "line": 17,
+            "offset": 9,
+          },
+          "text": "Element implicitly has an 'any' type because expression of type '"loading"' can't be used to index type 'Required<FlattenBlockParams<{ pending: { Params: { Positional: []; }; }; success: { Params: { Positional: [value: string]; }; }; }>>'.
+        Property 'loading' does not exist on type 'Required<FlattenBlockParams<{ pending: { Params: { Positional: []; }; }; success: { Params: { Positional: [value: string]; }; }; }>>'.",
+        },
+      ]
+    `);
+  });
+
+  test('using a named block not declared in the signature -- suppressed with @glint-expect-error', async () => {
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface ProviderSignature {
+        Blocks: {
+          pending: [];
+          success: [value: string];
+        };
+      }
+
+      class Provider extends Component<ProviderSignature> {
+        <template>{{yield to="pending"}}</template>
+      }
+
+      export default class Consumer extends Component {
+        <template>
+          <Provider>
+            {{! @glint-expect-error: no such block }}
+            <:loading>...</:loading>
+            <:success as |value|>{{value}}</:success>
+          </Provider>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`[]`);
+  });
 });

--- a/test-packages/package-test-core/__tests__/type-tests/named-blocks.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/named-blocks.test.gts
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+
+// Regression test for https://github.com/typed-ember/glint/issues/1132.
+//
+// Passing a named block that isn't declared in the component's `Blocks`
+// signature must be reported. TypeScript anchors its "Property 'foo' does not
+// exist" diagnostic on the synthetic `__glintY__.blockParams[...]` element
+// access in the generated code, and its mapping was previously dropped — so
+// invoking a component with a nonexistent named block type-checked clean.
+//
+// The `@glint-expect-error` directives below also exercise directive comments
+// *between* named blocks, which were previously discarded entirely.
+
+interface AwaitLikeSignature {
+  Args: { promise: Promise<string> };
+  Blocks: {
+    pending: [];
+    error: [error: unknown];
+    success: [value: string];
+  };
+}
+
+class AwaitLike extends Component<AwaitLikeSignature> {
+  <template>{{yield to="pending"}}</template>
+}
+
+const myPromise = Promise.resolve('hello');
+
+<template>
+  {{! Blocks declared in the signature type-check cleanly. }}
+  <AwaitLike @promise={{myPromise}}>
+    <:pending>loading...</:pending>
+    <:error as |err|>{{String err}}</:error>
+    <:success as |value|>{{value}}</:success>
+  </AwaitLike>
+
+  <AwaitLike @promise={{myPromise}}>
+    {{! @glint-expect-error: no block named "loading" in the signature }}
+    <:loading>loading...</:loading>
+    <:success as |value|>{{value}}</:success>
+  </AwaitLike>
+</template>;


### PR DESCRIPTION
Fixes #1132

Invoking a component with a named block that isn't declared in its `Blocks` signature type-checked clean:

```hbs
<Await @promise={{this.myPromise}}>
  <:loading>{{! Await has no "loading" block — no error reported }}</:loading>
</Await>
```

## Root cause

The generated TypeScript is fine — `const [] = __glintY__.blockParams["loading"];` — and TS does raise `TS7053: Property 'loading' does not exist on type ...` on it. But TS anchors that diagnostic on the whole `__glintY__.blockParams["loading"]` element access, whose start is synthetic text with no covering source mapping: named blocks only produced zero-width boundary mappings plus a leaf mapping for the `"loading"` string. With no verification mapping covering the diagnostic's anchor, Volar silently dropped it when translating back to the template.

This is the same failure mode as #1168 (missing-arg errors anchored on the synthetic `resolve(...)` callee), and the fix reuses the `wideVerification` mechanism introduced there.

## Fix

- `emitBlockContents` now wraps the `__glintY__.blockParams["name"]` access in a `wideVerification` mapping anchored to the block **name** span in the source, so the diagnostic maps back to `loading` in `<:loading>`. The wrapper is deliberately tight — it contains no user content, so narrower leaf mappings and `@glint-expect-error` scoping are unaffected.
- Added a `Mapper.forRange(...)` primitive (like `forNode`, but anchored to an explicit source range), since @glimmer/syntax doesn't model the block name as an AST node.
- Re-enabled comment children among named blocks in `determineBlockChildren` (disabled without explanation in #799, leaving the comment-handling branch of the named-block loop dead). Without this, a `{{! @glint-expect-error }}` placed between named blocks was discarded entirely — and there'd be no way to suppress the newly-surfaced diagnostic.

Scoped to named blocks (the reported case): an *implicit* default block passed to a component whose signature declares no `default` block still isn't reported, since there's no name token to anchor to — left as a follow-up.

Note: the surfaced diagnostic is TS7053, which only fires under `noImplicitAny`.

## Testing

- `diagnostics.test.ts`: unknown named block surfaces TS7053 anchored exactly on the block name (line/offset span of `loading`), and is suppressible with `{{! @glint-expect-error }}` between blocks.
- New `type-tests/named-blocks.test.gts` regression test (valid blocks clean; unknown block consumed by `@glint-expect-error` — which would report "unused expect-error" if the diagnostic regressed to being dropped, and also exercises directive comments between named blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
