### PR TITLE
Fix #1193: stop dropping TS2367 "no overlap" errors on `eq`/`neq` comparisons

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -580,79 +580,105 @@ export function templateToTypescript(
       });
     }
 
+    // Operator emits opt into `wideVerification` (the literal `true` passed
+    // to their `forNode` calls; see #1168): TypeScript anchors operator-level
+    // diagnostics on the whole emitted expression — notably TS2367
+    // ("comparison appears to be unintentional") for `===`/`!==` — and with
+    // the keyword consumption attached to the first operand
+    // (`((noop(eq), x) === y)`, #1169) that expression starts on synthetic
+    // text. Without a covering verification mapping Volar silently dropped
+    // such diagnostics, so impossible `(eq ...)` comparisons went unreported
+    // and `@glint-expect-error` directives guarding them read as unused
+    // (#1193). (A shared `const` is a TDZ trap here: these declarations sit
+    // after the closure's early `return`, so only hoisted functions execute.)
     function emitBinaryOperatorExpression(
       formInfo: SpecialFormInfo,
       node: AST.MustacheStatement | AST.SubExpression,
     ): void {
-      mapper.forNode(node, () => {
-        assert(
-          node.hash.pairs.length === 0,
-          () => `{{${formInfo.name}}} only accepts positional parameters`,
-        );
-        assert(
-          node.params.length === 2,
-          () => `{{${formInfo.name}}} requires exactly two parameters`,
-        );
+      mapper.forNode(
+        node,
+        () => {
+          assert(
+            node.hash.pairs.length === 0,
+            () => `{{${formInfo.name}}} only accepts positional parameters`,
+          );
+          assert(
+            node.params.length === 2,
+            () => `{{${formInfo.name}}} requires exactly two parameters`,
+          );
 
-        const [left, right] = node.params;
+          const [left, right] = node.params;
 
-        mapper.text('(');
-        emitConsumedOperand(formInfo, node, () => emitExpression(left));
-        mapper.text(` ${formInfo.form} `);
-        emitExpression(right);
-        mapper.text(')');
-      });
+          mapper.text('(');
+          emitConsumedOperand(formInfo, node, () => emitExpression(left));
+          mapper.text(` ${formInfo.form} `);
+          emitExpression(right);
+          mapper.text(')');
+        },
+        undefined,
+        /* wideVerification */ true,
+      );
     }
 
     function emitLogicalExpression(
       formInfo: SpecialFormInfo,
       node: AST.MustacheStatement | AST.SubExpression,
     ): void {
-      mapper.forNode(node, () => {
-        assert(
-          node.hash.pairs.length === 0,
-          () => `{{${formInfo.name}}} only accepts positional parameters`,
-        );
-        assert(
-          node.params.length >= 2,
-          () => `{{${formInfo.name}}} requires at least two parameters`,
-        );
+      mapper.forNode(
+        node,
+        () => {
+          assert(
+            node.hash.pairs.length === 0,
+            () => `{{${formInfo.name}}} only accepts positional parameters`,
+          );
+          assert(
+            node.params.length >= 2,
+            () => `{{${formInfo.name}}} requires at least two parameters`,
+          );
 
-        mapper.text('(');
-        for (const [index, param] of node.params.entries()) {
-          if (index === 0) {
-            emitConsumedOperand(formInfo, node, () => emitExpression(param));
-          } else {
-            emitExpression(param);
-          }
+          mapper.text('(');
+          for (const [index, param] of node.params.entries()) {
+            if (index === 0) {
+              emitConsumedOperand(formInfo, node, () => emitExpression(param));
+            } else {
+              emitExpression(param);
+            }
 
-          if (index < node.params.length - 1) {
-            mapper.text(` ${formInfo.form} `);
+            if (index < node.params.length - 1) {
+              mapper.text(` ${formInfo.form} `);
+            }
           }
-        }
-        mapper.text(')');
-      });
+          mapper.text(')');
+        },
+        undefined,
+        /* wideVerification */ true,
+      );
     }
 
     function emitUnaryOperatorExpression(
       formInfo: SpecialFormInfo,
       node: AST.MustacheStatement | AST.SubExpression,
     ): void {
-      mapper.forNode(node, () => {
-        assert(
-          node.hash.pairs.length === 0,
-          () => `{{${formInfo.name}}} only accepts positional parameters`,
-        );
-        assert(
-          node.params.length === 1,
-          () => `{{${formInfo.name}}} requires exactly one parameter`,
-        );
+      mapper.forNode(
+        node,
+        () => {
+          assert(
+            node.hash.pairs.length === 0,
+            () => `{{${formInfo.name}}} only accepts positional parameters`,
+          );
+          assert(
+            node.params.length === 1,
+            () => `{{${formInfo.name}}} requires exactly one parameter`,
+          );
 
-        const [param] = node.params;
+          const [param] = node.params;
 
-        mapper.text(formInfo.form);
-        emitConsumedOperand(formInfo, node, () => emitExpression(param));
-      });
+          mapper.text(formInfo.form);
+          emitConsumedOperand(formInfo, node, () => emitExpression(param));
+        },
+        undefined,
+        /* wideVerification */ true,
+      );
     }
 
     type SpecialFormInfo = {

--- a/test-packages/ts-gts-7-1-app/src/eq-no-overlap.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/eq-no-overlap.test.gts
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+
+// Regression guard for https://github.com/typed-ember/glint/issues/1193
+//
+// TS2367 ("this comparison appears to be unintentional") anchors on the whole
+// emitted binary expression. Since #1169 attached the keyword-consumption
+// comma to the first operand — `((noop(eq), x) === y)` — that expression
+// starts on synthetic text, and without a covering verification mapping the
+// diagnostic was silently dropped: impossible comparisons went unreported and
+// the directives below read as "unused". Each directive being consumed is the
+// assertion that the diagnostic survives the mapping.
+export default class Demo extends Component {
+  kind: 'a' | 'b' = 'a';
+
+  <template>
+    {{! @glint-expect-error -- 'a' | 'b' and "z" have no overlap (TS2367) }}
+    {{#if (eq this.kind "z")}}impossible{{/if}}
+
+    {{! @glint-expect-error -- 'a' | 'b' and "z" have no overlap (TS2367) }}
+    {{#if (neq this.kind "z")}}always{{/if}}
+
+    {{! @glint-expect-error -- the eq's TS2367 must also survive nested inside (and ...) }}
+    {{#if (and (eq this.kind "z") this.kind)}}nested{{/if}}
+
+    {{! valid comparisons must stay error-free }}
+    {{#if (eq this.kind "a")}}possible{{/if}}
+    {{#if (neq this.kind "b")}}possible{{/if}}
+  </template>
+}


### PR DESCRIPTION
Fixes #1193

## What was happening

Exactly as diagnosed in the issue: TypeScript reports TS2367 on the whole binary expression, and since #1169 attached the keyword-consumption comma to the first operand (`((noop(eq), x) === "z")`), that expression's span starts on synthetic generated text. Volar drops diagnostics without a covering verification mapping, so the error vanished and any `@glint-expect-error` guarding it read as unused.

## The fix

Of the two directions proposed in the issue, this takes neither exactly — there's a third with direct prior art in the codebase: `forNode`'s `wideVerification` flag (#1168), which exists precisely for "diagnostics anchored on synthetic boilerplate within a node's span" and already covers the analogous callee-anchored arity errors (and, since #1189, the `fn` comma-pair emit). The binary (`===`/`!==`), logical (`&&`/`||`), and unary (`!`) operator emits now opt in.

Compared to moving the consumption to the right operand: this is a pure *mapping* change — the emitted TypeScript is byte-identical, so the control-flow narrowing #1169/#1179 established is provably unaffected, and it also rescues any other operator-level diagnostic anchored on the wrapper (not just TS2367). The narrowing suites in `ts-special-forms-app`, `ts-special-forms-pre-7-1-app`, and `ts-gts-7-1-app` all pass unchanged.

One observable difference from 1.8.5: the diagnostic now maps to the whole `(eq this.kind "z")` subexpression rather than starting at `this.kind` (7,12 vs 7,15 in the issue's repro) — arguably the better span for a comparison-level error, and directives behave identically.

## Tests

`eq-no-overlap.test.gts` covers the issue's repro shape for `eq`, `neq`, and an `eq` nested inside `(and ...)` — each impossible comparison sits under a `@glint-expect-error`, so the directive being *consumed* is the assertion that the diagnostic survives mapping (on `main`, all three directives report as unused). Valid comparisons alongside assert no new false positives.

All package typechecks, vitest suites, and lint pass (VS Code smoke timeout remains the known pre-existing environmental failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)