### PR TITLE
Fix member completions in gts files during mid-keystroke parse errors

### DIFF
--- a/packages/ember-tsc/src/cli/run-volar-tsc.ts
+++ b/packages/ember-tsc/src/cli/run-volar-tsc.ts
@@ -137,10 +137,11 @@ function patchTscJsExtensionForGts(source: string): string {
 
 // Volar's `runTsc` does not surface the content-tag parse errors that we attach
 // to `TransformedModule.errors` when content-tag fails to parse a .gts/.gjs
-// file. The transformed source is intentionally blanked to whitespace in that
-// case (see `rewriteModule`) so TypeScript does not emit a flood of misleading
-// errors against the still-unparsed `<template>` tags; the trade-off is that
-// the underlying parse failure is silently dropped.
+// file. In that case the transformed source is the raw .gts/.gjs source and
+// every mapping carries `verification: false` (see `rewriteModule` /
+// `toVolarMappings`), so volar drops the flood of misleading TS errors against
+// the still-unparsed `<template>` tags; the trade-off is that the underlying
+// parse failure is silently dropped.
 //
 // In language-server / tsserver-plugin contexts that silence is fine because
 // the parse error is re-surfaced by separate diagnostic providers. But the
@@ -175,12 +176,12 @@ function injectContentTagDiagnostics(language: unknown, program: ts.Program): vo
   const lang = language as { scripts: { get(id: string): any } };
 
   // Cache of synthetic SourceFiles built from the original .gts/.gjs text,
-  // keyed by file name. We need our own SourceFile here because the one TS
+  // keyed by file name. We use our own SourceFile here because the one TS
   // gives us via `program.getSourceFile` was built from the *transformed*
-  // (whitespace-blanked, on parse failure) text — so `--pretty` rendering
-  // would print an empty source line under the diagnostic header (see
-  // https://github.com/typed-ember/glint/pull/1149#discussion_r... for the
-  // bug report). The original text lives on volar's `sourceScript.snapshot`.
+  // text, which is not guaranteed to match the original — so `--pretty`
+  // rendering could print the wrong source line under the diagnostic header
+  // (see https://github.com/typed-ember/glint/pull/1149#discussion_r... for
+  // the bug report). The original text lives on volar's `sourceScript.snapshot`.
   const originalSourceFiles = new Map<string, ts.SourceFile>();
 
   const getOriginalSourceFile = (fileName: string): ts.SourceFile | undefined => {
@@ -222,8 +223,8 @@ function injectContentTagDiagnostics(language: unknown, program: ts.Program): vo
       return [];
     }
     // Render against the original .gts/.gjs text (not the SourceFile TS
-    // hands back, which holds the blanked transformed contents) so
-    // `tsc --pretty` prints the actual offending source line.
+    // hands back, which holds the transformed contents) so `tsc --pretty`
+    // prints the actual offending source line.
     const originalSourceFile = getOriginalSourceFile(sourceFile.fileName) ?? sourceFile;
     return getTransformErrorDiagnostics(transformedModule, originalSourceFile);
   };

--- a/packages/ember-tsc/src/transform/diagnostics/transform-errors.ts
+++ b/packages/ember-tsc/src/transform/diagnostics/transform-errors.ts
@@ -8,15 +8,15 @@ import { Diagnostic } from './index.js';
  * tsserver-plugin path see the underlying error rather than nothing.
  *
  * Without this, when content-tag fails to parse a .gts/.gjs file we suppress
- * the resulting flood of TS errors by blanking the transformed contents (see
- * `rewriteModule`). That leaves the tsserver path silent on its own — fine
- * inside VS Code, where the Volar language server's `g-compiler-errors`
- * plugin surfaces the error, but unhelpful for any consumer running only
- * the tsserver plugin.
+ * the resulting flood of TS errors by disabling `verification` on every
+ * mapping (see `rewriteModule` / `toVolarMappings`). That leaves the tsserver
+ * path silent on its own — fine inside VS Code, where the Volar language
+ * server's `g-compiler-errors` plugin surfaces the error, but unhelpful for
+ * any consumer running only the tsserver plugin.
  *
  * Offsets are in original (.gts) source coordinates; tsserver maps them to
  * line/column using its own ScriptInfo for the source file, so the same
- * value works regardless of how we blanked the transformed output.
+ * value works regardless of what the transformed output contains.
  */
 export function getTransformErrorDiagnostics(
   transformedModule: TransformedModule,

--- a/packages/ember-tsc/src/transform/template/rewrite-module.ts
+++ b/packages/ember-tsc/src/transform/template/rewrite-module.ts
@@ -49,29 +49,20 @@ export function rewriteModule(
   let sparseSpans = completeCorrelatedSpans(partialSpans);
   let { contents, correlatedSpans } = calculateTransformedSource(script, sparseSpans, directives);
 
-  if (errors.some((error) => error.isContentTagError)) {
-    // content-tag failed to parse the .gts/.gjs source, which means the
-    // "transformed" output above is just the raw source (still containing
-    // `<template>` tags etc.). Feeding that to TypeScript would produce a
-    // flood of misleading syntax/type errors on top of the underlying
-    // parse failure. Blank the transformed output to whitespace so TS sees
-    // an effectively empty file and stays quiet. The content-tag error
-    // itself is preserved on `errors` and surfaced as the sole diagnostic
-    // by the `g-compiler-errors` language service plugin.
-    contents = blankNonNewlineChars(contents);
-    correlatedSpans = correlatedSpans.map((span) => ({
-      ...span,
-      transformedSource: blankNonNewlineChars(span.transformedSource),
-    }));
-  }
-
+  // When content-tag fails to parse the .gts/.gjs source (which happens
+  // constantly while the user is mid-keystroke, e.g. right after typing
+  // `foo.`), the "transformed" output above is just the raw source (still
+  // containing `<template>` tags etc.). We keep that raw source as the
+  // transformed contents so that TypeScript's error-tolerant parser can
+  // continue to power completions/hover/navigation in the script portions
+  // of the file. The flood of misleading syntax/type errors TS would report
+  // against the still-unparsed `<template>` tags is suppressed via the
+  // mappings instead: `toVolarMappings` disables `verification` for every
+  // mapping when a content-tag error is present, so Volar drops all TS
+  // diagnostics for the file. The content-tag error itself is preserved on
+  // `errors` and surfaced as the sole diagnostic by the `g-compiler-errors`
+  // language service plugin (and by the CLI's decorateProgram patch).
   return new TransformedModule(contents, errors, directives, correlatedSpans, script.filename);
-}
-
-function blankNonNewlineChars(value: string): string {
-  // Preserve newlines so that line/column tracking still works for any
-  // remaining offset-mapping queries; replace everything else with spaces.
-  return value.replace(/[^\n]/g, ' ');
 }
 
 /**

--- a/packages/ember-tsc/src/transform/template/transformed-module.ts
+++ b/packages/ember-tsc/src/transform/template/transformed-module.ts
@@ -275,6 +275,14 @@ export default class TransformedModule {
   public toVolarMappings(filenameFilter?: string): CodeMapping[] {
     const codeMappings: CodeMapping[] = [];
 
+    // When content-tag failed to parse the file, the "transformed" contents
+    // are the raw source (see `rewriteModule`). We still map it so that
+    // completions/hover/navigation keep working in the script portions while
+    // the user is mid-edit, but we disable `verification` so Volar drops the
+    // flood of TS diagnostics against the unparsed `<template>` tags; the
+    // content-tag parse error itself is surfaced separately.
+    const hasContentTagError = this.errors.some((error) => error.isContentTagError);
+
     const push = (
       sourceOffset: number,
       generatedOffset: number,
@@ -448,6 +456,8 @@ export default class TransformedModule {
 
             // This enables symbol/outline info for the transformed TS to appear in for the .gts file.
             structure: true,
+
+            ...(hasContentTagError ? { verification: false } : null),
           });
         }
       }

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -690,8 +690,8 @@ function getSemanticDiagnostics<T>(
 
     // Surface content-tag parse errors directly through the tsserver path so
     // consumers that don't run the Volar language server still see the actual
-    // error (rather than the silence produced by blanking the transformed
-    // output in `rewriteModule`).
+    // error (rather than the silence produced by the verification-disabled
+    // mappings emitted on parse failure — see `rewriteModule`).
     const transformErrorDiagnostics = getTransformErrorDiagnostics
       ? getTransformErrorDiagnostics(transformedModule, sourceFile)
       : [];

--- a/test-packages/package-test-core/__tests__/language-server/completions.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/completions.test.ts
@@ -165,6 +165,40 @@ describe('Language Server: Completions (ts plugin)', () => {
     `);
   });
 
+  test('member completions in script portion while file has a content-tag parse error', async () => {
+    // Regression test: asking for member completions right after typing `.`
+    // means the file is momentarily invalid — content-tag/swc fails to parse
+    // it (unlike TS's error-tolerant parser, which recovers fine in .ts
+    // files). We used to blank the entire transformed file to whitespace in
+    // that case, which made tsserver answer every completion request with the
+    // global scope list (AbortController, AbstractRange, ...) instead of the
+    // members of the object left of the cursor.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      const params = new URLSearchParams();
+      params.%
+
+      export default class MyComponent extends Component {
+        <template>
+          hello
+        </template>
+      }
+    `;
+
+    const completions = await requestCompletion(
+      'ts-template-imports-app/src/index.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(completions.some((c: any) => c.name === 'append')).toBe(true);
+    expect(completions.some((c: any) => c.name === 'getAll')).toBe(true);
+    // The global-scope list is what we get when the position maps to
+    // whitespace; its presence would mean the member context was lost.
+    expect(completions.some((c: any) => c.name === 'AbortController')).toBe(false);
+  });
+
   test('referencing class properties', async () => {
     const code = stripIndent`
       import Component from '@glimmer/component';

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -253,7 +253,7 @@ describe('Transform: rewriteModule', () => {
       `);
     });
 
-    test('with a content-tag parse error, blanks transformed contents so TS sees an empty file', () => {
+    test('with a content-tag parse error, keeps raw source but disables verification', () => {
       let script = {
         filename: 'test.gts',
         contents: stripIndent`
@@ -274,13 +274,23 @@ describe('Transform: rewriteModule', () => {
       expect(transformedModule?.errors.length).toBe(1);
       expect(transformedModule?.errors[0]?.isContentTagError).toBe(true);
 
-      // The transformed source is whitespace-only (preserving line structure)
-      // so TypeScript will treat it as an empty file rather than producing a
-      // cascade of misleading errors against the still-unparsed `<template>` tags.
-      const transformed = transformedModule?.transformedContents ?? '';
-      expect(transformed.length).toBeGreaterThan(0);
-      expect(/\S/.test(transformed)).toBe(false);
-      expect(transformed.split('\n').length).toBe(script.contents.split('\n').length);
+      // The transformed source is the raw .gts source: content-tag parse
+      // errors happen constantly mid-keystroke (e.g. right after typing
+      // `foo.`), and TypeScript's error-tolerant parser can still provide
+      // completions/hover/navigation for the script portions of the raw
+      // source. The flood of misleading TS errors against the still-unparsed
+      // `<template>` tags is suppressed via the mappings instead: every
+      // mapping has `verification: false`, so Volar drops all TS diagnostics
+      // for the file (in both tsserver and CLI modes) while other language
+      // features keep working.
+      expect(transformedModule?.transformedContents).toBe(script.contents);
+
+      const mappings = transformedModule!.toVolarMappings();
+      expect(mappings.length).toBeGreaterThan(0);
+      for (const mapping of mappings) {
+        expect(mapping.data.verification).toBe(false);
+        expect(mapping.data.completion).toBe(true);
+      }
     });
   });
 


### PR DESCRIPTION
## The bug

Reported on Discord: in a `.gts` file, typing `params.` (where `params` is a `URLSearchParams`) shows the global scope list (`AbortController`, `AbstractRange`, …) instead of the object's members. The same code in a `.ts` file works fine.

## Root cause

Asking for member completions right after typing `.` means the file is **momentarily syntactically invalid**. TypeScript's parser recovers from that gracefully (which is why `.ts` files work), but content-tag/swc has no error recovery and fails to parse the whole file.

Since #1123, a content-tag parse error blanked the entire transformed file to whitespace (to suppress the flood of misleading TS errors against still-unparsed `<template>` tags). But the whole-file mapping still had `completion: true`, so tsserver served completions from a file of spaces — yielding the global scope list. Since typing `.` always makes the file invalid, this broke essentially **all** member completions in gts files (plus hover/go-to-def during any invalid intermediate state).

No existing test caught it because the completion tests all use syntactically *valid* documents.

## The fix

Degrade diagnostics via Volar mapping metadata instead of destroying the generated text:

- `rewrite-module.ts`: on content-tag error, keep the raw source as the transformed contents (no more blanking) so TS's error-tolerant parser can keep powering completions/hover/navigation in the script portions.
- `transformed-module.ts`: `toVolarMappings()` emits `verification: false` on every mapping when a content-tag error is present. Volar filters diagnostics through `shouldReportDiagnostics` (which checks that flag) on **both** the tsserver-plugin path (`decorateLanguageService`) and the CLI path (`decorateProgram`), so the diagnostic-flood suppression #1123 wanted is fully preserved.
- The single content-tag error is still surfaced by `getTransformErrorDiagnostics` (tsserver plugin + CLI `decorateProgram` patch) and the `g-compiler-errors` language service plugin — unchanged.
- Updated the now-stale comments describing the blanking behavior.

## Verification

- New regression test in `completions.test.ts`: `params.` in a gts file must offer `append`/`getAll` and must **not** offer the global list. Fails before this change, passes after.
- Rewrote the #1123 rewrite test to assert the new contract (raw contents preserved + every mapping `verification: false`, `completion: true`).
- `content-tag parse errors do not produce spurious tsserver diagnostics` still passes (no diagnostic flood).
- ts-extensionless-app CLI suite (content-tag error surfacing in `ember-tsc`) passes 5/5.
- Full package-test-core suite: 221 passed, 4 failed — all 4 failures (the #610 conditional-Element snapshot and 3 modifier diagnostic-augmentation tests) reproduce identically on clean `main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)