### PR TITLE
Report dropped diagnostics on quoted attribute keys via `wideVerification`

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -879,27 +879,39 @@ export function templateToTypescript(
             mapper.text('{ ');
 
             for (let attr of dataAttrs) {
-              mapper.forNode(attr, () => {
-                mapper.newline();
+              // The arg opts into `wideVerification` (see #1168) for the same
+              // reason as plain attributes in `emitPlainAttributes`: unsafe
+              // arg names (e.g. dashed ones) are emitted as *quoted* object
+              // keys, and TS anchors diagnostics such as TS2353 on the full
+              // quoted key. The quotes are generated-only text, so without a
+              // covering verification mapping Volar cannot translate the
+              // diagnostic back to the template and silently drops it.
+              mapper.forNode(
+                attr,
+                () => {
+                  mapper.newline();
 
-                const attrStartOffset = attr.loc.getStart().offset!;
-                emitHashKey(attr.name.slice(1), attrStartOffset + prefix.length + 1);
-                mapper.text(': ');
+                  const attrStartOffset = attr.loc.getStart().offset!;
+                  emitHashKey(attr.name.slice(1), attrStartOffset + prefix.length + 1);
+                  mapper.text(': ');
 
-                switch (attr.value.type) {
-                  case 'TextNode':
-                    emitQuotedTextNodeValue(attr.value);
-                    break;
-                  case 'ConcatStatement':
-                    emitConcatStatement(attr.value);
-                    break;
-                  case 'MustacheStatement':
-                    emitMustacheStatement(attr.value, 'arg');
-                    break;
-                  default:
-                    unreachable(attr.value);
-                }
-              });
+                  switch (attr.value.type) {
+                    case 'TextNode':
+                      emitQuotedTextNodeValue(attr.value);
+                      break;
+                    case 'ConcatStatement':
+                      emitConcatStatement(attr.value);
+                      break;
+                    case 'MustacheStatement':
+                      emitMustacheStatement(attr.value, 'arg');
+                      break;
+                    default:
+                      unreachable(attr.value);
+                  }
+                },
+                undefined,
+                /* wideVerification */ !isSafeKey(attr.name.slice(1)),
+              );
 
               start = rangeForNode(attr.value).end;
               mapper.text(', ');
@@ -1109,22 +1121,37 @@ export function templateToTypescript(
           mapper.newline();
           mapper.indent();
 
-          mapper.forNode(attr, () => {
-            const attrStartOffset = attr.loc.getStart().offset!;
-            emitHashKey(attr.name, attrStartOffset + prefix.length);
-            mapper.text(': ');
+          // Unsafe attribute names (e.g. dashed ones like `vector-effect`)
+          // are emitted as *quoted* object keys, and TS anchors diagnostics
+          // such as TS2353 ("Object literal may only specify known
+          // properties") on the full quoted key. The quotes are
+          // generated-only text, so without a covering verification mapping
+          // Volar cannot translate the diagnostic back to the template and
+          // silently drops it — hence `wideVerification` (see #1168) for
+          // unsafe keys. Safe identifier keys are mapped 1:1 and their
+          // diagnostics already survive, so they don't need the extra
+          // covering mapping.
+          mapper.forNode(
+            attr,
+            () => {
+              const attrStartOffset = attr.loc.getStart().offset!;
+              emitHashKey(attr.name, attrStartOffset + prefix.length);
+              mapper.text(': ');
 
-            if (attr.value.type === 'MustacheStatement') {
-              emitMustacheStatement(attr.value, 'attr');
-            } else if (attr.value.type === 'ConcatStatement') {
-              emitConcatStatement(attr.value);
-            } else {
-              mapper.text(JSON.stringify(attr.value.chars));
-            }
+              if (attr.value.type === 'MustacheStatement') {
+                emitMustacheStatement(attr.value, 'attr');
+              } else if (attr.value.type === 'ConcatStatement') {
+                emitConcatStatement(attr.value);
+              } else {
+                mapper.text(JSON.stringify(attr.value.chars));
+              }
 
-            mapper.text(',');
-            mapper.newline();
-          });
+              mapper.text(',');
+              mapper.newline();
+            },
+            undefined,
+            /* wideVerification */ !isSafeKey(attr.name),
+          );
         }
         mapper.newline();
       });

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics-quoted-keys.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics-quoted-keys.test.ts
@@ -1,0 +1,71 @@
+import { stripIndent } from 'common-tags';
+import {
+  requestTsserverDiagnostics,
+  teardownSharedTestWorkspaceAfterEach,
+  ensureNoOpenDocuments,
+} from 'glint-monorepo-test-utils';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+describe('Language Server: Diagnostics — quoted attribute and arg keys', () => {
+  beforeEach(ensureNoOpenDocuments);
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('reports unknown dashed attribute names', async () => {
+    // Dashed attribute names are emitted as quoted object keys; the quotes
+    // are generated-only text, so TS2353 (anchored on the full quoted key)
+    // had no covering mapping and was silently dropped.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Repro extends Component {
+        <template>
+          <svg viewBox='0 0 1 1'><circle bogus-attr='y' /></svg>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].code).toBe(2353);
+    expect(diagnostics[0].text).toContain('bogus-attr');
+    expect(diagnostics[0].start.line).toBe(5);
+  });
+
+  test('reports unknown dashed argument names on components', async () => {
+    // Component `@`-args go through their own quoted-key emission in
+    // `emitComponent`, so they need the same wideVerification opt-in as
+    // plain attributes.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface InnerSig {
+        Args: { label?: string };
+      }
+      class Inner extends Component<InnerSig> {
+        <template>{{@label}}</template>
+      }
+
+      export default class Outer extends Component {
+        <template>
+          <Inner @bogus-arg='x' />
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].code).toBe(2353);
+    expect(diagnostics[0].text).toContain('bogus-arg');
+    expect(diagnostics[0].start.line).toBe(12);
+  });
+});


### PR DESCRIPTION
Dashed attribute and component-arg names are emitted as *quoted* object keys; TS anchors TS2353 on the full quoted key, whose quotes are generated-only text, so Volar dropped the diagnostic — e.g. `<circle stroke-widht='2'>` and `<Inner @bogus-arg='x' />` both type-checked clean.

Fix: opt plain-attribute emission (`emitPlainAttributes`) and component-arg emission (`emitComponent`) into the existing `wideVerification` mechanism (#1168), mirroring #1193. Two failing tests included.

Note for reviewers: this surfaces TS2353 for valid SVG 2 attributes missing from the `svg-element-attributes` dataset (e.g. `vector-effect`) until the upstream data fix lands — may warrant sequencing after a dep bump.

Cowritten by Claude