### PR TITLE
Report dropped {{yield}} diagnostics (arity + undeclared block target)

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -1235,40 +1235,64 @@ export function templateToTypescript(
       node: AST.MustacheStatement | AST.SubExpression,
       position: InvokePosition,
     ): void {
-      mapper.forNode(node, () => {
-        assert(
-          position === 'top-level',
-          () => `{{${formInfo.name}}} may only appear as a top-level statement`,
-        );
-
-        let to = 'default';
-        let toPair = node.hash.pairs.find((pair) => pair.key === 'to');
-        if (toPair) {
+      // `wideVerification` (see #1168): TS anchors "Expected N arguments,
+      // but got M" for an under-supplied `{{yield}}` on the generated
+      // `__glintDSL__.yieldToBlock(__glintRef__, "...")` callee, which is
+      // generated-only text; without a covering verification mapping Volar
+      // cannot translate the diagnostic back to the template and silently
+      // drops it.
+      mapper.forNode(
+        node,
+        () => {
           assert(
-            toPair.value.type === 'StringLiteral',
-            () => `Named block {{${formInfo.name}}}s must have a literal block name`,
+            position === 'top-level',
+            () => `{{${formInfo.name}}} may only appear as a top-level statement`,
           );
-          to = toPair.value.value;
-        }
 
-        if (to === 'inverse') {
-          to = 'else';
-        }
-
-        mapper.text('__glintDSL__.yieldToBlock(__glintRef__, ');
-        mapper.text(JSON.stringify(to));
-        mapper.text(')(');
-
-        for (let [index, param] of node.params.entries()) {
-          if (index) {
-            mapper.text(', ');
+          let to = 'default';
+          let toPair = node.hash.pairs.find((pair) => pair.key === 'to');
+          if (toPair) {
+            assert(
+              toPair.value.type === 'StringLiteral',
+              () => `Named block {{${formInfo.name}}}s must have a literal block name`,
+            );
+            to = toPair.value.value;
           }
 
-          emitExpression(param);
-        }
+          if (to === 'inverse') {
+            to = 'else';
+          }
 
-        mapper.text(')');
-      });
+          mapper.text('__glintDSL__.yieldToBlock(__glintRef__, ');
+          if (toPair) {
+            // Map the emitted block-name string to the `to='...'` literal so
+            // that a TS2345 for an undeclared block anchors on the name in
+            // the template rather than on unmapped generated text.
+            mapper.forNode(toPair.value, () => {
+              mapper.text(JSON.stringify(to));
+            });
+          } else {
+            // No explicit target; map the implicit "default" to the yield
+            // statement itself.
+            mapper.forNode(node, () => {
+              mapper.text(JSON.stringify(to));
+            });
+          }
+          mapper.text(')(');
+
+          for (let [index, param] of node.params.entries()) {
+            if (index) {
+              mapper.text(', ');
+            }
+
+            emitExpression(param);
+          }
+
+          mapper.text(')');
+        },
+        undefined,
+        /* wideVerification */ true,
+      );
     }
 
     function emitSpecialFormStatement(formInfo: SpecialFormInfo, node: AST.BlockStatement): void {

--- a/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -160,6 +160,19 @@ describe('Language Server: Diagnostic Augmentation', () => {
           "category": "error",
           "code": 2554,
           "end": {
+            "line": 25,
+            "offset": 42,
+          },
+          "start": {
+            "line": 25,
+            "offset": 5,
+          },
+          "text": "Expected 2 arguments, but got 1.",
+        },
+        {
+          "category": "error",
+          "code": 2554,
+          "end": {
             "line": 26,
             "offset": 28,
           },
@@ -168,6 +181,37 @@ describe('Language Server: Diagnostic Augmentation', () => {
             "offset": 21,
           },
           "text": "Expected 2 arguments, but got 3.",
+        },
+        {
+          "category": "error",
+          "code": 2555,
+          "end": {
+            "line": 27,
+            "offset": 42,
+          },
+          "relatedInformation": [
+            {
+              "category": "error",
+              "code": 6236,
+              "message": "Arguments for the rest parameter 'values' were not provided.",
+              "span": {
+                "end": {
+                  "line": 139,
+                  "offset": 49,
+                },
+                "file": "\${repoRootPath}/packages/template/-private/dsl/emit.d.ts",
+                "start": {
+                  "line": 139,
+                  "offset": 5,
+                },
+              },
+            },
+          ],
+          "start": {
+            "line": 27,
+            "offset": 5,
+          },
+          "text": "Expected at least 1 arguments, but got 0.",
         },
       ]
     `);

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics-yield.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics-yield.test.ts
@@ -1,0 +1,77 @@
+import { stripIndent } from 'common-tags';
+import {
+  requestTsserverDiagnostics,
+  teardownSharedTestWorkspaceAfterEach,
+  ensureNoOpenDocuments,
+} from 'glint-monorepo-test-utils';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+describe('Language Server: Diagnostics — {{yield}}', () => {
+  beforeEach(ensureNoOpenDocuments);
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('reports missing-argument errors on {{yield}}', async () => {
+    // TS anchors "Expected N arguments, but got M" on the generated
+    // `__glintDSL__.yieldToBlock(__glintRef__, "...")` callee, which is
+    // generated-only text; without a covering mapping the diagnostic is
+    // silently dropped.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface Sig {
+        Blocks: {
+          body: [a: string, b: number];
+        };
+      }
+
+      export default class Repro extends Component<Sig> {
+        <template>
+          {{yield 'one' to='body'}}
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].code).toBe(2554);
+    expect(diagnostics[0].text).toContain('Expected 2 arguments, but got 1');
+    expect(diagnostics[0].start.line).toBe(11);
+  });
+
+  test('reports {{yield}} to an undeclared named block', async () => {
+    // The block name is emitted as a generated string literal
+    // (`JSON.stringify(to)`) with no source mapping, so the TS2345 anchored
+    // on it is silently dropped.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface Sig {
+        Blocks: {
+          default: [];
+        };
+      }
+
+      export default class Repro extends Component<Sig> {
+        <template>
+          {{yield to='nope'}}
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].code).toBe(2345);
+    expect(diagnostics[0].text).toContain('nope');
+    expect(diagnostics[0].start.line).toBe(11);
+  });
+});


### PR DESCRIPTION
Two dropped-diagnostic bugs in `emitYieldExpression`, shown by failing tests in the first commit:

- `{{yield 'one' to='body'}}` against `Blocks: { body: [a: string, b: number] }` reported nothing — TS2554 anchors on the generated `yieldToBlock(...)` callee. Fixed with the `wideVerification` opt-in (#1168).
- `{{yield to='nope'}}` reported nothing — the block name is a generated string with no mapping. Fixed by mapping it to the `to='...'` literal, giving a precise anchor.

The `expected argument count` snapshot gains the two diagnostics its fixture always deliberately included but which were silently dropped.

Found via a coverage audit against vue-language-tools' tsc fixtures.

Cowritten by Claude