### PR TITLE
Report dropped ...attributes element-type mismatch diagnostics

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -1151,7 +1151,15 @@ export function templateToTypescript(
         mapper.forNode(splattributes, () => {
           mapper.text('__glintRef__.element');
         });
-        mapper.text(', __glintY__.element);');
+        mapper.text(', ');
+        // Also map __glintY__.element: TS anchors the target-element
+        // mismatch (e.g. `<div ...attributes>` where the signature declares
+        // `Element: HTMLCanvasElement`) on this *second* argument, and
+        // without a mapping the diagnostic is silently dropped.
+        mapper.forNode(splattributes, () => {
+          mapper.text('__glintY__.element');
+        });
+        mapper.text(');');
       });
 
       mapper.newline();

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics-splattributes.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics-splattributes.test.ts
@@ -1,0 +1,43 @@
+import { stripIndent } from 'common-tags';
+import {
+  requestTsserverDiagnostics,
+  teardownSharedTestWorkspaceAfterEach,
+  ensureNoOpenDocuments,
+} from 'glint-monorepo-test-utils';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+describe('Language Server: Diagnostics — ...attributes', () => {
+  beforeEach(ensureNoOpenDocuments);
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('reports element-type mismatch for ...attributes', async () => {
+    // `applySplattributes(__glintRef__.element, __glintY__.element)` anchors
+    // the target-element mismatch on the *second* argument, which had no
+    // source mapping, so the diagnostic was silently dropped. Only the
+    // source-side case (no Element in the signature) was reported.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      interface Sig {
+        Element: HTMLCanvasElement;
+      }
+
+      export default class Repro extends Component<Sig> {
+        <template>
+          <div ...attributes>x</div>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].code).toBe(2345);
+    expect(diagnostics[0].text).toContain("'HTMLDivElement' is not assignable");
+    expect(diagnostics[0].start.line).toBe(9);
+  });
+});


### PR DESCRIPTION
`<div ...attributes>` inside a component declaring `Element: HTMLCanvasElement` type-checked clean: `applySplattributes` anchors the TS2345 on its second argument (`__glintY__.element`), which had no source mapping. Failing test in the first commit; fix maps the argument to the `...attributes` node, mirroring `emitModifiers`.

Found via a coverage audit against vue-language-tools' tsc fixtures (candidate bug B2).

Cowritten by Claude