### PR TITLE
Report dropped block-form curly missing-argument diagnostics

### DIFF
--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -1382,7 +1382,12 @@ export function templateToTypescript(
         mapper.indent();
 
         mapper.text('const __glintY__ = __glintDSL__.emitComponent(');
-        emitResolve(node, 'resolve');
+        // `wideVerification` (see #1168) for the same reason as direct
+        // mustaches and sub-expressions: TS anchors missing-argument
+        // diagnostics on the generated `__glintDSL__.resolve(...)` callee,
+        // which needs a covering mapping to survive translation back to the
+        // template.
+        emitResolve(node, 'resolve', /* wideVerification */ true);
         mapper.text(');');
         mapper.newline();
 

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -76,6 +76,34 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     `);
   });
 
+  test('reports missing-argument errors on block-form invocations', async () => {
+    // TS anchors "Expected N arguments, but got M" on the generated
+    // `__glintDSL__.resolve(...)` callee emitted by emitBlockStatement,
+    // which had no covering mapping, so an {{#each}} (or {{#let}},
+    // {{#in-element}}, or block-form component) invoked without its
+    // required arguments was silently accepted.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Repro extends Component {
+        <template>
+          {{#each as |item|}}{{item}}{{/each}}
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0].code).toBe(2554);
+    expect(diagnostics[0].text).toContain('Expected 1-2 arguments, but got 0');
+    expect(diagnostics[0].start.line).toBe(5);
+  });
+
   test('honors @glint-expect-error / ignore shared test throws error', async () => {
     const componentA = stripIndent`
       import Component from '@glimmer/component';

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -607,11 +607,16 @@ describe('Transform: rewriteModule', () => {
         | | | |
         | | | | | Mapping: PathExpression
         | | | | |  hbs(107:110): let
-        | | | | |  ts(298:322):  __glintDSL__.Globals.let
+        | | | | |  ts(277:323):  __glintDSL__.resolve(__glintDSL__.Globals.let)
         | | | | |
-        | | | | | | Mapping: Identifier
+        | | | | | | Mapping: PathExpression
         | | | | | |  hbs(107:110): let
-        | | | | | |  ts(319:322):  let
+        | | | | | |  ts(298:322):  __glintDSL__.Globals.let
+        | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(107:110): let
+        | | | | | | |  ts(319:322):  let
+        | | | | | | |
         | | | | | |
         | | | | |
         | | | | | Mapping: PathExpression


### PR DESCRIPTION
`{{#each as |item|}}` (missing the iterable), `{{#in-element}}` (missing the destination), and block-form components invoked without required args all type-checked clean: TS2554 anchors on the generated `resolve(...)` callee, and `emitBlockStatement` never got #1168's `wideVerification` opt-in. Failing test (using `{{#each}}`) in the first commit; one-line fix plus the resulting mapping-tree snapshot update in the second.

Note: argument-anchored block diagnostics were already fine (`{{#each 123}}` reports TS2345 on the literal) — only callee-anchored arity errors were dropped.

Found via a coverage audit against vue-language-tools' tsc fixtures (candidate bug B4).

Cowritten by Claude,