### PR TITLE
Regression fix: Add missing SVG 2 / Filter Effects attributes to generated element types by bumping `svg-element-attributes` to `2.2.0`

### DIFF
--- a/bin/build-elements.mjs
+++ b/bin/build-elements.mjs
@@ -42,25 +42,6 @@ const runtimeAdditionalProperties = new Map([
   ['SVGSVGElement', new Map([['xmlns', 'AttrValue']])],
 ]);
 
-// Valid attributes missing from svg-element-attributes@2.1.0, whose crawler
-// misses the SVG 2 presentation attributes list (fix proposed upstream:
-// https://github.com/wooorm/svg-element-attributes/pull/5 — remove these
-// once a release includes it and the dependency is bumped).
-const missingSpecAttributes = new Map([
-  // SVG 2 presentation attribute; may be specified on any SVG element:
-  // https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty
-  ['GlobalSVG', new Map([['vector-effect', 'AttrValue']])],
-  // Filter Effects 1 applies these to <feDropShadow>, not just <feFlood>:
-  // https://drafts.fxtf.org/filter-effects/#feDropShadowElement
-  [
-    'SVGFEDropShadowElement',
-    new Map([
-      ['flood-color', 'AttrValue'],
-      ['flood-opacity', 'AttrValue'],
-    ]),
-  ],
-]);
-
 const GLOBAL_HTML_ATTRIBUTES_NAME = 'GlobalHTMLAttributes';
 const GLOBAL_SVG_ATTRIBUTES_NAME = 'GlobalSVGAttributes';
 const htmlElementsMap = new Map([[GLOBAL_HTML_ATTRIBUTES_NAME, 'HTMLElement']]);
@@ -225,13 +206,6 @@ function createSvgElementAttributesMap() {
     if (properties) {
       properties.forEach((value, property) => {
         svgElementsContent += `  ['${property}']: ${value};\n`;
-      });
-    }
-
-    const missingAttributes = missingSpecAttributes.get(type);
-    if (missingAttributes) {
-      missingAttributes.forEach((value, attribute) => {
-        svgElementsContent += `  ['${attribute}']: ${value};\n`;
       });
     }
 

--- a/bin/build-elements.mjs
+++ b/bin/build-elements.mjs
@@ -42,6 +42,25 @@ const runtimeAdditionalProperties = new Map([
   ['SVGSVGElement', new Map([['xmlns', 'AttrValue']])],
 ]);
 
+// Valid attributes missing from svg-element-attributes@2.1.0, whose crawler
+// misses the SVG 2 presentation attributes list (fix proposed upstream:
+// https://github.com/wooorm/svg-element-attributes/pull/5 — remove these
+// once a release includes it and the dependency is bumped).
+const missingSpecAttributes = new Map([
+  // SVG 2 presentation attribute; may be specified on any SVG element:
+  // https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty
+  ['GlobalSVG', new Map([['vector-effect', 'AttrValue']])],
+  // Filter Effects 1 applies these to <feDropShadow>, not just <feFlood>:
+  // https://drafts.fxtf.org/filter-effects/#feDropShadowElement
+  [
+    'SVGFEDropShadowElement',
+    new Map([
+      ['flood-color', 'AttrValue'],
+      ['flood-opacity', 'AttrValue'],
+    ]),
+  ],
+]);
+
 const GLOBAL_HTML_ATTRIBUTES_NAME = 'GlobalHTMLAttributes';
 const GLOBAL_SVG_ATTRIBUTES_NAME = 'GlobalSVGAttributes';
 const htmlElementsMap = new Map([[GLOBAL_HTML_ATTRIBUTES_NAME, 'HTMLElement']]);
@@ -206,6 +225,13 @@ function createSvgElementAttributesMap() {
     if (properties) {
       properties.forEach((value, property) => {
         svgElementsContent += `  ['${property}']: ${value};\n`;
+      });
+    }
+
+    const missingAttributes = missingSpecAttributes.get(type);
+    if (missingAttributes) {
+      missingAttributes.forEach((value, attribute) => {
+        svgElementsContent += `  ['${attribute}']: ${value};\n`;
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier-plugin-ember-template-tag": "^2.1.3",
     "release-plan": "^0.18.0",
     "rimraf": "^6.0.1",
-    "svg-element-attributes": "^2.1.0",
+    "svg-element-attributes": "^2.2.0",
     "svg-event-attributes": "^2.0.2",
     "typescript": "^5.9.3"
   },

--- a/packages/template/-private/dsl/elements.d.ts
+++ b/packages/template/-private/dsl/elements.d.ts
@@ -702,19 +702,78 @@ interface GlintHtmlElementAttributesMap {
 declare global {
 interface GlobalSVGAttributes extends GlobalHTMLAttributes {
   ['about']: AttrValue;
+  ['alignment-baseline']: AttrValue;
+  ['baseline-shift']: AttrValue;
   ['class']: AttrValue;
+  ['clip-path']: AttrValue;
+  ['clip-rule']: AttrValue;
+  ['color']: AttrValue;
+  ['color-interpolation']: AttrValue;
+  ['color-interpolation-filters']: AttrValue;
+  ['color-rendering']: AttrValue;
   ['content']: AttrValue;
+  ['cursor']: AttrValue;
   ['datatype']: AttrValue;
+  ['direction']: AttrValue;
+  ['display']: AttrValue;
+  ['dominant-baseline']: AttrValue;
+  ['fill']: AttrValue;
+  ['fill-opacity']: AttrValue;
+  ['fill-rule']: AttrValue;
+  ['filter']: AttrValue;
+  ['flood-color']: AttrValue;
+  ['flood-opacity']: AttrValue;
+  ['font-family']: AttrValue;
+  ['font-size']: AttrValue;
+  ['font-size-adjust']: AttrValue;
+  ['font-stretch']: AttrValue;
+  ['font-style']: AttrValue;
+  ['font-variant']: AttrValue;
+  ['font-weight']: AttrValue;
+  ['glyph-orientation-horizontal']: AttrValue;
+  ['glyph-orientation-vertical']: AttrValue;
   ['id']: AttrValue;
+  ['image-rendering']: AttrValue;
   ['lang']: AttrValue;
+  ['letter-spacing']: AttrValue;
+  ['lighting-color']: AttrValue;
+  ['marker-end']: AttrValue;
+  ['marker-mid']: AttrValue;
+  ['marker-start']: AttrValue;
+  ['mask']: AttrValue;
+  ['opacity']: AttrValue;
+  ['overflow']: AttrValue;
+  ['paint-order']: AttrValue;
+  ['pointer-events']: AttrValue;
   ['property']: AttrValue;
   ['rel']: AttrValue;
   ['resource']: AttrValue;
   ['rev']: AttrValue;
+  ['shape-rendering']: AttrValue;
+  ['stop-color']: AttrValue;
+  ['stop-opacity']: AttrValue;
+  ['stroke']: AttrValue;
+  ['stroke-dasharray']: AttrValue;
+  ['stroke-dashoffset']: AttrValue;
+  ['stroke-linecap']: AttrValue;
+  ['stroke-linejoin']: AttrValue;
+  ['stroke-miterlimit']: AttrValue;
+  ['stroke-opacity']: AttrValue;
+  ['stroke-width']: AttrValue;
   ['style']: AttrValue;
   ['tabindex']: AttrValue;
+  ['text-anchor']: AttrValue;
+  ['text-decoration']: AttrValue;
+  ['text-overflow']: AttrValue;
+  ['text-rendering']: AttrValue;
+  ['transform']: AttrValue;
   ['typeof']: AttrValue;
+  ['unicode-bidi']: AttrValue;
   ['vector-effect']: AttrValue;
+  ['visibility']: AttrValue;
+  ['white-space']: AttrValue;
+  ['word-spacing']: AttrValue;
+  ['writing-mode']: AttrValue;
   ['onabort']: AttrValue;
   ['onactivate']: AttrValue;
   ['onafterprint']: AttrValue;
@@ -819,8 +878,8 @@ interface SVGAElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -1055,8 +1114,8 @@ interface SVGCircleElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -1279,8 +1338,8 @@ interface SVGEllipseElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -1848,8 +1907,6 @@ interface SVGFEDropShadowElementAttributes extends GlobalSVGAttributes {
   ['width']: AttrValue;
   ['x']: AttrValue;
   ['y']: AttrValue;
-  ['flood-color']: AttrValue;
-  ['flood-opacity']: AttrValue;
 }
 interface SVGFEFloodElementAttributes extends GlobalSVGAttributes {
   ['alignment-baseline']: AttrValue;
@@ -2615,8 +2672,8 @@ interface SVGForeignObjectElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -2699,8 +2756,8 @@ interface SVGGElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -2780,8 +2837,8 @@ interface SVGImageElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -2867,8 +2924,8 @@ interface SVGLineElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3175,8 +3232,8 @@ interface SVGPathElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3331,8 +3388,8 @@ interface SVGPolygonElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3413,8 +3470,8 @@ interface SVGPolylineElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3567,8 +3624,8 @@ interface SVGRectElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3727,8 +3784,8 @@ interface SVGStyleElementAttributes extends GlobalSVGAttributes {
 }
 interface SVGSVGElementAttributes extends GlobalSVGAttributes {
   ['alignment-baseline']: AttrValue;
-  ['baseProfile']: AttrValue;
   ['baseline-shift']: AttrValue;
+  ['baseProfile']: AttrValue;
   ['clip']: AttrValue;
   ['clip-path']: AttrValue;
   ['clip-rule']: AttrValue;
@@ -3751,8 +3808,8 @@ interface SVGSVGElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3783,8 +3840,8 @@ interface SVGSVGElementAttributes extends GlobalSVGAttributes {
   ['nav-up-right']: AttrValue;
   ['opacity']: AttrValue;
   ['overflow']: AttrValue;
-  ['playbackOrder']: AttrValue;
   ['playbackorder']: AttrValue;
+  ['playbackOrder']: AttrValue;
   ['pointer-events']: AttrValue;
   ['preserveAspectRatio']: AttrValue;
   ['requiredExtensions']: AttrValue;
@@ -3807,8 +3864,8 @@ interface SVGSVGElementAttributes extends GlobalSVGAttributes {
   ['text-anchor']: AttrValue;
   ['text-decoration']: AttrValue;
   ['text-rendering']: AttrValue;
-  ['timelineBegin']: AttrValue;
   ['timelinebegin']: AttrValue;
+  ['timelineBegin']: AttrValue;
   ['transform']: AttrValue;
   ['unicode-bidi']: AttrValue;
   ['version']: AttrValue;
@@ -3845,8 +3902,8 @@ interface SVGSwitchElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -3998,8 +4055,8 @@ interface SVGTextElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -4165,8 +4222,8 @@ interface SVGTSpanElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;
@@ -4249,8 +4306,8 @@ interface SVGUseElementAttributes extends GlobalSVGAttributes {
   ['filter']: AttrValue;
   ['flood-color']: AttrValue;
   ['flood-opacity']: AttrValue;
-  ['focusHighlight']: AttrValue;
   ['focusable']: AttrValue;
+  ['focusHighlight']: AttrValue;
   ['font-family']: AttrValue;
   ['font-size']: AttrValue;
   ['font-size-adjust']: AttrValue;

--- a/packages/template/-private/dsl/elements.d.ts
+++ b/packages/template/-private/dsl/elements.d.ts
@@ -714,6 +714,7 @@ interface GlobalSVGAttributes extends GlobalHTMLAttributes {
   ['style']: AttrValue;
   ['tabindex']: AttrValue;
   ['typeof']: AttrValue;
+  ['vector-effect']: AttrValue;
   ['onabort']: AttrValue;
   ['onactivate']: AttrValue;
   ['onafterprint']: AttrValue;
@@ -1847,6 +1848,8 @@ interface SVGFEDropShadowElementAttributes extends GlobalSVGAttributes {
   ['width']: AttrValue;
   ['x']: AttrValue;
   ['y']: AttrValue;
+  ['flood-color']: AttrValue;
+  ['flood-opacity']: AttrValue;
 }
 interface SVGFEFloodElementAttributes extends GlobalSVGAttributes {
   ['alignment-baseline']: AttrValue;

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -32,7 +32,7 @@
     "html-element-attributes": "^3.5.0",
     "html-event-attributes": "^2.2.0",
     "sums-up": "^2.1.0",
-    "svg-element-attributes": "^2.1.0",
+    "svg-element-attributes": "^2.2.0",
     "svg-event-attributes": "^2.0.2",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       svg-element-attributes:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.0
+        version: 2.2.0
       svg-event-attributes:
         specifier: ^2.0.2
         version: 2.0.2
@@ -199,8 +199,8 @@ importers:
         specifier: ^2.1.0
         version: 2.2.0
       svg-element-attributes:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.0
+        version: 2.2.0
       svg-event-attributes:
         specifier: ^2.0.2
         version: 2.0.2
@@ -7607,8 +7607,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svg-element-attributes@2.1.0:
-    resolution: {integrity: sha512-Tq0WY3uGw/rltlSlAsro/WWqbg5oNiaRwzq13I9H1m/dYjMjesuxKV76dGSlpacjslGyAis8VIwqPXaUUXw26w==}
+  svg-element-attributes@2.2.0:
+    resolution: {integrity: sha512-t/7bOuynnY9XNkGAiMFq7nNsSqzoBQj4PZ1luVaSE1l2iZqAb1HctffddeQcKbXgYtBcHuzp6oauj5FWwo/mOw==}
 
   svg-event-attributes@2.0.2:
     resolution: {integrity: sha512-q8c6knvA5SccFLurAhSANIgMnYEN+KO7lxV92nr8ORB1pYSe1XSQ9NT57J9kyUJ71krR3th8R3+ufYdo5w7ffA==}
@@ -17847,7 +17847,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svg-element-attributes@2.1.0: {}
+  svg-element-attributes@2.2.0: {}
 
   svg-event-attributes@2.0.2: {}
 

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics-svg-attributes.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics-svg-attributes.test.ts
@@ -11,13 +11,8 @@ describe('Language Server: Diagnostics — SVG presentation attributes', () => {
   afterEach(teardownSharedTestWorkspaceAfterEach);
 
   test('accepts valid SVG 2 / Filter Effects presentation attributes', async () => {
-    // `vector-effect` (SVG 2) and `flood-color`/`flood-opacity` on
-    // <feDropShadow> (Filter Effects 1) are valid attributes that are missing
-    // from the svg-element-attributes dataset; they are added via
-    // `missingSpecAttributes` in bin/build-elements.mjs so they must never be
-    // reported. This guards against regressions for real-world SVG usage
-    // once diagnostics on quoted attribute keys are reported (see the
-    // wideVerification work).
+    // SVG 2 presentation attributes are valid on any element in the SVG
+    // namespace, including ones whose per-element list omits them.
     const code = stripIndent`
       import Component from '@glimmer/component';
 

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics-svg-attributes.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics-svg-attributes.test.ts
@@ -1,0 +1,43 @@
+import { stripIndent } from 'common-tags';
+import {
+  requestTsserverDiagnostics,
+  teardownSharedTestWorkspaceAfterEach,
+  ensureNoOpenDocuments,
+} from 'glint-monorepo-test-utils';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+describe('Language Server: Diagnostics — SVG presentation attributes', () => {
+  beforeEach(ensureNoOpenDocuments);
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('accepts valid SVG 2 / Filter Effects presentation attributes', async () => {
+    // `vector-effect` (SVG 2) and `flood-color`/`flood-opacity` on
+    // <feDropShadow> (Filter Effects 1) are valid attributes that are missing
+    // from the svg-element-attributes dataset; they are added via
+    // `missingSpecAttributes` in bin/build-elements.mjs so they must never be
+    // reported. This guards against regressions for real-world SVG usage
+    // once diagnostics on quoted attribute keys are reported (see the
+    // wideVerification work).
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      export default class Repro extends Component {
+        <template>
+          <svg viewBox='0 0 1 1'>
+            <circle cx='0' r='1' vector-effect='non-scaling-stroke' />
+            <path d='M0 0' vector-effect='non-scaling-stroke' />
+            <filter><feDropShadow flood-color='black' flood-opacity='0.5' /></filter>
+          </svg>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
#1203 shipped in `@glint/ember-tsc@1.8.13` before https://github.com/wooorm/svg-element-attributes/pull/5 was released, so valid attributes absent from the dataset started reporting TS2353 — `<circle vector-effect='non-scaling-stroke'>`, and `flood-color`/`flood-opacity` on `<feDropShadow>`.

`svg-element-attributes@2.2.0` crawls the SVG 2 presentation attributes table, so its `*` entry now carries the attributes valid on any element in the SVG namespace (12 → 73). Every generated SVG element interface extends `GlobalSVGAttributes`, so `<feDropShadow>` picks up `flood-color`/`flood-opacity` by inheritance — its own per-element list is unchanged upstream.

**The regression test in this PR fails on current `main` (three TS2353s) and passes with the bump.**

Note: since `elements.d.ts` lives in `@glint/template`, this needs a `@glint/template` release to reach consumers.

Cowritten by Claude
