### PR TITLE
Add type-system support for custom elements / web components

### DIFF
--- a/docs/glint-types.md
+++ b/docs/glint-types.md
@@ -207,3 +207,59 @@ declare global {
   }
 }
 ```
+
+### Custom Elements / Web Components
+
+By default, Glint knows nothing about custom elements: `<my-element>` is typed
+as a plain `Element`, and any attributes are accepted.
+
+To teach Glint about a custom element, register it in one (or both) of two
+global interfaces:
+
+- `GlintCustomElementTagNameMap` — maps the tag name to the element's instance
+  type (mirroring the DOM's own `HTMLElementTagNameMap`). This is what gives
+  the element a real type for modifiers, `...attributes`, and hover info.
+- `GlintCustomElementAttributesMap` — maps the tag name to the attributes the
+  element accepts. Attributes are registered separately because TypeScript has
+  no way to derive "settable attributes" from an element class (methods and
+  readonly DOM properties would leak in).
+
+```ts
+import '@glint/template';
+
+import type { MyCustomElement } from './wherever';
+
+declare global {
+  interface GlintCustomElementTagNameMap {
+    'my-custom-element': MyCustomElement;
+  }
+
+  interface GlintCustomElementAttributesMap {
+    'my-custom-element': {
+      'prop-num': number;
+      'prop-str': string;
+    };
+  }
+}
+```
+
+With both registered:
+
+```handlebars
+<my-custom-element prop-num={{123}} prop-str="hello"></my-custom-element>
+{{! ^ attributes are checked, and the element itself is typed as MyCustomElement }}
+```
+
+The two registries are independent:
+
+- Registering only the element type gives you a typed element (for modifiers
+  and `...attributes`) while leaving attributes unchecked.
+- Registering only attributes checks them while leaving the element typed as
+  `Element`.
+- Tag names registered in neither registry behave as before: `Element` type,
+  arbitrary attributes accepted.
+
+If you already augment the DOM's standard `HTMLElementTagNameMap` for your
+custom elements (as is conventional in e.g. Lit), Glint picks the element type
+up from there too — `GlintCustomElementTagNameMap` exists for projects that
+prefer not to extend the DOM's own registry.

--- a/docs/glint-types.md
+++ b/docs/glint-types.md
@@ -250,6 +250,9 @@ With both registered:
 {{! ^ attributes are checked, and the element itself is typed as MyCustomElement }}
 ```
 
+Hovering a registered element's tag name shows its element type, and
+go-to-definition on the tag name resolves to its registry entry.
+
 The two registries are independent:
 
 - Registering only the element type gives you a typed element (for modifiers

--- a/packages/ember-tsc/src/transform/template/map-template-contents.ts
+++ b/packages/ember-tsc/src/transform/template/map-template-contents.ts
@@ -252,8 +252,10 @@ export function mapTemplateContents(
           // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide) from being
           // source-mapped back to the glimmer template. These might be useful to reinstate at some
           // point in the future but by default tends to make the highlighting in gts files look wrong.
-          codeFeaturesForNode ??
-            augmentCodeFeaturesWithIgnoreDirectivesSupport(codeFeatures.withoutHighlight, hbsRange),
+          augmentCodeFeaturesWithIgnoreDirectivesSupport(
+            codeFeaturesForNode ?? codeFeatures.withoutHighlight,
+            hbsRange,
+          ),
           wideVerification,
         ),
       );

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -43,6 +43,19 @@ const TAG_NAME_NAVIGATION_FEATURES: CodeInformation = {
   verification: false,
 };
 
+// The `__glintY__`/`__glintY__.element` target argument of
+// `applyTagAttributes`/`applyAttributes` is mapped onto the attribute node
+// purely so that "can't apply attributes to this element" diagnostics show up
+// on the attribute. It must not serve hover, navigation, or completion —
+// those would surface the private `__glintY__` binding when pointing at the
+// attribute name.
+const ATTR_TARGET_FEATURES: CodeInformation = {
+  semantic: false,
+  navigation: false,
+  completion: false,
+  verification: true,
+};
+
 // Hyphenated globals translated to identifier-safe aliases declared on the
 // `Globals` interface (see `KeywordAliasesForEmber` in
 // `types/-private/dsl/globals.d.ts`). Aliases substitute `-` with `_` so the
@@ -1189,9 +1202,13 @@ export function templateToTypescript(
           // We map the `__glintY__.element`/`__glintY__` arg to the attribute node, which has the
           // effect such that diagnostics due to passing attributes to invalid elements will show
           // up on the attribute, rather than on the whole element.
-          mapper.forNode(attr, () => {
-            mapper.text(kind === 'component' ? '__glintY__.element' : '__glintY__');
-          });
+          mapper.forNode(
+            attr,
+            () => {
+              mapper.text(kind === 'component' ? '__glintY__.element' : '__glintY__');
+            },
+            ATTR_TARGET_FEATURES,
+          );
 
           mapper.text(', {');
           mapper.newline();

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -924,7 +924,7 @@ export function templateToTypescript(
         mapper.text('));');
         mapper.newline();
 
-        emitAttributesAndModifiers(node);
+        emitAttributesAndModifiers(node, 'component');
 
         if (!node.selfClosing) {
           let blocks = determineBlockChildren(node);
@@ -1066,7 +1066,7 @@ export function templateToTypescript(
         mapper.text('");');
         mapper.newline();
 
-        emitAttributesAndModifiers(node);
+        emitAttributesAndModifiers(node, 'element');
 
         for (let child of node.children) {
           emitTopLevelStatement(child);
@@ -1082,13 +1082,16 @@ export function templateToTypescript(
       });
     }
 
-    function emitAttributesAndModifiers(node: AST.ElementNode): void {
+    function emitAttributesAndModifiers(
+      node: AST.ElementNode,
+      kind: 'component' | 'element',
+    ): void {
       emitSplattributes(node);
-      emitPlainAttributes(node);
+      emitPlainAttributes(node, kind);
       emitModifiers(node);
     }
 
-    function emitPlainAttributes(node: AST.ElementNode): void {
+    function emitPlainAttributes(node: AST.ElementNode, kind: 'component' | 'element'): void {
       let attributes = node.attributes.filter(
         (attr) => !attr.name.startsWith('@') && attr.name !== SPLATTRIBUTES,
       );
@@ -1106,13 +1109,21 @@ export function templateToTypescript(
           if (isFirstAttribute) {
             isFirstAttribute = false;
 
-            mapper.text('__glintDSL__.applyAttributes(');
+            // Components resolve attributes from their signature's `Element`
+            // type; plain elements resolve them from the tag name they were
+            // emitted with, which is what allows registered custom elements
+            // to have their attributes checked.
+            mapper.text(
+              kind === 'component'
+                ? '__glintDSL__.applyAttributes('
+                : '__glintDSL__.applyTagAttributes(',
+            );
 
-            // We map the `__glintY__.element` arg to the first attribute node, which has the effect
-            // such that diagnostics due to passing attributes to invalid elements will show up
-            // on the attribute, rather than on the whole element.
+            // We map the `__glintY__.element`/`__glintY__` arg to the first attribute node, which
+            // has the effect such that diagnostics due to passing attributes to invalid elements
+            // will show up on the attribute, rather than on the whole element.
             mapper.forNode(attr, () => {
-              mapper.text('__glintY__.element');
+              mapper.text(kind === 'component' ? '__glintY__.element' : '__glintY__');
             });
 
             mapper.text(', {');

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -1103,32 +1103,29 @@ export function templateToTypescript(
         .withStart(node.path.loc.getEnd())
         .withEnd(node.openTag.getEnd().move(-1));
       mapper.forNodeWithSpan(node, attrsSpan, () => {
-        let isFirstAttribute = true;
-
+        // Each attribute is applied in its own call: TypeScript's
+        // excess-property check only reports the FIRST unknown key in an
+        // object literal, so bundling all attributes into one object would
+        // surface an "unknown attribute" error only for the first offender.
         for (let attr of attributes) {
-          if (isFirstAttribute) {
-            isFirstAttribute = false;
+          // Components resolve attributes from their signature's `Element`
+          // type; plain elements resolve them from the tag name they were
+          // emitted with, which is what allows registered custom elements
+          // to have their attributes checked.
+          mapper.text(
+            kind === 'component'
+              ? '__glintDSL__.applyAttributes('
+              : '__glintDSL__.applyTagAttributes(',
+          );
 
-            // Components resolve attributes from their signature's `Element`
-            // type; plain elements resolve them from the tag name they were
-            // emitted with, which is what allows registered custom elements
-            // to have their attributes checked.
-            mapper.text(
-              kind === 'component'
-                ? '__glintDSL__.applyAttributes('
-                : '__glintDSL__.applyTagAttributes(',
-            );
+          // We map the `__glintY__.element`/`__glintY__` arg to the attribute node, which has the
+          // effect such that diagnostics due to passing attributes to invalid elements will show
+          // up on the attribute, rather than on the whole element.
+          mapper.forNode(attr, () => {
+            mapper.text(kind === 'component' ? '__glintY__.element' : '__glintY__');
+          });
 
-            // We map the `__glintY__.element`/`__glintY__` arg to the first attribute node, which
-            // has the effect such that diagnostics due to passing attributes to invalid elements
-            // will show up on the attribute, rather than on the whole element.
-            mapper.forNode(attr, () => {
-              mapper.text(kind === 'component' ? '__glintY__.element' : '__glintY__');
-            });
-
-            mapper.text(', {');
-          }
-
+          mapper.text(', {');
           mapper.newline();
           mapper.indent();
 
@@ -1163,13 +1160,12 @@ export function templateToTypescript(
             undefined,
             /* wideVerification */ !isSafeKey(attr.name),
           );
+
+          mapper.dedent();
+          mapper.text('});');
+          mapper.newline();
         }
-        mapper.newline();
       });
-      mapper.newline();
-      mapper.dedent();
-      mapper.text('});');
-      mapper.newline();
     }
 
     function emitSplattributes(node: AST.ElementNode): void {

--- a/packages/ember-tsc/src/transform/template/template-to-typescript.ts
+++ b/packages/ember-tsc/src/transform/template/template-to-typescript.ts
@@ -1,4 +1,5 @@
 import { AST } from '@glimmer/syntax';
+import { CodeInformation } from '@volar/language-server/node.js';
 import { GlintEmitMetadata, GlintSpecialForm } from '@glint/ember-tsc/config-types';
 import { assert, unreachable } from '../util.js';
 import { TextContent } from './glimmer-ast-mapping-tree.js';
@@ -17,6 +18,30 @@ const SPLATTRIBUTES = '...attributes';
 // between `Globals.NAME` (which preserves JSDoc on hover/completions) and
 // the bracket-string fallback `Globals["NAME"]` for hyphenated keywords.
 const VALID_JS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// Tag names that become valid JS identifiers once hyphens are substituted
+// with underscores, and can therefore be emitted as `elementTypes.tag_name`
+// property accesses (see `emitPlainElement`).
+const IDENTIFIER_SAFE_TAG_NAME = /^[A-Za-z_$][A-Za-z0-9_$-]*$/;
+
+// Mapping capabilities for the two discarded `elementTypes` tag-name
+// references (see `emitPlainElement`): the identifier form serves hover, the
+// quoted-key form serves navigation (definition/references). Everything else
+// is disabled so the two mappings can't produce duplicate or misanchored
+// results for other language features.
+const TAG_NAME_HOVER_FEATURES: CodeInformation = {
+  semantic: { shouldHighlight: () => false },
+  navigation: false,
+  completion: false,
+  verification: false,
+};
+
+const TAG_NAME_NAVIGATION_FEATURES: CodeInformation = {
+  semantic: false,
+  navigation: true,
+  completion: false,
+  verification: false,
+};
 
 // Hyphenated globals translated to identifier-safe aliases declared on the
 // `Globals` interface (see `KeywordAliasesForEmber` in
@@ -1054,16 +1079,59 @@ export function templateToTypescript(
         mapper.indent();
 
         if (inHtmlContext === 'default') {
-          mapper.text('const __glintY__ = __glintDSL__.emitElement("');
-        } else if (inHtmlContext === 'svg') {
-          mapper.text('const __glintY__ = __glintDSL__.emitSVGElement("');
-        } else if (inHtmlContext === 'math') {
-          mapper.text('const __glintY__ = __glintDSL__.emitMathMlElement("');
+          // The tag name is mapped onto discarded `elementTypes` lookups
+          // (rather than onto `emitElement`'s string argument) so that
+          // hovering the tag name shows the element's type and
+          // go-to-definition resolves to its `HTMLElementTagNameMap` /
+          // `GlintCustomElementTagNameMap` entry. Each feature needs its own
+          // reference form:
+          //
+          // - Hover requires an *identifier* whose length matches the source
+          //   tag name (hyphens substituted with underscores, matching
+          //   `elementTypes`' remapped keys — like `each-in` ->
+          //   `Globals.each_in`): a quoted key's quickinfo textSpan includes
+          //   the quotes, which Volar can't map back to the template, so the
+          //   hover result gets dropped.
+          // - Go-to-definition requires the *raw quoted key*: TypeScript
+          //   retains no declaration links through the key-remapped mapped
+          //   type, so definition comes up empty on the identifier form.
+          if (IDENTIFIER_SAFE_TAG_NAME.test(node.tag)) {
+            mapper.text('__glintDSL__.noop(__glintDSL__.elementTypes.');
+            mapper.forNode(
+              node.path,
+              () => {
+                mapper.text(node.tag.replace(/-/g, '_'));
+              },
+              TAG_NAME_HOVER_FEATURES,
+            );
+            mapper.text(');');
+            mapper.newline();
+          }
+          mapper.text('__glintDSL__.noop(__glintDSL__.elementTypes["');
+          mapper.forNode(
+            node.path,
+            () => {
+              mapper.text(node.tag);
+            },
+            TAG_NAME_NAVIGATION_FEATURES,
+          );
+          mapper.text('"]);');
+          mapper.newline();
+          mapper.text(`const __glintY__ = __glintDSL__.emitElement("${node.tag}");`);
+        } else {
+          // In SVG/MathML context the tag name stays mapped onto the emit
+          // function's argument: its `keyof` constraint anchors "unknown
+          // element" diagnostics there.
+          if (inHtmlContext === 'svg') {
+            mapper.text('const __glintY__ = __glintDSL__.emitSVGElement("');
+          } else {
+            mapper.text('const __glintY__ = __glintDSL__.emitMathMlElement("');
+          }
+          mapper.forNode(node.path, () => {
+            mapper.text(node.tag);
+          });
+          mapper.text('");');
         }
-        mapper.forNode(node.path, () => {
-          mapper.text(node.tag);
-        });
-        mapper.text('");');
         mapper.newline();
 
         emitAttributesAndModifiers(node, 'element');

--- a/packages/template/-private/dsl/custom-elements.d.ts
+++ b/packages/template/-private/dsl/custom-elements.d.ts
@@ -1,0 +1,58 @@
+// Registries for typed custom elements / web components.
+//
+// Both interfaces are intentionally empty by default; projects register
+// their custom elements by merging additional entries into them via
+// `declare global`.
+
+declare global {
+  /**
+   * Maps custom element tag names to their element instance type, mirroring
+   * the built-in `HTMLElementTagNameMap`. Registering an element here gives
+   * `<my-element>` a real element type in templates, so modifiers,
+   * `...attributes`, and hover information all work.
+   *
+   * ```ts
+   * import type { MyElement } from './my-element';
+   *
+   * declare global {
+   *   interface GlintCustomElementTagNameMap {
+   *     'my-element': MyElement;
+   *   }
+   * }
+   * ```
+   *
+   * Note that augmenting the standard `HTMLElementTagNameMap` (as is
+   * conventional for custom elements, e.g. in Lit) works as well; this
+   * interface exists for projects that prefer not to extend the DOM's own
+   * registry.
+   */
+  interface GlintCustomElementTagNameMap {
+    /* intentionally empty; projects register their own custom elements */
+  }
+
+  /**
+   * Maps custom element tag names to the attributes they accept. There is no
+   * TypeScript mechanism for deriving "settable attributes" from an element
+   * class (methods and readonly DOM properties would leak in), so attributes
+   * are registered separately from the element type.
+   *
+   * Attributes for tag names registered here are checked strictly; tag names
+   * not registered here continue to accept arbitrary attribute values.
+   *
+   * ```ts
+   * declare global {
+   *   interface GlintCustomElementAttributesMap {
+   *     'my-element': {
+   *       'prop-num': number;
+   *       'prop-str': string;
+   *     };
+   *   }
+   * }
+   * ```
+   */
+  interface GlintCustomElementAttributesMap {
+    /* intentionally empty; projects register their own custom elements */
+  }
+}
+
+export {};

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -38,6 +38,47 @@ export declare const NamedArgsMarker: NamedArgs<unknown>;
 export declare function emitContent(value: ContentValue): void;
 
 /*
+ * Rewrites hyphens in tag names to underscores so that tag names can be
+ * emitted as *identifier* property accesses of the same length as the source
+ * tag name. Both constraints matter: hover only works when TypeScript's
+ * quickinfo textSpan (the referenced identifier) lies entirely within a
+ * length-preserving mapping back to the template — a quoted key's textSpan
+ * includes the quotes, which have no source counterpart, so Volar drops the
+ * hover result. (This is the same trick used for hyphenated keywords like
+ * `each-in` -> `Globals.each_in`.)
+ */
+type IdentifierSafeName<Name> = Name extends `${infer Head}-${infer Tail}`
+  ? `${Head}_${IdentifierSafeName<Tail>}`
+  : Name;
+
+type IdentifierSafeKeys<T> = {
+  [K in keyof T as IdentifierSafeName<K & string>]: T[K];
+};
+
+/*
+ * A value-level tag name -> element type lookup. The transform emits
+ * discarded references like:
+ *
+ *     __glintDSL__.noop(__glintDSL__.elementTypes.my_element);
+ *     __glintDSL__.noop(__glintDSL__.elementTypes["my-element"]);
+ *
+ * with the tag name in the template mapped onto both, so that hovering an
+ * element's tag name shows its element type (served by the identifier form)
+ * and go-to-definition resolves to the corresponding `HTMLElementTagNameMap`
+ * / `GlintCustomElementTagNameMap` entry (served by the raw-key form, since
+ * TypeScript retains no declaration links through the key-remapped copies).
+ */
+export declare const elementTypes: HTMLElementTagNameMap &
+  GlintCustomElementTagNameMap &
+  IdentifierSafeKeys<HTMLElementTagNameMap> &
+  IdentifierSafeKeys<GlintCustomElementTagNameMap> & {
+    svg: SVGSVGElement;
+    math: MathMLElement;
+  } & {
+    [tagName: string]: Element;
+  };
+
+/*
  * Emits an element of the given name, providing a value to the
  * given handler of an appropriate type for the DOM node that will
  * be produced. This:

--- a/packages/template/-private/dsl/emit.d.ts
+++ b/packages/template/-private/dsl/emit.d.ts
@@ -12,6 +12,7 @@ import {
 } from '../integration';
 import {
   AttributesForElement,
+  AttributesForTagName,
   ElementForTagName,
   MathMlElementForTagName,
   SVGElementForTagName,
@@ -54,20 +55,35 @@ export declare function emitContent(value: ContentValue): void;
 export declare function emitElement<Name extends string | 'math' | 'svg'>(
   name: Name,
 ): {
+  name: Name;
   element: Name extends 'math'
     ? MathMlElementForTagName<'math'>
     : Name extends 'svg'
       ? SVGElementForTagName<'svg'>
       : ElementForTagName<Name>;
+  attributes: Name extends 'math'
+    ? Record<string, AttrValue>
+    : Name extends 'svg'
+      ? AttributesForElement<SVGElementForTagName<'svg'>>
+      : AttributesForTagName<Name>;
 };
 
 export declare function emitSVGElement<Name extends keyof SVGElementTagNameMap>(
   name: Name,
-): { element: SVGElementForTagName<Name> };
+): {
+  name: Name;
+  element: SVGElementForTagName<Name>;
+  attributes: AttributesForElement<SVGElementTagNameMap[Name]>;
+};
 
 export declare function emitMathMlElement<Name extends keyof MathMLElementTagNameMap>(
   name: Name,
-): { element: MathMlElementForTagName<Name> };
+): {
+  name: Name;
+  element: MathMlElementForTagName<Name>;
+  // MathML elements have no attribute typings, so anything goes.
+  attributes: Record<string, AttrValue>;
+};
 
 /*
  * Emits the given value as an entity that expects to receive blocks
@@ -159,6 +175,25 @@ export declare function applySplattributes<
 export declare function applyAttributes<T extends Element>(
   element: T,
   attrs: Partial<AttributesForElement<T>>,
+): void;
+
+/*
+ * Applies named attributes to a plain element, resolving them from the tag
+ * name the element was emitted with (via the `attributes` member of the
+ * `emitElement`/`emitSVGElement`/`emitMathMlElement` result) rather than from
+ * the element's instance type. This is what allows registered custom elements
+ * to have their attributes checked.
+ *
+ *     <my-element prop-num={{123}}></my-element>
+ *
+ * Would produce code like:
+ *
+ *     const __glintY__ = emitElement('my-element');
+ *     applyTagAttributes(__glintY__, { 'prop-num': 123 });
+ */
+export declare function applyTagAttributes<T extends { attributes: object }>(
+  target: T,
+  attrs: Partial<T['attributes']>,
 ): void;
 
 /*

--- a/packages/template/-private/dsl/types.d.ts
+++ b/packages/template/-private/dsl/types.d.ts
@@ -1,4 +1,5 @@
 import './elements';
+import './custom-elements';
 import { AttrValue } from '../index';
 import type { HTMLElementMap, SVGElementMap } from './lib.dom.augmentation';
 
@@ -14,7 +15,11 @@ export type ResolveOrReturn<T> = T & (<U>(item: U) => () => U);
  */
 export type ElementForTagName<Name extends string> = Name extends keyof HTMLElementTagNameMap
   ? HTMLElementTagNameMap[Name]
-  : Element;
+  : Name extends keyof GlintCustomElementTagNameMap
+    ? GlintCustomElementTagNameMap[Name] extends Element
+      ? GlintCustomElementTagNameMap[Name]
+      : Element
+    : Element;
 
 export type SVGElementForTagName<Name extends string> = Name extends keyof SVGElementTagNameMap
   ? SVGElementTagNameMap[Name]
@@ -51,10 +56,54 @@ type SVGElementLookup<T> = {
     : never;
 }[keyof SVGElementMap];
 
-type WithDataAttributes<T> = T & Record<`data-${string}`, AttrValue>;
+export type WithDataAttributes<T> = T & Record<`data-${string}`, AttrValue>;
 
-export type AttributesForElement<T extends Element> = T extends HTMLElement
-  ? WithDataAttributes<GlintHtmlElementAttributesMap[HTMLElementLookup<T>]>
-  : T extends SVGElement
-    ? WithDataAttributes<GlintSvgElementAttributesMap[SVGElementLookup<T>]>
-    : Record<string, AttrValue>;
+/**
+ * Reverse lookup from an element instance type to its registered custom
+ * element tag name(s), using the same bidirectional-assignability technique
+ * as `HTMLElementLookup` above. `never` when the type isn't registered.
+ */
+type CustomElementLookup<T> = {
+  [K in keyof GlintCustomElementTagNameMap]: [GlintCustomElementTagNameMap[K]] extends [T]
+    ? [T] extends [GlintCustomElementTagNameMap[K]]
+      ? K
+      : never
+    : never;
+}[keyof GlintCustomElementTagNameMap];
+
+/**
+ * Attributes for a registered custom element tag name: strict when the tag
+ * has an entry in `GlintCustomElementAttributesMap`, otherwise arbitrary
+ * attribute values are accepted (custom elements take arbitrary attributes,
+ * and we have no way to know which ones are meaningful).
+ */
+type AttributesForCustomElement<Name> = Name extends keyof GlintCustomElementAttributesMap
+  ? WithDataAttributes<GlintCustomElementAttributesMap[Name]>
+  : Record<string, AttrValue>;
+
+export type AttributesForElement<T extends Element> = [CustomElementLookup<T>] extends [never]
+  ? T extends HTMLElement
+    ? [HTMLElementLookup<T>] extends [never]
+      ? // An `HTMLElement` subclass we know nothing about, e.g. an unregistered
+        // custom element class used as a component signature's `Element`.
+        Record<string, AttrValue>
+      : WithDataAttributes<GlintHtmlElementAttributesMap[HTMLElementLookup<T>]>
+    : T extends SVGElement
+      ? [SVGElementLookup<T>] extends [never]
+        ? Record<string, AttrValue>
+        : WithDataAttributes<GlintSvgElementAttributesMap[SVGElementLookup<T>]>
+      : Record<string, AttrValue>
+  : AttributesForCustomElement<CustomElementLookup<T>>;
+
+/**
+ * Attributes for an element written with the given tag name. Unlike
+ * `AttributesForElement`, this can resolve attributes for custom elements
+ * that only have an attributes registration (no element type registration),
+ * since it looks up by name rather than by element type.
+ */
+export type AttributesForTagName<Name extends string> =
+  Name extends keyof GlintCustomElementAttributesMap
+    ? WithDataAttributes<GlintCustomElementAttributesMap[Name]>
+    : Name extends keyof HTMLElementTagNameMap
+      ? AttributesForElement<HTMLElementTagNameMap[Name]>
+      : Record<string, AttrValue>;

--- a/packages/template/__tests__/attributes.test.ts
+++ b/packages/template/__tests__/attributes.test.ts
@@ -10,6 +10,8 @@ import {
   resolve,
   templateForBackingValue,
 } from '../-private/dsl';
+import type { AttrValue } from '../-private/index';
+import type { AttributesForTagName } from '../-private/dsl';
 import { ModifierLike } from '../-private/index';
 import TestComponent from './test-component';
 
@@ -54,12 +56,17 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
 // `emitElement` type resolution
 {
   const el = emitElement('img');
-  expectTypeOf(el).toEqualTypeOf<{ element: HTMLImageElement }>();
+  expectTypeOf(el.name).toEqualTypeOf<'img'>();
+  expectTypeOf(el.element).toEqualTypeOf<HTMLImageElement>();
+  expectTypeOf(el.attributes).toEqualTypeOf<AttributesForTagName<'img'>>();
 }
 
 {
   const el = emitElement('customelement');
-  expectTypeOf(el).toEqualTypeOf<{ element: Element }>();
+  expectTypeOf(el.name).toEqualTypeOf<'customelement'>();
+  expectTypeOf(el.element).toEqualTypeOf<Element>();
+  // Unregistered elements accept arbitrary attribute values.
+  expectTypeOf(el.attributes).toEqualTypeOf<Record<string, AttrValue>>();
 }
 
 /**
@@ -110,7 +117,8 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
  */
 {
   const ctx = emitElement('a');
-  expectTypeOf(ctx).toEqualTypeOf<{ element: HTMLAnchorElement }>();
+  expectTypeOf(ctx.name).toEqualTypeOf<'a'>();
+  expectTypeOf(ctx.element).toEqualTypeOf<HTMLAnchorElement>();
   applyModifier(resolve(anchorModifier)(ctx.element));
 }
 
@@ -262,16 +270,16 @@ class MyComponent extends TestComponent<{ Element: HTMLImageElement }> {
 // (Verified fixed in V2 - emitSVGElement correctly resolves SVG child element types)
 {
   const text = emitSVGElement('text');
-  expectTypeOf(text).toEqualTypeOf<{ element: SVGTextElement }>();
+  expectTypeOf(text.element).toEqualTypeOf<SVGTextElement>();
 
   const rect = emitSVGElement('rect');
-  expectTypeOf(rect).toEqualTypeOf<{ element: SVGRectElement }>();
+  expectTypeOf(rect.element).toEqualTypeOf<SVGRectElement>();
 
   const circle = emitSVGElement('circle');
-  expectTypeOf(circle).toEqualTypeOf<{ element: SVGCircleElement }>();
+  expectTypeOf(circle.element).toEqualTypeOf<SVGCircleElement>();
 
   const path = emitSVGElement('path');
-  expectTypeOf(path).toEqualTypeOf<{ element: SVGPathElement }>();
+  expectTypeOf(path.element).toEqualTypeOf<SVGPathElement>();
 }
 
 {

--- a/packages/template/__tests__/custom-elements-registry.ts
+++ b/packages/template/__tests__/custom-elements-registry.ts
@@ -1,0 +1,44 @@
+/**
+ * Registers custom elements for use in other test files, ensuring that
+ * registration works across module boundaries (i.e. you don't have to
+ * declaration-merge in the same file where you use a custom element).
+ *
+ * NOTE: because these are global interface merges, the registrations below
+ * are visible to every test file in this project. Keep the registered tag
+ * names distinctive, and give the element classes distinguishing members so
+ * they aren't structurally identical to `HTMLElement` (which would make the
+ * reverse type-to-tag-name lookup ambiguous).
+ */
+
+export class RegisteredElement extends HTMLElement {
+  declare registeredElementProp: number;
+}
+
+export class RegisteredElementWithAttrs extends HTMLElement {
+  declare propNum: number;
+  declare propStr: string;
+}
+
+export interface RegisteredElementAttributes {
+  'prop-num': number;
+  'prop-str': string;
+}
+
+declare global {
+  interface GlintCustomElementTagNameMap {
+    // Element type only: `<registered-element>` gets a real element type
+    // (for modifiers, splattributes, hover), attributes stay unchecked.
+    'registered-element': RegisteredElement;
+
+    // Element type + attributes: fully checked.
+    'registered-element-with-attrs': RegisteredElementWithAttrs;
+  }
+
+  interface GlintCustomElementAttributesMap {
+    'registered-element-with-attrs': RegisteredElementAttributes;
+
+    // Attributes only: `<attrs-only-element>` has checked attributes even
+    // though its element type is just `Element`.
+    'attrs-only-element': { count: number };
+  }
+}

--- a/packages/template/__tests__/custom-elements.test.ts
+++ b/packages/template/__tests__/custom-elements.test.ts
@@ -1,0 +1,172 @@
+import { expectTypeOf } from 'expect-type';
+import {
+  applyAttributes,
+  applyModifier,
+  applySplattributes,
+  applyTagAttributes,
+  emitComponent,
+  emitElement,
+  resolve,
+} from '../-private/dsl';
+import type {
+  AttributesForElement,
+  AttributesForTagName,
+  ElementForTagName,
+  WithDataAttributes,
+} from '../-private/dsl';
+import type { AttrValue } from '../-private/index';
+import { ModifierLike } from '../-private/index';
+import TestComponent from './test-component';
+import {
+  RegisteredElement,
+  RegisteredElementWithAttrs,
+  RegisteredElementAttributes,
+} from './custom-elements-registry';
+
+declare const registeredElementModifier: ModifierLike<{ Element: RegisteredElement }>;
+
+/**
+ * Baseline: attributes for built-in elements are resolved from the tag name.
+ *
+ * ```handlebars
+ * <div class="x" data-foo="1" nope="x"></div>
+ * ```
+ */
+{
+  const div = emitElement('div');
+
+  expectTypeOf<AttributesForTagName<'div'>>().toEqualTypeOf<AttributesForElement<HTMLDivElement>>();
+
+  applyTagAttributes(div, {
+    class: 'x',
+    role: 'button',
+    'data-foo': '1',
+    // @ts-expect-error: unknown attribute for <div>
+    nope: 'x',
+  });
+}
+
+/**
+ * A registered element type (without registered attributes) gives the element
+ * a real type — so modifiers and splattributes are checked — while attributes
+ * remain unchecked.
+ *
+ * ```handlebars
+ * <registered-element anything="goes" {{registeredElementModifier}}></registered-element>
+ * ```
+ */
+{
+  const el = emitElement('registered-element');
+
+  expectTypeOf(el.name).toEqualTypeOf<'registered-element'>();
+  expectTypeOf(el.element).toEqualTypeOf<RegisteredElement>();
+  expectTypeOf<ElementForTagName<'registered-element'>>().toEqualTypeOf<RegisteredElement>();
+  expectTypeOf(el.attributes).toEqualTypeOf<Record<string, AttrValue>>();
+
+  applyTagAttributes(el, { anything: 'goes', whatever: 123 });
+
+  applyModifier(resolve(registeredElementModifier)(el.element));
+
+  const div = emitElement('div');
+  applyModifier(
+    resolve(registeredElementModifier)(
+      // @ts-expect-error: `registeredElementModifier` expects a `RegisteredElement`
+      div.element,
+    ),
+  );
+}
+
+/**
+ * A fully registered custom element has its attributes strictly checked.
+ *
+ * ```handlebars
+ * <registered-element-with-attrs prop-num={{123}} prop-str="hello"></registered-element-with-attrs>
+ * ```
+ */
+{
+  const el = emitElement('registered-element-with-attrs');
+
+  expectTypeOf(el.element).toEqualTypeOf<RegisteredElementWithAttrs>();
+  expectTypeOf(el.attributes).toEqualTypeOf<WithDataAttributes<RegisteredElementAttributes>>();
+
+  applyTagAttributes(el, {
+    'prop-num': 123,
+    'prop-str': 'hello',
+    'data-test-id': 'ok',
+  });
+
+  applyTagAttributes(el, {
+    // @ts-expect-error: 'prop-num' expects a number
+    'prop-num': 'wrong',
+    // @ts-expect-error: 'prop-str' expects a string
+    'prop-str': 123,
+  });
+
+  applyTagAttributes(el, {
+    // @ts-expect-error: unknown attribute
+    'prop-nope': 'x',
+  });
+}
+
+/**
+ * Registering only attributes still checks them; the element type just stays
+ * the generic `Element`.
+ *
+ * ```handlebars
+ * <attrs-only-element count={{3}}></attrs-only-element>
+ * ```
+ */
+{
+  const el = emitElement('attrs-only-element');
+
+  expectTypeOf(el.element).toEqualTypeOf<Element>();
+
+  applyTagAttributes(el, { count: 3 });
+
+  applyTagAttributes(el, {
+    // @ts-expect-error: 'count' expects a number
+    count: 'wrong',
+  });
+
+  applyTagAttributes(el, {
+    // @ts-expect-error: unknown attribute
+    other: 'x',
+  });
+}
+
+/**
+ * A component whose signature `Element` is a registered custom element gets
+ * the same attribute checking, via reverse lookup from the element type.
+ *
+ * ```handlebars
+ * <CustomElementComponent prop-num={{123}} ...attributes />
+ * ```
+ */
+class CustomElementComponent extends TestComponent<{ Element: RegisteredElementWithAttrs }> {}
+{
+  const component = emitComponent(resolve(CustomElementComponent)());
+
+  applyAttributes(component.element, { 'prop-num': 123, 'data-test-id': 'ok' });
+
+  applyAttributes(component.element, {
+    // @ts-expect-error: 'prop-num' expects a number
+    'prop-num': 'wrong',
+  });
+
+  applySplattributes(new RegisteredElementWithAttrs(), component.element);
+}
+
+/**
+ * An *unregistered* `HTMLElement` subclass used as a signature `Element`
+ * accepts arbitrary attributes. (Previously the element-type lookup produced
+ * `never`, making it impossible to pass any attribute at all.)
+ */
+class UnregisteredElement extends HTMLElement {
+  declare unregisteredElementProp: number;
+}
+class UnregisteredElementComponent extends TestComponent<{ Element: UnregisteredElement }> {}
+{
+  const component = emitComponent(resolve(UnregisteredElementComponent)());
+
+  applyAttributes(component.element, { anything: 'goes', 'data-foo': 'ok' });
+}

--- a/packages/template/__tests__/emit-component.test.ts
+++ b/packages/template/__tests__/emit-component.test.ts
@@ -46,7 +46,8 @@ class MyComponent<T> extends TestComponent<MyComponentSignature<T>> {
 
       {
         const __glintY__ = emitElement('div');
-        expectTypeOf(__glintY__).toEqualTypeOf<{ element: HTMLDivElement }>();
+        expectTypeOf(__glintY__.name).toEqualTypeOf<'div'>();
+        expectTypeOf(__glintY__.element).toEqualTypeOf<HTMLDivElement>();
         applyModifier(
           resolve(globals.on)(__glintY__.element, 'click', __glintRef__.this.wrapperClicked),
         );

--- a/packages/template/__tests__/private/AttributesForElement.test.ts
+++ b/packages/template/__tests__/private/AttributesForElement.test.ts
@@ -41,6 +41,11 @@ import type { AttributesForElement } from '../../-private/dsl';
 }
 
 {
+  type AttributeMap = AttributesForElement<HTMLSelectElement>;
+  expectTypeOf<AttributeMap['length']>().toEqualTypeOf<number>();
+}
+
+{
   type Attributes = keyof AttributesForElement<HTMLDivElement> & string;
   expectTypeOf<Attributes>().toEqualTypeOf<`data-${string}` | keyof HTMLDivElementAttributes>();
 

--- a/packages/template/__tests__/private/ElementForTagName.test.ts
+++ b/packages/template/__tests__/private/ElementForTagName.test.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf } from 'expect-type';
+import type { ElementForTagName } from '../../-private/dsl';
+import { RegisteredElement } from '../custom-elements-registry';
+
+// Built-in elements come from `HTMLElementTagNameMap`
+{
+  expectTypeOf<ElementForTagName<'div'>>().toEqualTypeOf<HTMLDivElement>();
+  expectTypeOf<ElementForTagName<'img'>>().toEqualTypeOf<HTMLImageElement>();
+}
+
+// Registered custom elements come from `GlintCustomElementTagNameMap`
+{
+  type X = ElementForTagName<'registered-element'>;
+
+  expectTypeOf<X>().toEqualTypeOf<RegisteredElement>();
+  expectTypeOf<X['registeredElementProp']>().toEqualTypeOf<number>();
+}
+
+// Unknown tag names fall back to `Element`
+{
+  expectTypeOf<ElementForTagName<'not-registered'>>().toEqualTypeOf<Element>();
+}

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -582,6 +582,8 @@ function proxyLanguageServiceForGlint<T>(
       // case 'getDefinitionAndBoundSpan': return getDefinitionAndBoundSpan(ts, language, languageService, glintOptions, asScriptId, target[p]);
       case 'getQuickInfoAtPosition':
         return getQuickInfoAtPosition(ts, language, languageService, asScriptId, target[p]);
+      case 'getDefinitionAndBoundSpan':
+        return getDefinitionAndBoundSpan(language, asScriptId, target, target[p]);
       // TS plugin only
 
       // Left as an example in case we want to augment semantic classification in .gts files.
@@ -632,27 +634,15 @@ function getQuickInfoAtPosition<T>(
     const info = (getQuickInfoAtPosition as any)(fileName, position, ...rest);
 
     try {
-      const sourceScript = language.scripts.get(asScriptId(fileName));
-      const root = sourceScript?.generated?.root;
-      const transformedModule: TransformedModule = root?.transformedModule;
-
-      let mapping: any = null;
-      let containingSpan: any = null;
-      for (const span of transformedModule?.correlatedSpans ?? []) {
-        if (!span.glimmerAstMapping) continue;
-        if (position < span.originalStart || position >= span.originalStart + span.originalLength) {
-          continue;
-        }
-        // `narrowestMappingForOriginalRange` returns the *first* containing
-        // child, and the mapping tree can hold sibling twins of the same
-        // node where the first has no children — so search for the
-        // smallest containing mapping ourselves.
-        mapping = smallestMappingAt(span.glimmerAstMapping, position - span.originalStart);
-        containingSpan = span;
-        break;
-      }
+      const { transformedModule, mapping, containingSpan } = locateTemplateMapping(
+        language,
+        asScriptId,
+        fileName,
+        position,
+      );
 
       if (!info) {
+        if (!transformedModule) return info;
         return recoverAttributeNameQuickInfo(
           ts,
           languageService,
@@ -814,6 +804,80 @@ function recoverAttributeNameQuickInfo(
   }
 
   return undefined;
+}
+
+/**
+ * VS Code (and most LSP clients) resolve definitions through tsserver's
+ * `definitionAndBoundSpan` command. Volar's proxy for it drops the *entire*
+ * result when the origin ("bound") span can't be translated back to the
+ * template — which is the case for the quoted `elementTypes["my-element"]`
+ * keys serving element tag names, and for quoted attribute keys: their
+ * quotes have no source counterpart. Fall back to `getDefinitionAtPosition`
+ * (whose per-target translation works fine) and synthesize the bound span
+ * from the mapping tree.
+ */
+function getDefinitionAndBoundSpan<T>(
+  language: any, // Language<T>,
+  asScriptId: (fileName: string) => T,
+  languageServiceProxy: ts.LanguageService,
+  getDefinitionAndBoundSpan: ts.LanguageService['getDefinitionAndBoundSpan'],
+): ts.LanguageService['getDefinitionAndBoundSpan'] {
+  return (fileName, position) => {
+    const result = getDefinitionAndBoundSpan(fileName, position);
+    if (result?.definitions?.length) return result;
+
+    try {
+      const { mapping, containingSpan } = locateTemplateMapping(
+        language,
+        asScriptId,
+        fileName,
+        position,
+      );
+      if (!mapping) return result;
+
+      const definitions = languageServiceProxy.getDefinitionAtPosition(fileName, position);
+      if (!definitions?.length) return result;
+
+      return {
+        definitions,
+        textSpan: {
+          start: containingSpan.originalStart + mapping.originalRange.start,
+          length: mapping.originalRange.end - mapping.originalRange.start,
+        },
+      };
+    } catch {
+      return result;
+    }
+  };
+}
+
+function locateTemplateMapping<T>(
+  language: any, // Language<T>,
+  asScriptId: (fileName: string) => T,
+  fileName: string,
+  position: number,
+): { transformedModule: TransformedModule | undefined; mapping: any; containingSpan: any } {
+  const sourceScript = language.scripts.get(asScriptId(fileName));
+  const root = sourceScript?.generated?.root;
+  const transformedModule: TransformedModule = root?.transformedModule;
+
+  let mapping: any = null;
+  let containingSpan: any = null;
+  for (const span of transformedModule?.correlatedSpans ?? []) {
+    if (!span.glimmerAstMapping) continue;
+    if (position < span.originalStart || position >= span.originalStart + span.originalLength) {
+      continue;
+    }
+    // `narrowestMappingForOriginalRange` returns the *first* containing
+    // child, and the mapping tree can hold sibling twins of the same
+    // node where the first has no children — so search for the
+    // smallest containing mapping ourselves.
+    mapping = smallestMappingAt(span.glimmerAstMapping, position - span.originalStart);
+    containingSpan = span;
+    break;
+  }
+
+  return { transformedModule, mapping, containingSpan };
 }
 
 function smallestMappingAt(mapping: any, offset: number): any {

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -580,7 +580,8 @@ function proxyLanguageServiceForGlint<T>(
       // case 'getCompletionEntryDetails': return getCompletionEntryDetails(language, asScriptId, target[p]);
       // case 'getCodeFixesAtPosition': return getCodeFixesAtPosition(target[p]);
       // case 'getDefinitionAndBoundSpan': return getDefinitionAndBoundSpan(ts, language, languageService, glintOptions, asScriptId, target[p]);
-      // case 'getQuickInfoAtPosition': return getQuickInfoAtPosition(ts, target, target[p]);
+      case 'getQuickInfoAtPosition':
+        return getQuickInfoAtPosition(language, asScriptId, target[p]);
       // TS plugin only
 
       // Left as an example in case we want to augment semantic classification in .gts files.
@@ -610,6 +611,115 @@ function proxyLanguageServiceForGlint<T>(
       return Reflect.set(target, p, value, receiver);
     },
   });
+}
+
+/**
+ * Hovering a plain element's tag name serves quickinfo from the discarded
+ * `elementTypes` lookup the transform emits for it, whose property-style
+ * display would read `(property) my_element: MyElement`. Rewrite it to show
+ * just the element type. Components (PascalCase / `this.` / `@` / dotted
+ * tags) are untouched, as is any quickinfo that doesn't match the expected
+ * `(property) <tag-name-ish>: ...` shape.
+ */
+function getQuickInfoAtPosition<T>(
+  language: any, // Language<T>,
+  asScriptId: (fileName: string) => T,
+  getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition'],
+): ts.LanguageService['getQuickInfoAtPosition'] {
+  return (fileName, position, ...rest: any[]) => {
+    const info = (getQuickInfoAtPosition as any)(fileName, position, ...rest);
+    if (!info?.displayParts) return info;
+
+    try {
+      const sourceScript = language.scripts.get(asScriptId(fileName));
+      const root = sourceScript?.generated?.root;
+      const transformedModule: TransformedModule = root?.transformedModule;
+
+      let mapping: any = null;
+      for (const span of transformedModule?.correlatedSpans ?? []) {
+        if (!span.glimmerAstMapping) continue;
+        if (position < span.originalStart || position >= span.originalStart + span.originalLength) {
+          continue;
+        }
+        // `narrowestMappingForOriginalRange` returns the *first* containing
+        // child, and the mapping tree can hold sibling twins of the same
+        // node where the first has no children — so search for the
+        // smallest containing mapping ourselves.
+        mapping = smallestMappingAt(span.glimmerAstMapping, position - span.originalStart);
+        break;
+      }
+
+      const parentNode = mapping?.parent?.sourceNode;
+
+      if (
+        mapping?.sourceNode?.type === 'PathExpression' &&
+        parentNode?.type === 'ElementNode' &&
+        isPlainElementTagName(parentNode.tag)
+      ) {
+        const parts: Array<{ text: string; kind: string }> = info.displayParts;
+        const tag = parentNode.tag;
+        const identifierSafeTag = tag.replace(/-/g, '_');
+        const nameIndex = parts.findIndex(
+          (part) =>
+            part.text === identifierSafeTag ||
+            part.text === tag ||
+            part.text === `'${tag}'` ||
+            part.text === `"${tag}"`,
+        );
+        const colonIndex =
+          nameIndex >= 0
+            ? parts.findIndex(
+                (part, index) =>
+                  index > nameIndex && part.kind === 'punctuation' && part.text === ':',
+              )
+            : -1;
+
+        if (parts[1]?.text === 'property' && colonIndex >= 0) {
+          let typeParts = parts.slice(colonIndex + 1);
+          while (typeParts[0]?.kind === 'space') {
+            typeParts = typeParts.slice(1);
+          }
+          if (typeParts.length) {
+            return { ...info, displayParts: typeParts };
+          }
+        }
+      }
+    } catch {
+      // If anything goes wrong inspecting the mapping, fall through to the
+      // unmodified quickinfo.
+    }
+
+    return info;
+  };
+}
+
+function smallestMappingAt(mapping: any, offset: number): any {
+  if (offset < mapping.originalRange.start || offset >= mapping.originalRange.end) {
+    return null;
+  }
+  let best: any = null;
+  for (const child of mapping.children) {
+    const found = smallestMappingAt(child, offset);
+    if (
+      found &&
+      (!best ||
+        found.originalRange.end - found.originalRange.start <=
+          best.originalRange.end - best.originalRange.start)
+    ) {
+      best = found;
+    }
+  }
+  return best ?? mapping;
+}
+
+function isPlainElementTagName(tag: string): boolean {
+  const firstChar = tag.charAt(0);
+  return (
+    firstChar === firstChar.toLowerCase() &&
+    !tag.includes('.') &&
+    !tag.startsWith('@') &&
+    !tag.startsWith(':')
+  );
 }
 
 function getCompletionsAtPosition<T>(

--- a/packages/tsserver-plugin/src/typescript-server-plugin.ts
+++ b/packages/tsserver-plugin/src/typescript-server-plugin.ts
@@ -581,7 +581,7 @@ function proxyLanguageServiceForGlint<T>(
       // case 'getCodeFixesAtPosition': return getCodeFixesAtPosition(target[p]);
       // case 'getDefinitionAndBoundSpan': return getDefinitionAndBoundSpan(ts, language, languageService, glintOptions, asScriptId, target[p]);
       case 'getQuickInfoAtPosition':
-        return getQuickInfoAtPosition(language, asScriptId, target[p]);
+        return getQuickInfoAtPosition(ts, language, languageService, asScriptId, target[p]);
       // TS plugin only
 
       // Left as an example in case we want to augment semantic classification in .gts files.
@@ -622,13 +622,14 @@ function proxyLanguageServiceForGlint<T>(
  * `(property) <tag-name-ish>: ...` shape.
  */
 function getQuickInfoAtPosition<T>(
+  ts: typeof import('typescript'),
   language: any, // Language<T>,
+  languageService: ts.LanguageService,
   asScriptId: (fileName: string) => T,
   getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition'],
 ): ts.LanguageService['getQuickInfoAtPosition'] {
   return (fileName, position, ...rest: any[]) => {
     const info = (getQuickInfoAtPosition as any)(fileName, position, ...rest);
-    if (!info?.displayParts) return info;
 
     try {
       const sourceScript = language.scripts.get(asScriptId(fileName));
@@ -636,6 +637,7 @@ function getQuickInfoAtPosition<T>(
       const transformedModule: TransformedModule = root?.transformedModule;
 
       let mapping: any = null;
+      let containingSpan: any = null;
       for (const span of transformedModule?.correlatedSpans ?? []) {
         if (!span.glimmerAstMapping) continue;
         if (position < span.originalStart || position >= span.originalStart + span.originalLength) {
@@ -646,8 +648,23 @@ function getQuickInfoAtPosition<T>(
         // node where the first has no children — so search for the
         // smallest containing mapping ourselves.
         mapping = smallestMappingAt(span.glimmerAstMapping, position - span.originalStart);
+        containingSpan = span;
         break;
       }
+
+      if (!info) {
+        return recoverAttributeNameQuickInfo(
+          ts,
+          languageService,
+          transformedModule,
+          fileName,
+          position,
+          mapping,
+          containingSpan,
+        );
+      }
+
+      if (!info.displayParts) return info;
 
       const parentNode = mapping?.parent?.sourceNode;
 
@@ -691,6 +708,112 @@ function getQuickInfoAtPosition<T>(
 
     return info;
   };
+}
+
+/**
+ * Hovering an attribute whose name isn't a safe JS identifier (e.g. the
+ * hyphenated `prop-num`) yields no quickinfo: such names are emitted as
+ * *quoted* object keys, and TypeScript's quickinfo textSpan for a quoted key
+ * includes the quotes — which have no source counterpart, so Volar drops the
+ * result. Recover by resolving the contextual property for the attribute
+ * ourselves and synthesizing a property-style quickinfo with a source-space
+ * span.
+ */
+function recoverAttributeNameQuickInfo(
+  ts: typeof import('typescript'),
+  languageService: ts.LanguageService,
+  transformedModule: TransformedModule,
+  fileName: string,
+  position: number,
+  mapping: any,
+  containingSpan: any,
+): ts.QuickInfo | undefined {
+  // The name of an unsafe-key attribute is mapped as an `Identifier` child
+  // of the `AttrNode` mapping (see `emitHashKey`).
+  const attrMapping = mapping?.sourceNode?.type === 'AttrNode' ? mapping : mapping?.parent;
+  const attrNode = attrMapping?.sourceNode;
+  if (attrNode?.type !== 'AttrNode') return undefined;
+
+  const name: string = attrNode.name;
+  if (name.startsWith('@') || name === '...attributes') return undefined;
+
+  // Only handle the attribute *name* portion (the name sits at the start of
+  // the attribute's source range); values have their own mappings.
+  const attrStart = containingSpan.originalStart + attrMapping.originalRange.start;
+  if (position < attrStart || position >= attrStart + name.length) return undefined;
+
+  const program = languageService.getProgram();
+  if (!program) return undefined;
+  const sourceFile = program.getSourceFile(fileName);
+  if (!sourceFile) return undefined;
+  const checker = program.getTypeChecker();
+
+  // Several mappings cover parts of this attribute (the name identifier, the
+  // applyAttributes target argument, the value); find the one whose
+  // generated text is the (possibly quoted) key.
+  const contents = transformedModule.transformedContents;
+  const candidates: any[] = [mapping, attrMapping, ...(attrMapping.children ?? [])];
+  for (const candidate of candidates) {
+    const generatedStart = containingSpan.transformedStart + candidate.transformedRange.start;
+    const generated = contents.slice(generatedStart, generatedStart + name.length + 2);
+    let keyPosition = -1;
+    if (generated.startsWith(`"${name}`) || generated.startsWith(`'${name}`)) {
+      keyPosition = generatedStart + 1;
+    } else if (generated.startsWith(name)) {
+      keyPosition = generatedStart;
+    }
+    if (keyPosition < 0) {
+      continue;
+    }
+
+    // In TS plugin mode the target script's text is the *source* text with
+    // the generated text appended (Volar's "leading offset"), so program
+    // positions are shifted by the source length relative to
+    // `transformedContents` offsets.
+    const leadingOffset = sourceFile.text.length - contents.length;
+    if (leadingOffset > 0) {
+      keyPosition += leadingOffset;
+    }
+    if (!sourceFile.text.startsWith(name, keyPosition)) {
+      continue;
+    }
+
+    const token = (ts as any).getTokenAtPosition(sourceFile, keyPosition) as ts.Node | undefined;
+    const propertyAssignment = token?.parent;
+    if (!token || !propertyAssignment || !ts.isPropertyAssignment(propertyAssignment)) {
+      continue;
+    }
+    const objectLiteral = propertyAssignment.parent;
+    if (!ts.isObjectLiteralExpression(objectLiteral)) continue;
+
+    const contextualType = checker.getContextualType(objectLiteral);
+    const property = contextualType?.getProperty(name);
+    if (!property) continue;
+
+    // Strip the `| undefined` that `Partial<...>` adds; it's noise for a
+    // "what does this attribute accept" hover.
+    const type = checker.getNonNullableType(checker.getTypeOfSymbol(property));
+
+    return {
+      kind: ts.ScriptElementKind.memberVariableElement,
+      kindModifiers: '',
+      textSpan: { start: attrStart, length: name.length },
+      displayParts: [
+        { text: '(', kind: 'punctuation' },
+        { text: 'property', kind: 'text' },
+        { text: ')', kind: 'punctuation' },
+        { text: ' ', kind: 'space' },
+        { text: `'${name}'`, kind: 'propertyName' },
+        { text: ':', kind: 'punctuation' },
+        { text: ' ', kind: 'space' },
+        { text: checker.typeToString(type), kind: 'text' },
+      ],
+      documentation: property.getDocumentationComment(checker),
+      tags: property.getJsDocTags(checker),
+    };
+  }
+
+  return undefined;
 }
 
 function smallestMappingAt(mapping: any, offset: number): any {

--- a/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -196,12 +196,12 @@ describe('Language Server: Diagnostic Augmentation', () => {
               "message": "Arguments for the rest parameter 'values' were not provided.",
               "span": {
                 "end": {
-                  "line": 139,
+                  "line": 155,
                   "offset": 49,
                 },
                 "file": "\${repoRootPath}/packages/template/-private/dsl/emit.d.ts",
                 "start": {
-                  "line": 139,
+                  "line": 155,
                   "offset": 5,
                 },
               },

--- a/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostic-augmentation.test.ts
@@ -196,12 +196,12 @@ describe('Language Server: Diagnostic Augmentation', () => {
               "message": "Arguments for the rest parameter 'values' were not provided.",
               "span": {
                 "end": {
-                  "line": 155,
+                  "line": 196,
                   "offset": 49,
                 },
                 "file": "\${repoRootPath}/packages/template/-private/dsl/emit.d.ts",
                 "start": {
-                  "line": 155,
+                  "line": 196,
                   "offset": 5,
                 },
               },

--- a/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
@@ -73,6 +73,82 @@ describe('Language Server: element tag hover and definition (ts plugin)', () => 
     `);
   });
 
+  test('hovering a registered custom element attribute shows the attribute type', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      export const Usage = <template>
+        <my-custom-element prop-%num={{123}} prop-str="hello"></my-custom-element>
+      </template>;
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const hover = await performHoverRequest(doc, offset);
+
+    expect(hover.displayString).toMatchInlineSnapshot(`"(property) 'prop-num': number"`);
+  });
+
+  test('go-to-definition on a custom element attribute resolves to its registry entry', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      export const Usage = <template>
+        <my-custom-element prop-%num={{123}} prop-str="hello"></my-custom-element>
+      </template>;
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const definitions = await performDefinitionRequest(doc, offset);
+
+    expect(definitions).toMatchInlineSnapshot(`
+      [
+        {
+          "contextEnd": {
+            "line": 18,
+            "offset": 26,
+          },
+          "contextStart": {
+            "line": 18,
+            "offset": 7,
+          },
+          "end": {
+            "line": 18,
+            "offset": 17,
+          },
+          "file": "\${testWorkspacePath}/ts-template-imports-app/src/custom-elements.gts",
+          "start": {
+            "line": 18,
+            "offset": 7,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('hovering a built-in element attribute shows the attribute type', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      export const Usage = <template>
+        <div cla%ss="x"></div>
+      </template>;
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const hover = await performHoverRequest(doc, offset);
+
+    expect(hover.displayString).toMatchInlineSnapshot(`"(property) class: string"`);
+  });
+
   test('hovering a built-in element shows its element type', async () => {
     const [offset, content] = extractCursor(stripIndent`
       export const Usage = <template>

--- a/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
@@ -30,9 +30,7 @@ describe('Language Server: element tag hover and definition (ts plugin)', () => 
 
     const hover = await performHoverRequest(doc, offset);
 
-    expect(hover.displayString).toMatchInlineSnapshot(
-      `"(property) my_custom_element: MyCustomElement"`,
-    );
+    expect(hover.displayString).toMatchInlineSnapshot(`"MyCustomElement"`);
   });
 
   test('go-to-definition on a registered custom element resolves to its registry entry', async () => {
@@ -90,9 +88,7 @@ describe('Language Server: element tag hover and definition (ts plugin)', () => 
 
     const hover = await performHoverRequest(doc, offset);
 
-    expect(hover.displayString).toMatchInlineSnapshot(
-      `"(property) HTMLElementTagNameMap["div"]: HTMLDivElement"`,
-    );
+    expect(hover.displayString).toMatchInlineSnapshot(`"HTMLDivElement"`);
   });
 });
 

--- a/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
@@ -1,0 +1,132 @@
+import { stripIndent } from 'common-tags';
+import {
+  extractCursor,
+  getSharedTestWorkspaceHelper,
+  prepareDocument,
+  teardownSharedTestWorkspaceAfterEach,
+  testWorkspacePath,
+} from 'glint-monorepo-test-utils';
+import { afterEach, describe, expect, test } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+
+// The `my-custom-element` registrations used here live in
+// `ts-template-imports-app/src/custom-elements.gts`.
+describe('Language Server: element tag hover and definition (ts plugin)', () => {
+  afterEach(teardownSharedTestWorkspaceAfterEach);
+
+  test('hovering a registered custom element shows its element type', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      export const Usage = <template>
+        <my-cus%tom-element prop-num={{123}} prop-str="hello"></my-custom-element>
+      </template>;
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const hover = await performHoverRequest(doc, offset);
+
+    expect(hover.displayString).toMatchInlineSnapshot(
+      `"(property) my_custom_element: MyCustomElement"`,
+    );
+  });
+
+  test('go-to-definition on a registered custom element resolves to its registry entry', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      export const Usage = <template>
+        <my-cus%tom-element prop-num={{123}} prop-str="hello"></my-custom-element>
+      </template>;
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const definitions = await performDefinitionRequest(doc, offset);
+
+    expect(definitions).toMatchInlineSnapshot(`
+      [
+        {
+          "contextEnd": {
+            "line": 13,
+            "offset": 42,
+          },
+          "contextStart": {
+            "line": 13,
+            "offset": 5,
+          },
+          "end": {
+            "line": 13,
+            "offset": 24,
+          },
+          "file": "\${testWorkspacePath}/ts-template-imports-app/src/custom-elements.gts",
+          "start": {
+            "line": 13,
+            "offset": 5,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('hovering a built-in element shows its element type', async () => {
+    const [offset, content] = extractCursor(stripIndent`
+      export const Usage = <template>
+        <di%v></div>
+      </template>;
+    `);
+
+    const doc = await prepareDocument(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      content,
+    );
+
+    const hover = await performHoverRequest(doc, offset);
+
+    expect(hover.displayString).toMatchInlineSnapshot(
+      `"(property) HTMLElementTagNameMap["div"]: HTMLDivElement"`,
+    );
+  });
+});
+
+async function performHoverRequest(document: TextDocument, offset: number): Promise<any> {
+  const workspaceHelper = await getSharedTestWorkspaceHelper();
+
+  const res = await workspaceHelper.tsserver.message({
+    seq: workspaceHelper.nextSeq(),
+    command: 'quickinfo',
+    arguments: {
+      file: URI.parse(document.uri).fsPath,
+      position: offset,
+    },
+  });
+  expect(res.success).toBe(true);
+
+  return res.body;
+}
+
+async function performDefinitionRequest(document: TextDocument, offset: number): Promise<any> {
+  const workspaceHelper = await getSharedTestWorkspaceHelper();
+
+  const res = await workspaceHelper.tsserver.message({
+    seq: workspaceHelper.nextSeq(),
+    command: 'definition',
+    arguments: {
+      file: URI.parse(document.uri).fsPath,
+      position: offset,
+    },
+  });
+  expect(res.success).toBe(true);
+
+  for (const ref of res.body) {
+    ref.file = '${testWorkspacePath}' + ref.file.slice(testWorkspacePath.length);
+  }
+  return res.body;
+}

--- a/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/element-tag-hover.test.ts
@@ -49,27 +49,39 @@ describe('Language Server: element tag hover and definition (ts plugin)', () => 
     const definitions = await performDefinitionRequest(doc, offset);
 
     expect(definitions).toMatchInlineSnapshot(`
-      [
-        {
-          "contextEnd": {
-            "line": 13,
-            "offset": 42,
+      {
+        "definitions": [
+          {
+            "contextEnd": {
+              "line": 13,
+              "offset": 42,
+            },
+            "contextStart": {
+              "line": 13,
+              "offset": 5,
+            },
+            "end": {
+              "line": 13,
+              "offset": 24,
+            },
+            "file": "\${testWorkspacePath}/ts-template-imports-app/src/custom-elements.gts",
+            "start": {
+              "line": 13,
+              "offset": 5,
+            },
           },
-          "contextStart": {
-            "line": 13,
-            "offset": 5,
-          },
+        ],
+        "textSpan": {
           "end": {
-            "line": 13,
-            "offset": 24,
+            "line": 2,
+            "offset": 21,
           },
-          "file": "\${testWorkspacePath}/ts-template-imports-app/src/custom-elements.gts",
           "start": {
-            "line": 13,
-            "offset": 5,
+            "line": 2,
+            "offset": 4,
           },
         },
-      ]
+      }
     `);
   });
 
@@ -107,27 +119,39 @@ describe('Language Server: element tag hover and definition (ts plugin)', () => 
     const definitions = await performDefinitionRequest(doc, offset);
 
     expect(definitions).toMatchInlineSnapshot(`
-      [
-        {
-          "contextEnd": {
-            "line": 18,
-            "offset": 26,
+      {
+        "definitions": [
+          {
+            "contextEnd": {
+              "line": 18,
+              "offset": 26,
+            },
+            "contextStart": {
+              "line": 18,
+              "offset": 7,
+            },
+            "end": {
+              "line": 18,
+              "offset": 17,
+            },
+            "file": "\${testWorkspacePath}/ts-template-imports-app/src/custom-elements.gts",
+            "start": {
+              "line": 18,
+              "offset": 7,
+            },
           },
-          "contextStart": {
-            "line": 18,
-            "offset": 7,
-          },
+        ],
+        "textSpan": {
           "end": {
-            "line": 18,
-            "offset": 17,
+            "line": 2,
+            "offset": 30,
           },
-          "file": "\${testWorkspacePath}/ts-template-imports-app/src/custom-elements.gts",
           "start": {
-            "line": 18,
-            "offset": 7,
+            "line": 2,
+            "offset": 22,
           },
         },
-      ]
+      }
     `);
   });
 
@@ -184,12 +208,17 @@ async function performHoverRequest(document: TextDocument, offset: number): Prom
   return res.body;
 }
 
+// `definitionAndBoundSpan` is what real editors issue (VS Code's TS
+// integration and most LSP clients), and unlike the plain `definition`
+// command it also requires the origin ("bound") span to translate back to
+// the template — a regression surface of its own (see
+// `getDefinitionAndBoundSpan` in the tsserver plugin).
 async function performDefinitionRequest(document: TextDocument, offset: number): Promise<any> {
   const workspaceHelper = await getSharedTestWorkspaceHelper();
 
   const res = await workspaceHelper.tsserver.message({
     seq: workspaceHelper.nextSeq(),
-    command: 'definition',
+    command: 'definitionAndBoundSpan',
     arguments: {
       file: URI.parse(document.uri).fsPath,
       position: offset,
@@ -197,7 +226,7 @@ async function performDefinitionRequest(document: TextDocument, offset: number):
   });
   expect(res.success).toBe(true);
 
-  for (const ref of res.body) {
+  for (const ref of res.body.definitions ?? []) {
     ref.file = '${testWorkspacePath}' + ref.file.slice(testWorkspacePath.length);
   }
   return res.body;

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -294,7 +294,7 @@ describe('Transform: rewriteModule', () => {
     });
   });
 
-  describe({}, () => {
+  describe('with loaded environment', () => {
     test('in class extends', () => {
       let customEnv = GlintEnvironment.load({});
       let script = {

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -803,8 +803,6 @@ describe('Transform: rewriteTemplate', () => {
             const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(Foo)());
             __glintDSL__.applyAttributes(__glintY__.element, {
             "data-bar": __glintDSL__.resolve(helper)({ param: true , ...__glintDSL__.NamedArgsMarker }),
-
-
             });
             }"
           `);
@@ -839,8 +837,6 @@ describe('Transform: rewriteTemplate', () => {
             const __glintY__ = __glintDSL__.emitElement("div");
             __glintDSL__.applyTagAttributes(__glintY__, {
             "data-attr": __glintDSL__.resolveOrReturn(__glintRef__.args.input)(),
-
-
             });
             }"
           `);
@@ -854,8 +850,6 @@ describe('Transform: rewriteTemplate', () => {
             const __glintY__ = __glintDSL__.emitElement("div");
             __glintDSL__.applyTagAttributes(__glintY__, {
             "data-attr": \`\${__glintDSL__.resolveOrReturn(__glintRef__.args.input)()}\`,
-
-
             });
             }"
           `);
@@ -1010,8 +1004,6 @@ describe('Transform: rewriteTemplate', () => {
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "data-attr": __glintDSL__.resolve(concat)(__glintDSL__.resolve(foo)(1), __glintDSL__.resolve(foo)(true)),
-
-
         });
         }"
       `);
@@ -1112,8 +1104,6 @@ describe('Transform: rewriteTemplate', () => {
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "data-foo": __glintDSL__.resolveOrReturn(__glintRef__.args.foo)(),
-
-
         });
         }"
       `);
@@ -1127,8 +1117,6 @@ describe('Transform: rewriteTemplate', () => {
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "data-foo": \`\${__glintDSL__.resolveOrReturn(__glintRef__.args.foo)()}\${__glintDSL__.resolveOrReturn(__glintRef__.args.bar)()}\`,
-
-
         });
         }"
       `);
@@ -1187,10 +1175,9 @@ describe('Transform: rewriteTemplate', () => {
         const __glintY__ = __glintDSL__.emitElement("my-element");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "prop-num": 123,
-
+        });
+        __glintDSL__.applyTagAttributes(__glintY__, {
         "prop-str": "hello",
-
-
         });
         }"
       `);
@@ -1351,8 +1338,6 @@ describe('Transform: rewriteTemplate', () => {
         const __glintY__ = __glintDSL__.emitComponent(__glintDSL__.resolve(NS?.Nested?.Custom)());
         __glintDSL__.applyAttributes(__glintY__.element, {
         class: "foo",
-
-
         });
         }
         }

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -834,6 +834,8 @@ describe('Transform: rewriteTemplate', () => {
 
           expect(templateBody(template)).toMatchInlineSnapshot(`
             "{
+            __glintDSL__.noop(__glintDSL__.elementTypes.div);
+            __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
             const __glintY__ = __glintDSL__.emitElement("div");
             __glintDSL__.applyTagAttributes(__glintY__, {
             "data-attr": __glintDSL__.resolveOrReturn(__glintRef__.args.input)(),
@@ -847,6 +849,8 @@ describe('Transform: rewriteTemplate', () => {
 
           expect(templateBody(template)).toMatchInlineSnapshot(`
             "{
+            __glintDSL__.noop(__glintDSL__.elementTypes.div);
+            __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
             const __glintY__ = __glintDSL__.emitElement("div");
             __glintDSL__.applyTagAttributes(__glintY__, {
             "data-attr": \`\${__glintDSL__.resolveOrReturn(__glintRef__.args.input)()}\`,
@@ -977,6 +981,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.div);
+        __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyModifier(__glintDSL__.resolve(modifier)(__glintY__.element, { foo: "bar" , ...__glintDSL__.NamedArgsMarker }));
         }"
@@ -1001,6 +1007,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.div);
+        __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "data-attr": __glintDSL__.resolve(concat)(__glintDSL__.resolve(foo)(1), __glintDSL__.resolve(foo)(true)),
@@ -1090,6 +1098,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.div);
+        __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.foo)());
         }"
@@ -1101,6 +1111,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.div);
+        __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "data-foo": __glintDSL__.resolveOrReturn(__glintRef__.args.foo)(),
@@ -1114,6 +1126,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.div);
+        __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "data-foo": \`\${__glintDSL__.resolveOrReturn(__glintRef__.args.foo)()}\${__glintDSL__.resolveOrReturn(__glintRef__.args.bar)()}\`,
@@ -1127,6 +1141,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.div);
+        __glintDSL__.noop(__glintDSL__.elementTypes["div"]);
         const __glintY__ = __glintDSL__.emitElement("div");
         __glintDSL__.applySplattributes(__glintRef__.element, __glintY__.element);
         }"
@@ -1161,6 +1177,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.my_element);
+        __glintDSL__.noop(__glintDSL__.elementTypes["my-element"]);
         const __glintY__ = __glintDSL__.emitElement("my-element");
         __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.foo)());
         }"
@@ -1172,6 +1190,8 @@ describe('Transform: rewriteTemplate', () => {
 
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
+        __glintDSL__.noop(__glintDSL__.elementTypes.my_element);
+        __glintDSL__.noop(__glintDSL__.elementTypes["my-element"]);
         const __glintY__ = __glintDSL__.emitElement("my-element");
         __glintDSL__.applyTagAttributes(__glintY__, {
         "prop-num": 123,

--- a/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/template-to-typescript.test.ts
@@ -837,7 +837,7 @@ describe('Transform: rewriteTemplate', () => {
           expect(templateBody(template)).toMatchInlineSnapshot(`
             "{
             const __glintY__ = __glintDSL__.emitElement("div");
-            __glintDSL__.applyAttributes(__glintY__.element, {
+            __glintDSL__.applyTagAttributes(__glintY__, {
             "data-attr": __glintDSL__.resolveOrReturn(__glintRef__.args.input)(),
 
 
@@ -852,7 +852,7 @@ describe('Transform: rewriteTemplate', () => {
           expect(templateBody(template)).toMatchInlineSnapshot(`
             "{
             const __glintY__ = __glintDSL__.emitElement("div");
-            __glintDSL__.applyAttributes(__glintY__.element, {
+            __glintDSL__.applyTagAttributes(__glintY__, {
             "data-attr": \`\${__glintDSL__.resolveOrReturn(__glintRef__.args.input)()}\`,
 
 
@@ -1008,7 +1008,7 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template, { globals: [] })).toMatchInlineSnapshot(`
         "{
         const __glintY__ = __glintDSL__.emitElement("div");
-        __glintDSL__.applyAttributes(__glintY__.element, {
+        __glintDSL__.applyTagAttributes(__glintY__, {
         "data-attr": __glintDSL__.resolve(concat)(__glintDSL__.resolve(foo)(1), __glintDSL__.resolve(foo)(true)),
 
 
@@ -1110,7 +1110,7 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
         const __glintY__ = __glintDSL__.emitElement("div");
-        __glintDSL__.applyAttributes(__glintY__.element, {
+        __glintDSL__.applyTagAttributes(__glintY__, {
         "data-foo": __glintDSL__.resolveOrReturn(__glintRef__.args.foo)(),
 
 
@@ -1125,7 +1125,7 @@ describe('Transform: rewriteTemplate', () => {
       expect(templateBody(template)).toMatchInlineSnapshot(`
         "{
         const __glintY__ = __glintDSL__.emitElement("div");
-        __glintDSL__.applyAttributes(__glintY__.element, {
+        __glintDSL__.applyTagAttributes(__glintY__, {
         "data-foo": \`\${__glintDSL__.resolveOrReturn(__glintRef__.args.foo)()}\${__glintDSL__.resolveOrReturn(__glintRef__.args.bar)()}\`,
 
 
@@ -1164,6 +1164,36 @@ describe('Transform: rewriteTemplate', () => {
       expect(template.slice(mapping!.originalRange.start, mapping!.originalRange.end)).toBe(
         '...attributes',
       );
+    });
+  });
+
+  describe('custom elements', () => {
+    test('with programmatic contents', () => {
+      let template = '<my-element>{{@foo}}</my-element>';
+
+      expect(templateBody(template)).toMatchInlineSnapshot(`
+        "{
+        const __glintY__ = __glintDSL__.emitElement("my-element");
+        __glintDSL__.emitContent(__glintDSL__.resolveOrReturn(__glintRef__.args.foo)());
+        }"
+      `);
+    });
+
+    test('with attributes', () => {
+      let template = '<my-element prop-num={{123}} prop-str="hello"></my-element>';
+
+      expect(templateBody(template)).toMatchInlineSnapshot(`
+        "{
+        const __glintY__ = __glintDSL__.emitElement("my-element");
+        __glintDSL__.applyTagAttributes(__glintY__, {
+        "prop-num": 123,
+
+        "prop-str": "hello",
+
+
+        });
+        }"
+      `);
     });
   });
 

--- a/test-packages/ts-template-imports-app/src/custom-elements.gts
+++ b/test-packages/ts-template-imports-app/src/custom-elements.gts
@@ -1,0 +1,44 @@
+import '@glint/template';
+
+const two = 2;
+const str = 'hello';
+
+export class MyCustomElement extends HTMLElement {
+  propNum!: number;
+  propStr!: string;
+}
+
+declare global {
+  interface GlintCustomElementTagNameMap {
+    'my-custom-element': MyCustomElement;
+  }
+
+  interface GlintCustomElementAttributesMap {
+    'my-custom-element': {
+      'prop-num': number;
+      'prop-str': string;
+    };
+  }
+}
+
+// The registered element type is exposed via the same lookup templates use
+export type X = GlintCustomElementTagNameMap['my-custom-element'];
+
+export const UsesCustomElement = <template>
+  <my-custom-element prop-num={{two}} prop-str={{str}}></my-custom-element>
+
+  <my-custom-element
+    {{! @glint-expect-error: swapped props }}
+    prop-num={{str}}
+    {{! @glint-expect-error: swapped props }}
+    prop-str={{two}}
+  ></my-custom-element>
+
+  <my-custom-element
+    {{! @glint-expect-error: unknown attribute }}
+    prop-nope="x"
+  ></my-custom-element>
+
+  {{! unregistered custom elements still accept arbitrary attributes }}
+  <some-other-element anything="goes"></some-other-element>
+</template>;

--- a/test-packages/ts-template-imports-app/src/custom-elements.gts
+++ b/test-packages/ts-template-imports-app/src/custom-elements.gts
@@ -42,3 +42,13 @@ export const UsesCustomElement = <template>
   {{! unregistered custom elements still accept arbitrary attributes }}
   <some-other-element anything="goes"></some-other-element>
 </template>;
+
+export const MultipleUnknownAttributes = <template>
+  {{! every unknown attribute is reported, not just the first }}
+  <my-custom-element
+    {{! @glint-expect-error: unknown attribute }}
+    foo="hi"
+    {{! @glint-expect-error: unknown attribute }}
+    bar="hi"
+  ></my-custom-element>
+</template>;


### PR DESCRIPTION
Resolves #808. Supersedes #1016 (rebuilt on current `main`, which has moved ~360 commits since that branch's base).

## What this adds

Two global registries in `@glint/template`, both empty by default and populated by projects via `declare global`:

```ts
import '@glint/template';
import type { MyCustomElement } from './wherever';

declare global {
  interface GlintCustomElementTagNameMap {
    'my-custom-element': MyCustomElement;
  }

  interface GlintCustomElementAttributesMap {
    'my-custom-element': {
      'prop-num': number;
      'prop-str': string;
    };
  }
}
```

```handlebars
<my-custom-element prop-num={{123}} prop-str="hello"></my-custom-element>
{{! element is typed as MyCustomElement; attributes are checked }}
```

The registries are independent, and everything unregistered behaves exactly as it does today:

| Registration | Element type | Attributes |
| --- | --- | --- |
| element + attributes | registered type | strictly checked |
| element only | registered type (modifiers, `...attributes`, hover) | anything accepted |
| attributes only | `Element` | strictly checked |
| neither (status quo) | `Element` | anything accepted |

Augmenting the DOM's standard `HTMLElementTagNameMap` (the Lit convention) also works for the element-type half; `GlintCustomElementTagNameMap` exists for projects that prefer not to extend the DOM's own registry.

## How it works

- `emitElement(...)` now returns `{ name, element, attributes }` (previously just `{ element }`), and `ElementForTagName` falls back to `GlintCustomElementTagNameMap` before `Element`.
- Plain elements resolve attributes **by tag name**: the transform emits a new `applyTagAttributes(__glintY__, { ... })` DSL call whose attrs type comes from the new `AttributesForTagName<Name>`. This is what lets attributes-only registrations work — there's no element type to reverse-look-up.
- Components are untouched: they still emit `applyAttributes(__glintY__.element, { ... })` and resolve attributes from the signature's `Element` type, so all existing elementless-component diagnostics/augmentations are byte-for-byte unchanged. `AttributesForElement<T>` additionally does a reverse lookup into the custom-element registry, so a component with `Element: MyCustomElement` gets the same attribute checking.
- `AttributesForElement<T>` also gains a graceful fallback: an `HTMLElement`/`SVGElement` subclass that isn't in any registry now accepts arbitrary attributes. Previously the type-name lookup produced `never`, which rejected **every** attribute (including `class`) for such elements.

## Differences from #1016

#1016 was exploratory and internally inconsistent (it carried four different registry names across code/docs/fixtures, and a generated `GlintTagNameAttributesMap` whose duplicate HTML/SVG keys — `a`, `script`, `style`, `title` — can't compile). This PR keeps its core architecture (name-keyed registries, `name`/`attributes` on the `emitElement` result, tag-name-based attribute resolution) with these deliberate changes:

- **Two clearly-named registries** (`GlintCustomElementTagNameMap`, `GlintCustomElementAttributesMap`), both keyed by tag name; no generated tag-name map is needed, so `bin/build-elements.mjs` and `elements.d.ts` are untouched.
- **Unregistered tags stay permissive** (`Record<string, AttrValue>`), matching today's behavior, rather than being narrowed to global HTML attributes — no breaking change for existing users of custom elements.
- **Components keep the `applyAttributes(__glintY__.element, ...)` emit** instead of switching everything to `applyAttributes(__glintY__, ...)`, which avoids the nested/uglier "An Element must be specified..." diagnostics that #1016 had to counteract with message-text sniffing in the diagnostic augmentation layer.

## Testing

- New type tests: `packages/template/__tests__/custom-elements.test.ts` (+ registry in a separate module, proving cross-file registration), `private/ElementForTagName.test.ts`, additions to `attributes.test.ts` / `AttributesForElement.test.ts`.
- New transform tests + an end-to-end fixture `test-packages/ts-template-imports-app/src/custom-elements.gts` with `@glint-expect-error` assertions (verified they're load-bearing: making a flagged line valid fails with "Unused '@ts-expect-error' directive").
- Full local run: all `test:typecheck` / `test:tsc` suites, `package-test-core` vitest (247 tests), `ts-extensionless-app`, `v2-ts-ember-addon` testem, VS Code TS-plugin smoke tests, and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
