### PR TITLE
Map .gts declaration diagnostics to source coordinates in `--incremental` shape signatures

### DIFF
--- a/packages/ember-tsc/src/cli/run-volar-tsc.ts
+++ b/packages/ember-tsc/src/cli/run-volar-tsc.ts
@@ -260,8 +260,63 @@ function injectContentTagDiagnostics(language: unknown, program: ts.Program): vo
   // same signature as the methods above but is not part of the public types.
   wrapPerFileDiagnostics('getBindAndCheckDiagnostics' as unknown as 'getSyntacticDiagnostics');
 
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { transformDiagnostic } = require('@volar/typescript/lib/node/transform.js') as {
+    transformDiagnostic: (
+      language: unknown,
+      diagnostic: ts.Diagnostic,
+      program: ts.Program | undefined,
+      isTsc: boolean,
+    ) => ts.Diagnostic | undefined;
+  };
+
   const originalEmit = program.emit;
   program.emit = (...args) => {
+    // TypeScript's incremental builder computes a changed file's "shape
+    // signature" by declaration-emitting just that file through
+    // `program.emit(sourceFile, writeFile, ct, EmitOnly.BuilderSignature, ...,
+    // forceDtsEmit)` and hashing the result — including every declaration
+    // diagnostic's `(start,length)` (see `computeSignatureWithDiagnostics`).
+    // For a .ts file those offsets are source positions, so the signature only
+    // changes when something before the diagnostic moves. For .gts/.gjs they
+    // are *transformed-file* positions, and volar's transformed text begins
+    // with a whitespace pad exactly as long as the original file — so every
+    // offset shifts whenever the file's length changes at all. A .gts with any
+    // declaration-emit diagnostic (TS2742, TS4094, ... — invisible under
+    // `--noEmit`) therefore gets a new signature on every length-changing
+    // edit, and tsc re-checks its entire transitive importer closure every
+    // time. Restore parity with .ts by mapping the diagnostics back to
+    // original source coordinates before they are hashed. (Diagnostics that
+    // exist only in generated code have no source position and are dropped.)
+    const emitOnly = args[3] as boolean | number | undefined;
+    if (emitOnly === 2 /* ts.EmitOnly.BuilderSignature (internal) */) {
+      const [sourceFile, writeFile] = args;
+      if (
+        sourceFile &&
+        writeFile &&
+        lang.scripts.get(sourceFile.fileName)?.generated?.root instanceof VirtualGtsCode
+      ) {
+        const wrappedArgs = [...args] as typeof args;
+        wrappedArgs[1] = (fileName, text, writeByteOrderMark, onError, sourceFiles, data) => {
+          // `diagnostics` is not part of the public WriteFileCallbackData type.
+          const dataWithDiagnostics = data as
+            | (ts.WriteFileCallbackData & { diagnostics?: readonly ts.Diagnostic[] })
+            | undefined;
+          if (dataWithDiagnostics?.diagnostics?.length) {
+            const diagnostics = dataWithDiagnostics.diagnostics
+              .map((diagnostic) => transformDiagnostic(language, diagnostic, program, true))
+              .filter((diagnostic) => !!diagnostic);
+            data = { ...dataWithDiagnostics, diagnostics } as ts.WriteFileCallbackData;
+          }
+          writeFile(fileName, text, writeByteOrderMark, onError, sourceFiles, data);
+        };
+        return originalEmit.apply(program, wrappedArgs);
+      }
+      // Signature emits never surface user-facing diagnostics, so skip the
+      // content-tag extras: `collectExtras()` walks every source file in the
+      // program, which is pure overhead once per signature computation.
+      return originalEmit.apply(program, args);
+    }
     const result = originalEmit.apply(program, args);
     const extras = collectExtras();
     return extras.length ? { ...result, diagnostics: [...result.diagnostics, ...extras] } : result;

--- a/test-packages/ts-extensionless-app/__tests__/incremental.test.ts
+++ b/test-packages/ts-extensionless-app/__tests__/incremental.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { execa } from 'execa';
+import { appendFileSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PROJECT_ROOT = resolve(__dirname, '..');
+const FIXTURE = resolve(PROJECT_ROOT, 'incremental-fixture');
+const EDITED_FILE = resolve(FIXTURE, 'has-decl-error.gts');
+const BUILD_INFO = resolve(FIXTURE, 'tsconfig.incremental.tsbuildinfo');
+
+const originalContents = readFileSync(EDITED_FILE, 'utf8');
+
+// Regression for `--incremental` shape signatures of .gts files.
+//
+// The incremental builder computes a changed file's signature by
+// declaration-emitting it and hashing the output — including the
+// `(start,length)` of every declaration-emit diagnostic. Those positions are
+// in transformed-file coordinates, which begin with a whitespace pad exactly
+// as long as the raw .gts — so, unfixed, ANY length-changing edit to a .gts
+// with a declaration-emit diagnostic (e.g. TS4094, which `--noEmit` never
+// reports) produces a brand-new signature, and tsc re-checks the file's whole
+// transitive importer closure on every edit, forever.
+//
+// The fix maps the diagnostics back to original source coordinates before
+// they are hashed (`EmitOnly.BuilderSignature` emits), restoring parity with
+// how tsc treats a .ts file: the signature is stable under edits after the
+// diagnostic and changes for edits before it.
+describe('ember-tsc --incremental: .gts shape signatures are stable across edits', () => {
+  afterEach(() => {
+    writeFileSync(EDITED_FILE, originalContents);
+    rmSync(BUILD_INFO, { force: true });
+  });
+
+  async function check(): Promise<void> {
+    const result = await execa('pnpm', ['ember-tsc', '--project', 'tsconfig.incremental.json'], {
+      cwd: PROJECT_ROOT,
+      reject: false,
+      all: true,
+    });
+    expect(result.exitCode, result.all).toBe(0);
+  }
+
+  function storedSignature(): string {
+    const buildInfo = JSON.parse(readFileSync(BUILD_INFO, 'utf8')) as {
+      fileNames: string[];
+      fileInfos: Array<string | { version: string; signature?: string }>;
+    };
+    const index = buildInfo.fileNames.findIndex((name) => name.endsWith('has-decl-error.gts'));
+    expect(index).toBeGreaterThanOrEqual(0);
+    const info = buildInfo.fileInfos[index];
+    // A string entry means the signature is just the source-text hash (the
+    // builder never computed a declaration-based signature for the file).
+    return typeof info === 'string' ? info : (info.signature ?? info.version);
+  }
+
+  test('a length-changing edit does not change the declaration signature', async () => {
+    rmSync(BUILD_INFO, { force: true });
+
+    // Full build: every signature starts out as a source-text hash.
+    await check();
+
+    // First edit: the builder computes a real declaration-based signature.
+    appendFileSync(EDITED_FILE, '\n// length-changing edit one\n');
+    await check();
+    const signatureAfterFirstEdit = storedSignature();
+
+    // Second, differently-sized edit: the declaration output is unchanged, so
+    // the signature must not change — otherwise every edit to this file
+    // re-checks its entire transitive importer closure.
+    appendFileSync(EDITED_FILE, '\n// a second, longer length-changing edit\n');
+    await check();
+    const signatureAfterSecondEdit = storedSignature();
+
+    expect(signatureAfterSecondEdit).toBe(signatureAfterFirstEdit);
+  });
+
+  // The inverse case, to pin tsc parity: for a .ts file, an edit BEFORE a
+  // declaration-emit diagnostic moves its source position and therefore
+  // changes the signature. A .gts must behave the same — the diagnostics are
+  // mapped to source coordinates, not discarded.
+  test('an edit before the diagnostic changes the signature, as it does for .ts', async () => {
+    rmSync(BUILD_INFO, { force: true });
+
+    await check();
+
+    appendFileSync(EDITED_FILE, '\n// trailing edit\n');
+    await check();
+    const signatureBefore = storedSignature();
+
+    // Prepend: everything after it — including the diagnostic — shifts.
+    writeFileSync(EDITED_FILE, `// leading comment\n${readFileSync(EDITED_FILE, 'utf8')}`);
+    await check();
+    const signatureAfter = storedSignature();
+
+    expect(signatureAfter).not.toBe(signatureBefore);
+  });
+});

--- a/test-packages/ts-extensionless-app/incremental-fixture/has-decl-error.gts
+++ b/test-packages/ts-extensionless-app/incremental-fixture/has-decl-error.gts
@@ -1,0 +1,14 @@
+// This export is type-clean but produces a declaration-emit diagnostic
+// (TS4094: property 'x' of exported anonymous class type may not be private).
+// Declaration-emit diagnostics are invisible under `--noEmit`, but the
+// incremental builder folds them (including their positions) into the file's
+// shape signature.
+export const withDeclEmitDiagnostic = class {
+	private x = 1;
+
+	getX(): number {
+		return this.x;
+	}
+};
+
+<template>hello</template>

--- a/test-packages/ts-extensionless-app/incremental-fixture/importer.gts
+++ b/test-packages/ts-extensionless-app/incremental-fixture/importer.gts
@@ -1,0 +1,5 @@
+import { withDeclEmitDiagnostic } from './has-decl-error';
+
+export const Klass = withDeclEmitDiagnostic;
+
+<template>ok</template>

--- a/test-packages/ts-extensionless-app/tsconfig.incremental.json
+++ b/test-packages/ts-extensionless-app/tsconfig.incremental.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "incremental-fixture/tsconfig.incremental.tsbuildinfo"
+  },
+  "include": ["incremental-fixture"]
+}


### PR DESCRIPTION
> [!IMPORTANT]
> made with claude

I'm not an expert in this codebase, and could be way off base, and I apologize if this is a waste of time / completely wrong

-------------------------

On a 19k-file app (~3,600 `.gts`), `ember-tsc --noEmit` with `"incremental": true` took **~4 minutes after any `.gts` edit** (even a comment), but ~40s after a typical `.ts` edit. Instrumenting tsc's builder showed the 4 minutes is signature-driven over-invalidation — a comment-only `.gts` edit re-checked **14,776 files**.

### The `.gts`-specific bug this PR fixes

TS's incremental builder decides how far an edit propagates by comparing the file's stored "shape signature" against a fresh one computed by declaration-emitting the file (`EmitOnly.BuilderSignature`) and hashing the output — **including every declaration-emit diagnostic's `(start,length)`** (`computeSignatureWithDiagnostics`).

For a `.ts` file those are source positions: the signature only changes when something *before* the diagnostic moves. For `.gts`/`.gjs` they are *transformed-file* positions, which sit after volar's whitespace pad — a pad exactly as long as the raw file. So **every offset shifts whenever the file's length changes at all**, and any `.gts` with a declaration-emit diagnostic (TS2742/TS4094/… — never reported under `--noEmit`, so invisible) gets a brand-new signature on every edit. When the signature changes, `handleDtsMayChangeOfFileAndExportsOfFile` re-checks the transitive importer closure — for a component that's most of the app — *and* resets every visited file's stored signature, so one such file keeps re-degrading the whole graph's incremental state forever. Sampling 31 `.gts` files in the app above, **3 (~10%)** had such hidden diagnostics.

The fix restores parity with `.ts`: for `BuilderSignature` emits of virtual files, map the diagnostics back to **original source coordinates** (via volar's `transformDiagnostic`) before they're hashed. No new semantics — a `.gts` now behaves exactly like the equivalent `.ts`: signature stable under edits after the diagnostic, changed by edits before it. (Diagnostics existing only in generated code have no source position and are dropped.)

Also in this commit: signature emits skip the content-tag `collectExtras()` pass. It never surfaces user-facing diagnostics there, and it walks every source file in the program once per `program.emit` call — measured at ~+300s wall on a full build of the app above whenever signatures get computed en masse (O(files²)).

### Tests

`test-packages/ts-extensionless-app/__tests__/incremental.test.ts`, fixture is type-clean but produces TS4094 on declaration emit:
- a length-changing edit **after** the diagnostic must not change the stored signature (fails on `main` with signature drift);
- an edit **before** the diagnostic must change it, exactly as for `.ts` — pinning that we map, not discard.

Existing `ts-extensionless-app` tests (build-mode, watch, content-tag errors) pass; `pnpm lint` clean.

### Not in this PR (findings from the same investigation, for context)

- The remaining `.gts`-vs-`.ts` asymmetry is stock tsc behavior amplified by graph shape: a full `--incremental` build stores source-text hashes as signatures, so the *first* edit of any file afterwards is a guaranteed "shape changed" → closure re-check. `.ts` files in the app have tiny reverse-dependency closures (median 1, p90 19 files); `.gts` components sit under everything's import cone (p90 = 14,776). That's a TypeScript-core conversation (tsserver already opts out via `disableUseFileVersionAsSignature`), not something glint should paper over.
- The diagnostics-mapping arguably belongs upstream in `@volar/typescript`'s `decorateProgram` — vue-tsc has the same padded-offset exposure.

Related: #1200 fixes `--build --watch` program reuse — independent mechanisms, both needed for big-monorepo DX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)