### PR TITLE
Export package.json from @glint/ember-tsc

### DIFF
--- a/packages/ember-tsc/package.json
+++ b/packages/ember-tsc/package.json
@@ -45,6 +45,7 @@
     "./-private/intrinsics/truth-helpers": "./types/-private/intrinsics/truth-helpers.d.ts",
     "./-private/intrinsics/unbound": "./types/-private/intrinsics/unbound.d.ts",
     "./-private/intrinsics/unique-id": "./types/-private/intrinsics/unique-id.d.ts",
+    "./package.json": "./package.json",
     "./*": {
       "types": "./lib/*.d.ts",
       "default": "./lib/*.js"


### PR DESCRIPTION
Adds `"./package.json": "./package.json"` to `@glint/ember-tsc`'s exports map.

Tools that build on the transform need the installed package's version and location. [ember-content-mapper](https://github.com/NullVoxPopuli/ember-content-mapper/pull/1) (a TypeScript 7 content mapper wrapping `rewriteModule`) uses both: it fingerprints its dynamic configuration with the `@glint/ember-tsc` version, and it resolves `ember-source` from the package's location to mirror the ember-template-imports environment's own 7.1 probe. With the exports map blocking `require('@glint/ember-tsc/package.json')`, it currently derives the package root by walking up from `import.meta.resolve('@glint/ember-tsc/transform')`, which is fragile against layout changes.

`"./package.json"` is a conventional export (Node docs recommend it; most packages with exports maps include it) and exposes nothing that isn't already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)