### PR TITLE
Surface handlebars parse errors from ember-tsc and the tsserver plugin

### DIFF
--- a/packages/ember-tsc/src/transform/diagnostics/transform-errors.ts
+++ b/packages/ember-tsc/src/transform/diagnostics/transform-errors.ts
@@ -3,16 +3,24 @@ import TransformedModule from '../template/transformed-module.js';
 import { Diagnostic } from './index.js';
 
 /**
- * Synthesize TypeScript diagnostics for any unrecoverable transform errors
- * (currently: content-tag parse failures) so that consumers of the
- * tsserver-plugin path see the underlying error rather than nothing.
+ * Synthesize TypeScript diagnostics for the transform errors recorded on a
+ * `TransformedModule` so that consumers of the tsserver-plugin and `ember-tsc`
+ * CLI paths see the underlying error rather than nothing. Two kinds of error
+ * land here:
  *
- * Without this, when content-tag fails to parse a .gts/.gjs file we suppress
- * the resulting flood of TS errors by disabling `verification` on every
- * mapping (see `rewriteModule` / `toVolarMappings`). That leaves the tsserver
- * path silent on its own — fine inside VS Code, where the Volar language
- * server's `g-compiler-errors` plugin surfaces the error, but unhelpful for
- * any consumer running only the tsserver plugin.
+ * - content-tag parse failures (`isContentTagError`). When content-tag cannot
+ *   parse a .gts/.gjs file we suppress the resulting flood of TS errors by
+ *   disabling `verification` on every mapping (see `rewriteModule` /
+ *   `toVolarMappings`), which leaves those paths silent on their own.
+ *
+ * - handlebars parse failures inside an individual `<template>`. The template
+ *   contributes no transformed output, so TypeScript has nothing to report
+ *   for it and the rest of the template goes unchecked; the only trace of the
+ *   failure is the error recorded here (typed-ember/glint#1221).
+ *
+ * The Volar language server surfaces both through its `g-compiler-errors`
+ * plugin, so VS Code sees them regardless; this function covers every other
+ * consumer.
  *
  * Offsets are in original (.gts) source coordinates; tsserver maps them to
  * line/column using its own ScriptInfo for the source file, so the same
@@ -22,20 +30,18 @@ export function getTransformErrorDiagnostics(
   transformedModule: TransformedModule,
   sourceFile: ts.SourceFile,
 ): Diagnostic[] {
-  return transformedModule.errors
-    .filter((error) => error.isContentTagError)
-    .map((error) => ({
-      file: sourceFile,
-      start: error.location.start,
-      length: Math.max(1, error.location.end - error.location.start),
-      messageText: error.message,
-      // ts.DiagnosticCategory.Error — hardcoded to avoid importing the ts
-      // namespace just for the enum.
-      category: 1,
-      // Matches the code used by the Volar language server's compiler-errors
-      // plugin, so the two surfaces present a consistent identity.
-      code: 0,
-      source: 'glint',
-      isContentTagError: true,
-    }));
+  return transformedModule.errors.map((error) => ({
+    file: sourceFile,
+    start: error.location.start,
+    length: Math.max(1, error.location.end - error.location.start),
+    messageText: error.message,
+    // ts.DiagnosticCategory.Error — hardcoded to avoid importing the ts
+    // namespace just for the enum.
+    category: 1,
+    // Matches the code used by the Volar language server's compiler-errors
+    // plugin, so the two surfaces present a consistent identity.
+    code: 0,
+    source: 'glint',
+    isContentTagError: error.isContentTagError,
+  }));
 }

--- a/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
+++ b/test-packages/package-test-core/__tests__/language-server/diagnostics.test.ts
@@ -907,6 +907,68 @@ describe('Language Server: Diagnostics (ts plugin)', () => {
     `);
   });
 
+  test('handlebars parse errors are surfaced through tsserver alongside TS diagnostics', async () => {
+    // A `{{! }}` comment ends at the first `}}` (the one closing `{{array}}`),
+    // so the `{{#let}}` after it is parsed as content and the template fails
+    // to parse. The template
+    // contributes no transformed output in that case, so without surfacing
+    // the transform error here the tsserver path reports nothing at all for
+    // it (typed-ember/glint#1221). The script portion is still checked.
+    const code = stripIndent`
+      import Component from '@glimmer/component';
+
+      const notANumber: number = 'nope';
+
+      export default class MyComponent extends Component {
+        <template>
+          {{! ---- {{array}} bound via {{#let}} ---- }}
+          <div></div>
+        </template>
+      }
+    `;
+
+    const diagnostics = await requestTsserverDiagnostics(
+      'ts-template-imports-app/src/empty-fixture.gts',
+      'glimmer-ts',
+      code,
+    );
+
+    expect(diagnostics).toMatchInlineSnapshot(`
+      [
+        {
+          "category": "error",
+          "code": 0,
+          "end": {
+            "line": 9,
+            "offset": 3,
+          },
+          "source": "glint",
+          "start": {
+            "line": 7,
+            "offset": 42,
+          },
+          "text": "Parse error on line 4:
+      ...}    <div></div>  
+      ---------------------^
+      Expecting 'OPEN_INVERSE_CHAIN', 'INVERSE', 'OPEN_ENDBLOCK', got 'EOF'",
+        },
+        {
+          "category": "error",
+          "code": 2322,
+          "end": {
+            "line": 3,
+            "offset": 17,
+          },
+          "start": {
+            "line": 3,
+            "offset": 7,
+          },
+          "text": "Type 'string' is not assignable to type 'number'.",
+        },
+      ]
+    `);
+  });
+
   test('HTML attribute type-checking', async () => {
     const code = stripIndent`
       import Component from '@glimmer/component';

--- a/test-packages/ts-extensionless-app/__tests__/content-tag-errors.test.ts
+++ b/test-packages/ts-extensionless-app/__tests__/content-tag-errors.test.ts
@@ -182,3 +182,60 @@ describe('ember-tsc surfaces content-tag parse errors', () => {
     `);
   });
 });
+
+// Regression test for https://github.com/typed-ember/glint/issues/1221.
+// `ember-tsc` surfaced content-tag parse errors (above) but dropped handlebars
+// parse errors from individual `<template>` tags: the broken template
+// contributed no transformed output, so TypeScript had nothing to report and
+// the whole template went silently unchecked.
+describe('ember-tsc surfaces handlebars parse errors', () => {
+  const targets: string[] = [];
+
+  afterEach(() => {
+    while (targets.length) {
+      try {
+        unlinkSync(targets.pop()!);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  test('reports an unclosed block inside a template and exits non-zero', async () => {
+    const target = resolve(SRC_DIR, '_broken_handlebars.gts');
+    targets.push(target);
+    writeFileSync(
+      target,
+      [
+        `import Component from '@glimmer/component';`,
+        ``,
+        `export default class Broken extends Component {`,
+        `  <template>`,
+        // A `{{! }}` comment ends at the first `}}` (the one closing
+        // `{{array}}`), so the `{{#let}}` after it is parsed as content and
+        // never closed.
+        `    {{! ---- {{array}} bound via {{#let}} ---- }}`,
+        `    <div></div>`,
+        `  </template>`,
+        `}`,
+        ``,
+      ].join('\n'),
+    );
+
+    const result = await execa('node', [EMBER_TSC_BIN, '--noEmit'], {
+      cwd: PROJECT_ROOT,
+      reject: false,
+      all: true,
+    });
+
+    const diagnostic = stripAnsi(result.all ?? '').trimEnd();
+
+    expect(result.exitCode, `output:\n${result.all}`).not.toBe(0);
+    expect(diagnostic).toMatchInlineSnapshot(`
+      "src/_broken_handlebars.gts(5,42): error TS0: Parse error on line 4:
+      ...}    <div></div>  
+      ---------------------^
+      Expecting 'OPEN_INVERSE_CHAIN', 'INVERSE', 'OPEN_ENDBLOCK', got 'EOF'"
+    `);
+  });
+});

--- a/test-packages/ts-gts-7-1-app/src/globals/array-keyword-preserve-literals.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/array-keyword-preserve-literals.test.gts
@@ -15,12 +15,12 @@ const Layer: TOC<{ Args: { op: Expr } }> = <template></template>;
 const identity = <T,>(value: T): T => value;
 
 <template>
-  {{! ---- {{array}} bound directly via {{#let}} ---- }}
+  {{!-- ---- {{array}} bound directly via {{#let}} ---- --}}
   {{#let (array "case" 1 2) as |op|}}
     <Layer @op={{op}} />
   {{/let}}
 
-  {{! ---- {{array}} nested inside another helper, result bound via {{#let}} ---- }}
+  {{!-- ---- {{array}} nested inside another helper, result bound via {{#let}} ---- --}}
   {{#let (identity (array "case" 1 2)) as |op|}}
     <Layer @op={{op}} />
   {{/let}}

--- a/test-packages/ts-gts-7-1-app/src/globals/narrowing.test.gts
+++ b/test-packages/ts-gts-7-1-app/src/globals/narrowing.test.gts
@@ -85,7 +85,7 @@ const barLit = 'bar' as const;
   {{expectTypeOf (and truthyObj fallback) to.beString}}
   {{expectTypeOf (and truthyObj fallbackCount) to.beNumber}}
 
-  {{! ===== (2) control-flow narrowing via {{#if}} ===== }}
+  {{!-- ===== (2) control-flow narrowing via {{#if}} ===== --}}
 
   {{! ---- optional value: the guard refines `string | undefined` to `string`.
       (The else branch stays `string | undefined`, since `''` is also falsy and


### PR DESCRIPTION
Fixes #1221

`ember-tsc --noEmit` reported nothing for a `.gts` whose template failed handlebars parsing, and the rest of that template went unchecked.

**Cause:** `getTransformErrorDiagnostics` filtered `transformedModule.errors` to `isContentTagError`, so handlebars parse errors (which are recorded on the same array) were dropped by both the CLI and the tsserver plugin. The Volar language server's `g-compiler-errors` plugin already reported them, so VS Code was unaffected.

**Fix:** forward every transform error. The diagnostic keeps the same `code: 0` / `source: 'glint'` identity as the content-tag ones.

Also fixes two files in `test-packages/ts-gts-7-1-app` that hit this on main: their `{{! }}` comments contain nested mustaches, so the comment ended at the first `}}` and a stray `{{#let}}` was left open. With the fix, `pnpm test:typecheck` in that package fails on the old comments and passes with `{{!-- --}}`.

Tests:
- `ts-extensionless-app`: CLI test asserting a non-zero exit and the diagnostic for an unclosed block.
- `package-test-core`: tsserver-path test asserting the parse error is reported alongside a TS error from the script portion.

Note: like a TS syntax error, the injected diagnostic lands in `getSyntacticDiagnostics`, so `tsc` skips semantic checking of the program until it is fixed. That matches how tsc treats syntax errors in `.ts` files and how content-tag errors already behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsXgxh6vNRWMCNcAQ3g6TN
