### PR TITLE
VS Code extension: stand down on TypeScript 7 workspaces

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -78,6 +78,23 @@ export const { activate, deactivate } = defineExtension(() => {
   let pendingRestart = false;
   let lastActivationReason: string | undefined;
 
+  // Glint's language server and tsserver plugin require the TypeScript 5/6
+  // JS API, which the TypeScript 7 package does not ship. On a TS 7 workspace
+  // they would only produce broken diagnostics, so Glint stands down entirely:
+  // template type-checking comes from a content mapper run by TypeScript
+  // itself instead.
+  const workspaceTypeScriptVersion = detectWorkspaceTypeScriptVersion(getLibraryPathSetting());
+  if (workspaceTypeScriptVersion && parseInt(workspaceTypeScriptVersion, 10) >= 7) {
+    outputChannel.appendLine(
+      `[Activation] TypeScript ${workspaceTypeScriptVersion} is installed in this workspace. ` +
+        `Glint requires TypeScript 5 or 6, so the Glint language server and tsserver plugin will not start. ` +
+        `With TypeScript 7, template type-checking comes from a content mapper instead: add ` +
+        `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
+        `in tsconfig.json and run tsc with --runExternalCode.`,
+    );
+    return volarLabs.extensionExports;
+  }
+
   const emberTscStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   emberTscStatus.command = SELECT_EMBER_TSC_COMMAND;
   context.subscriptions.push(emberTscStatus);
@@ -489,6 +506,28 @@ function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | und
   try {
     const customRequire = createRequire(path.join(resolutionDir, 'package.json'));
     return customRequire.resolve('@glint/ember-tsc/bin/glint-language-server');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The version of the `typescript` package installed in the workspace, or
+ * `undefined` when there is no workspace folder or no resolvable typescript.
+ * Both the TypeScript 5/6 and 7 packages export their package.json, so this
+ * resolves across every version Glint might encounter.
+ */
+function detectWorkspaceTypeScriptVersion(libraryPath: string): string | undefined {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  if (!workspaceFolder) {
+    return undefined;
+  }
+
+  try {
+    const resolutionDir = path.resolve(workspaceFolder.uri.fsPath, libraryPath);
+    const customRequire = createRequire(path.join(resolutionDir, 'package.json'));
+    const manifest = customRequire('typescript/package.json') as { version?: unknown };
+    return typeof manifest.version === 'string' ? manifest.version : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
When the workspace's installed `typescript` is version 7 or newer, the Glint extension now disables itself at activation instead of starting a language server that cannot work.

Glint's language server and tsserver plugin need the TypeScript 5/6 JS API. The TypeScript 7 package is the native compiler and ships no JS API, so on a TS 7 workspace Glint can only produce broken output (in practice: syntax-error squiggles across every `<template>` tag, because the plugin never loads and tsserver parses `.gts` as plain TS). Template type-checking on TS 7 comes from a content mapper run by TypeScript itself ([ember-content-mapper](https://github.com/NullVoxPopuli/ember-content-mapper)).

What this PR does at activation:

- Resolves `typescript/package.json` from the first workspace folder, honoring `glint2.libraryPath`. Both the TS 5/6 and TS 7 packages export `./package.json`, so the resolution works across versions.
- If the major version is >= 7: logs to the "Glint2 Language Server" output channel that Glint requires TypeScript 5 or 6 and that template type-checking now comes from `ember-content-mapper` via `contentMappers` in tsconfig.json with `tsc --runExternalCode`, then returns early. The language server, the tsserver plugin configuration, and the Ember TSC status bar item never start.
- Otherwise: behavior is unchanged.

Notes for review:

- The check runs once at activation; switching the workspace TypeScript major requires a reload, which matches how the extension already treats server-affecting changes.
- The early return also skips registering `glint2.restart-language-server` and the Ember TSC source command. Since no server exists to restart or configure on these workspaces, that seemed right, but registering no-op commands instead is a small change if preferred.
- A follow-up could have the extension call the Native Preview extension's `registerContentMappers` API on these workspaces (microsoft/typescript-go#4712's LSP-activation section), so `.gts` files get TS 7 language features without opening a `.ts` file first. That needs a Native Preview build newer than 2026-08-19, which the marketplace does not have yet.

`pnpm compile` passes in `packages/vscode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)