### PR TITLE
Register .gts/.gjs with TypeScript (Native Preview) on TypeScript 7 workspaces

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -92,6 +92,7 @@ export const { activate, deactivate } = defineExtension(() => {
         `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
         `in tsconfig.json and run tsc with --runExternalCode.`,
     );
+    void registerContentMapperContribution(context, outputChannel);
     return volarLabs.extensionExports;
   }
 
@@ -508,6 +509,64 @@ function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | und
     return customRequire.resolve('@glint/ember-tsc/bin/glint-language-server');
   } catch {
     return undefined;
+  }
+}
+
+const NATIVE_PREVIEW_EXTENSION_ID = 'TypeScriptTeam.native-preview';
+
+interface NativePreviewApi {
+  registerContentMappers?: (
+    contributorId: string,
+    contributions: ReadonlyArray<{ extensions: ReadonlyArray<string> }>,
+  ) => vscode.Disposable;
+}
+
+/**
+ * TypeScript's native language server only tracks documents whose file
+ * extensions an extension has registered with it, so without this call a
+ * content-mapped `.gts` file never reaches the server and gets no hover,
+ * completions, or diagnostics in the editor. Registering also lets the server
+ * discover the project's tsconfig from a `.gts` file alone.
+ */
+async function registerContentMapperContribution(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+): Promise<void> {
+  const nativePreview = vscode.extensions.getExtension<NativePreviewApi | undefined>(
+    NATIVE_PREVIEW_EXTENSION_ID,
+  );
+  if (!nativePreview) {
+    outputChannel.appendLine(
+      `[Activation] The TypeScript (Native Preview) extension (${NATIVE_PREVIEW_EXTENSION_ID}) is not installed, ` +
+        `so .gts and .gjs files will not get TypeScript 7 language features.`,
+    );
+    return;
+  }
+
+  try {
+    const api = await nativePreview.activate();
+    const registration = api?.registerContentMappers?.(V2_EXTENSION_ID, [
+      { extensions: ['.gts', '.gjs'] },
+    ]);
+
+    if (!registration) {
+      outputChannel.appendLine(
+        `[Activation] The installed TypeScript (Native Preview) build does not support content mapper ` +
+          `registration; a build newer than 2026-08-19 is required for .gts and .gjs language features.`,
+      );
+      return;
+    }
+
+    context.subscriptions.push(registration);
+    outputChannel.appendLine(
+      '[Activation] Registered .gts and .gjs with TypeScript (Native Preview) for content mapper support.',
+    );
+  } catch (error) {
+    outputChannel.appendLine(
+      `[Activation] Registering with TypeScript (Native Preview) failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
 }
 


### PR DESCRIPTION
Follow-up to #1228, which made the extension stand down on TypeScript 7 workspaces. Standing down alone leaves `.gts`/`.gjs` files dark in the editor: TypeScript's native client only sends documents to the server for the languages in its own selector (`javascript`, `typescript`, and friends) plus whatever a third-party extension registers through `registerContentMappers`. `.gts` is `glimmer-ts`, so without a registration the server never receives a `didOpen` for it: no hover, completions, or in-editor diagnostics, even though `tsc --runExternalCode` checks the file fine on the CLI. (Confirmed against ember-content-mapper's example app: Neovim, which sets filetypes directly, worked; VS Code showed nothing until this registration.)

On TypeScript 7 workspaces, after standing down, the extension now activates TypeScript (Native Preview) and calls `registerContentMappers('typed-ember.glint2-vscode', [{ extensions: ['.gts', '.gjs'] }])`, keeping the returned disposable in the extension's subscriptions. It also lets the server discover the project's tsconfig from a `.gts` file alone, so users no longer need to open a `.ts` file first.

Outcomes are logged to the Glint output channel: Native Preview not installed, installed build too old to expose the API (needs a build newer than 2026-08-19; the marketplace is still on 0.20260708.2, so today this needs a build from typescript-go main), or registered. The API is typed loosely in the extension (`registerContentMappers?` on the `activate()` result) to avoid a dependency on Native Preview's types.

`pnpm compile` passes in `packages/vscode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)