### PR TITLE
Treat index-signature Args maps as shorthand named args

### DIFF
--- a/packages/template/-private/signature.d.ts
+++ b/packages/template/-private/signature.d.ts
@@ -17,18 +17,29 @@ export type InvokableArgs<Args> = [
 export type ComponentSignatureArgs<S> = S extends {
   Args: infer Args;
 }
-  ? Args extends {
-      Named?: object;
-      Positional?: unknown[];
-    }
-    ? {
-        Named: Get<S['Args'], 'Named', {}>;
-        Positional: Get<S['Args'], 'Positional', []>;
-      }
-    : {
+  ? string extends keyof Args
+    ? // An args map with a string index signature (e.g. `Record<string, never>`
+      // or `Record<string, unknown>`) is shorthand named args. Without this
+      // guard, the index signature satisfies the expanded-form test below (it
+      // "provides" both `Named` and `Positional`), normalizing the signature
+      // to `{ Named: never; Positional: never }` and making the component
+      // uninvokable.
+      {
         Named: S['Args'];
         Positional: [];
       }
+    : Args extends {
+          Named?: object;
+          Positional?: unknown[];
+        }
+      ? {
+          Named: Get<S['Args'], 'Named', {}>;
+          Positional: Get<S['Args'], 'Positional', []>;
+        }
+      : {
+          Named: S['Args'];
+          Positional: [];
+        }
   : {
       Named: keyof S extends 'Args' | 'Blocks' | 'Element' ? {} : S;
       Positional: [];

--- a/packages/template/__tests__/resolution.test.ts
+++ b/packages/template/__tests__/resolution.test.ts
@@ -12,6 +12,7 @@ import {
   NamedArgs,
   TemplateContext,
 } from '../-private/integration';
+import { ComponentLike } from '../-private/index';
 import TestComponent, { globals } from './test-component';
 
 declare function value<T>(): T;
@@ -84,6 +85,25 @@ declare function value<T>(): T;
   }>;
 
   expectTypeOf(resolve(value<DirectInvokable<TestSignature>>())).toEqualTypeOf<TestSignature>();
+}
+
+// A `ComponentLike` whose `Args` is an index-signature map resolves to an
+// invokable signature, the same as the equivalent expanded form. (Previously
+// the index signature satisfied the expanded-form detection in
+// `ComponentSignatureArgs`, normalizing the args to never/never and making
+// the component uninvokable.)
+{
+  type NoArgs = Record<string, never>;
+
+  const shorthand = resolve(value<ComponentLike<{ Args: NoArgs }>>());
+  const expanded = resolve(value<ComponentLike<{ Args: { Named: NoArgs; Positional: [] } }>>());
+
+  // Both forms resolve to the same signature...
+  expectTypeOf(shorthand).toEqualTypeOf(expanded);
+
+  // ...whose named args are optional, i.e. the component is invokable rather
+  // than degrading to `(...args: never)`.
+  expectTypeOf(shorthand).parameters.toEqualTypeOf<[named?: NamedArgs<NoArgs>]>();
 }
 
 // Values of type `any` or `never` (themselves typically the product of other type errors)

--- a/packages/template/__tests__/signature.test.ts
+++ b/packages/template/__tests__/signature.test.ts
@@ -38,6 +38,30 @@ expectTypeOf<ComponentSignatureArgs<ArgsOnly>>().toEqualTypeOf<{
 expectTypeOf<ComponentSignatureBlocks<ArgsOnly>>().toEqualTypeOf<{}>();
 expectTypeOf<ComponentSignatureElement<ArgsOnly>>().toEqualTypeOf<unknown>();
 
+// An args map with a string index signature is shorthand named args, not the
+// expanded `{ Named, Positional }` form (whose members the index signature
+// would otherwise appear to provide, degrading the signature to
+// `{ Named: never; Positional: never }`).
+interface IndexSignatureArgs {
+  Args: Record<string, never>;
+}
+
+expectTypeOf<ComponentSignatureArgs<IndexSignatureArgs>>().toEqualTypeOf<{
+  Named: Record<string, never>;
+  Positional: [];
+}>();
+expectTypeOf<ComponentSignatureBlocks<IndexSignatureArgs>>().toEqualTypeOf<{}>();
+expectTypeOf<ComponentSignatureElement<IndexSignatureArgs>>().toEqualTypeOf<unknown>();
+
+interface OpenIndexSignatureArgs {
+  Args: Record<string, unknown>;
+}
+
+expectTypeOf<ComponentSignatureArgs<OpenIndexSignatureArgs>>().toEqualTypeOf<{
+  Named: Record<string, unknown>;
+  Positional: [];
+}>();
+
 interface ElementOnly {
   Element: HTMLParagraphElement;
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made with Claude (via Claude Code), investigating type-checking regressions during a large TS 7 + content-mapper migration. Apologies in advance if it misses something — happy to adjust.

## The bug

`ComponentSignatureArgs` decides between the shorthand and expanded (`{ Named, Positional }`) arg forms with a weak-type test:

```ts
Args extends {
  Named?: object;
  Positional?: unknown[];
}
```

An args map with a **string index signature** — `Record<string, never>`, `Record<string, unknown>`, etc. — satisfies this test (the index signature "provides" both `Named` and `Positional`), so it's misclassified as the expanded form. `Get<Args, 'Named'>` then resolves through the index signature to the index value type, producing `{ Named: never; Positional: never }` for `Record<string, never>`, and `InvokableArgs` collapses to `(...args: never)` — the component becomes uninvokable, surfacing as:

```
error TS2345: Argument of type '[]' is not assignable to parameter of type 'never'.
```

at every invocation site. Minimal repro:

```ts
import type { ComponentLike } from '@glint/template';
import { resolve } from '@glint/ember-tsc/-private/dsl';

declare const RecNever: ComponentLike<{ Args: Record<string, never> }>;
declare const Explicit: ComponentLike<{ Args: { Named: Record<string, never>; Positional: [] } }>;

const r1 = resolve(RecNever);  // before: (...args: never) => any   ← uninvokable
const r2 = resolve(Explicit);  // (named?: NamedArgs<...>) => ComponentReturn<...>
```

(Verified identical under TypeScript 6.0.3 and the 7.1 nightly — it's a types bug, not a compiler divergence. Found via [ember-content-mapper#13](https://github.com/NullVoxPopuli/ember-content-mapper/issues/13); `Args: Record<string, never>` is a fairly common way to write "this component takes no args".)

## The fix

Detect index-signature args maps first (`string extends keyof Args`) and treat them as shorthand named args. Edge cases:

- `Args: {}` — unchanged (`keyof {}` is `never`; falls through to the existing branches).
- Shorthand `{ foo?: string }` — unchanged (weak-type overlap rules already reject it from the expanded branch).
- Real expanded forms — unchanged (`keyof` is `'Named' | 'Positional'`).

## Tests

- `signature.test.ts`: `ComponentSignatureArgs` normalization for `Record<string, never>` and `Record<string, unknown>`.
- `resolution.test.ts`: a `ComponentLike<{ Args: Record<string, never> }>` resolves to the same signature as the equivalent expanded form, with optional (non-`never`) named args.

`pnpm test` and `pnpm test:typecheck` pass across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
