### PR TITLE
Add a NoArgs signature Args type

### DIFF
--- a/packages/template/-private/index.d.ts
+++ b/packages/template/-private/index.d.ts
@@ -57,6 +57,20 @@ type ArglessCurlyComponent = ComponentReturn<{}, any>;
 export type AttrValue = string | number | boolean | null | undefined | SafeString;
 
 /**
+ * A signature `Args` member for an invokable that accepts no arguments:
+ * there are no positional arguments, and every named argument is an error.
+ *
+ *     import Component from '@glimmer/component';
+ *     import type { NoArgs } from '@glint/template';
+ *
+ *     export default class Divider extends Component<{ Args: NoArgs }> {}
+ */
+export type NoArgs = {
+  Named: Record<string, never>;
+  Positional: [];
+};
+
+/**
  * A value that is invokable like a component in a template. In an
  * appropriate Glint environment, subclasses of `EmberComponent` and
  * `GlimmerComponent` are examples of `ComponentLike` values, as are

--- a/packages/template/__tests__/no-args.test.ts
+++ b/packages/template/__tests__/no-args.test.ts
@@ -1,0 +1,70 @@
+import { expectTypeOf } from 'expect-type';
+import { NamedArgsMarker, resolve } from '../-private/dsl';
+import { ComponentLike, HelperLike, ModifierLike, NoArgs } from '../-private/index';
+import { ModifierReturn, NamedArgs } from '../-private/integration';
+
+declare function value<T>(): T;
+
+// ComponentLike
+{
+  const component = resolve(value<ComponentLike<{ Args: NoArgs }>>());
+
+  expectTypeOf(component).parameters.toEqualTypeOf<[named?: NamedArgs<Record<string, never>>]>();
+
+  component();
+  component({ ...NamedArgsMarker });
+  component(
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  component(
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+
+  // The `Args: NoArgs` and shorthand `Args: Record<string, never>` spellings
+  // normalize identically.
+  expectTypeOf(value<ComponentLike<{ Args: Record<string, never> }>>()).toEqualTypeOf<
+    ComponentLike<{ Args: NoArgs }>
+  >();
+}
+
+// HelperLike
+{
+  const helper = resolve(value<HelperLike<{ Args: NoArgs; Return: string }>>());
+
+  expectTypeOf(helper).toEqualTypeOf<(named?: NamedArgs<Record<string, never>>) => string>();
+  expectTypeOf(helper()).toEqualTypeOf<string>();
+
+  helper({ ...NamedArgsMarker });
+  helper(
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  helper(
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}
+
+// ModifierLike
+{
+  const modifier = resolve(value<ModifierLike<{ Args: NoArgs; Element: HTMLCanvasElement }>>());
+
+  expectTypeOf(modifier).toEqualTypeOf<
+    (element: HTMLCanvasElement, named?: NamedArgs<Record<string, never>>) => ModifierReturn
+  >();
+
+  modifier(value<HTMLCanvasElement>());
+  modifier(value<HTMLCanvasElement>(), { ...NamedArgsMarker });
+  modifier(
+    value<HTMLCanvasElement>(),
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  modifier(
+    value<HTMLCanvasElement>(),
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}

--- a/test-packages/package-test-core/__tests__/type-tests/no-args.test.ts
+++ b/test-packages/package-test-core/__tests__/type-tests/no-args.test.ts
@@ -149,9 +149,7 @@ declare function value<T>(): T;
   expectTypeOf(attach).parameters.toEqualTypeOf<
     [element: HTMLAudioElement, named?: NamedArgs<Record<string, never>>]
   >();
-  expectTypeOf(definition).toExtend<
-    ModifierLike<{ Args: NoArgs; Element: HTMLAudioElement }>
-  >();
+  expectTypeOf(definition).toExtend<ModifierLike<{ Args: NoArgs; Element: HTMLAudioElement }>>();
 
   attach(value<HTMLAudioElement>());
   attach(

--- a/test-packages/package-test-core/__tests__/type-tests/no-args.test.ts
+++ b/test-packages/package-test-core/__tests__/type-tests/no-args.test.ts
@@ -1,0 +1,167 @@
+import EmberComponent from '@ember/component';
+import Helper, { helper } from '@ember/component/helper';
+import { emitComponent, NamedArgsMarker, resolve } from '@glint/ember-tsc/-private/dsl';
+import { ComponentLike, HelperLike, ModifierLike, NoArgs } from '@glint/template';
+import { NamedArgs } from '@glint/template/-private/integration';
+import GlimmerComponent from '@glimmer/component';
+import Modifier, { modifier } from 'ember-modifier';
+import { expectTypeOf } from 'expect-type';
+
+import '@glint/ember-tsc/types';
+
+declare function value<T>(): T;
+
+// Glimmer component
+{
+  class NoArgsGlimmer extends GlimmerComponent<{ Args: NoArgs }> {}
+
+  const component = resolve(NoArgsGlimmer);
+
+  expectTypeOf(component).parameters.toEqualTypeOf<[named?: NamedArgs<Record<string, never>>]>();
+  expectTypeOf(NoArgsGlimmer).toExtend<ComponentLike<{ Args: NoArgs }>>();
+
+  emitComponent(component());
+  emitComponent(component({ ...NamedArgsMarker }));
+  component(
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  component(
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}
+
+// Ember (classic) component
+{
+  class NoArgsEmber extends EmberComponent<{ Args: NoArgs }> {}
+
+  const component = resolve(NoArgsEmber);
+
+  expectTypeOf(component).parameters.toEqualTypeOf<[named?: NamedArgs<Record<string, never>>]>();
+  expectTypeOf(NoArgsEmber).toExtend<ComponentLike<{ Args: NoArgs }>>();
+
+  emitComponent(component());
+  component(
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  component(
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}
+
+// Plain function helper
+{
+  const plain = (): string => 'hi';
+
+  const helperFn = resolve(plain);
+
+  expectTypeOf(helperFn()).toEqualTypeOf<string>();
+  // A zero-arg function is usable wherever a NoArgs helper's resolved
+  // signature is expected.
+  expectTypeOf(plain).toExtend<(named?: NamedArgs<Record<string, never>>) => string>();
+}
+
+// helper()
+{
+  const definition = helper<{ Args: NoArgs; Return: number }>(() => 123);
+
+  const info = resolve(definition);
+
+  expectTypeOf(info).parameters.toEqualTypeOf<[named?: NamedArgs<Record<string, never>>]>();
+  expectTypeOf(info()).toEqualTypeOf<number>();
+  expectTypeOf(definition).toExtend<HelperLike<{ Args: NoArgs; Return: number }>>();
+
+  info(
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  info(
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}
+
+// Class-based helper
+{
+  class NoArgsHelper extends Helper<{ Args: NoArgs; Return: number }> {
+    override compute(): number {
+      return 123;
+    }
+  }
+
+  const info = resolve(NoArgsHelper);
+
+  expectTypeOf(info).parameters.toEqualTypeOf<[named?: NamedArgs<Record<string, never>>]>();
+  expectTypeOf(info()).toEqualTypeOf<number>();
+  expectTypeOf(NoArgsHelper).toExtend<HelperLike<{ Args: NoArgs; Return: number }>>();
+
+  info(
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  info(
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}
+
+// Class-based modifier
+{
+  class NoArgsModifier extends Modifier<{ Args: NoArgs; Element: HTMLImageElement }> {
+    override modify(element: HTMLImageElement): void {
+      element;
+    }
+  }
+
+  const attach = resolve(NoArgsModifier);
+
+  expectTypeOf(attach).parameters.toEqualTypeOf<
+    [element: HTMLImageElement, named?: NamedArgs<Record<string, never>>]
+  >();
+  expectTypeOf(NoArgsModifier).toExtend<
+    ModifierLike<{ Args: NoArgs; Element: HTMLImageElement }>
+  >();
+
+  attach(value<HTMLImageElement>());
+  attach(
+    value<HTMLImageElement>(),
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  attach(
+    value<HTMLImageElement>(),
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}
+
+// Function-based modifier
+{
+  const definition = modifier<{ Args: NoArgs; Element: HTMLAudioElement }>((element) => {
+    element;
+  });
+
+  const attach = resolve(definition);
+
+  expectTypeOf(attach).parameters.toEqualTypeOf<
+    [element: HTMLAudioElement, named?: NamedArgs<Record<string, never>>]
+  >();
+  expectTypeOf(definition).toExtend<
+    ModifierLike<{ Args: NoArgs; Element: HTMLAudioElement }>
+  >();
+
+  attach(value<HTMLAudioElement>());
+  attach(
+    value<HTMLAudioElement>(),
+    // @ts-expect-error: no named args are accepted
+    { anything: true, ...NamedArgsMarker },
+  );
+  attach(
+    value<HTMLAudioElement>(),
+    // @ts-expect-error: no positional args are accepted
+    'oops',
+  );
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was made with Claude (via Claude Code). Apologies in advance if it misses something — happy to adjust.

Adds a `NoArgs` type to `@glint/template` — an explicit spelling for "this invokable accepts no arguments":

```ts
export type NoArgs = {
  Named: Record<string, never>;
  Positional: [];
};
```

```ts
import type { NoArgs } from '@glint/template';

export default class Divider extends Component<{ Args: NoArgs }> {}
```

Every named argument errors (`Record<string, never>`) and there are no positionals. With #1234's normalization fix, the shorthand `Args: Record<string, never>` resolves identically — the tests pin that equivalence — but the expanded form is self-documenting and works on every glint 1.x release.

## Tests

- `packages/template/__tests__/no-args.test.ts` — `ComponentLike`, `HelperLike`, and `ModifierLike` with `{ Args: NoArgs }`: resolved parameter lists are `[named?: NamedArgs<Record<string, never>>]` (plus the element for modifiers), zero-arg and empty-hash invocations pass, and any named or positional argument is a `@ts-expect-error`.
- `test-packages/package-test-core/__tests__/type-tests/no-args.test.ts` — the concrete forms: Glimmer components, classic Ember components, plain function helpers, `helper()`, `Helper` subclasses, `Modifier` subclasses, and `modifier()`. Each resolves with the expected parameters, rejects named/positional arguments, and `toExtend`s the corresponding `*Like<{ Args: NoArgs }>` type.

`pnpm test` (318 passed in package-test-core) and `pnpm test:typecheck` pass across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
