### PR TITLE
Escape backslashes when wrapping template content in a tagged literal

### DIFF
--- a/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/preprocess.ts
+++ b/packages/ember-tsc/src/environment-ember-template-imports/-private/environment/preprocess.ts
@@ -49,7 +49,18 @@ export const preprocess: GlintExtensionPreprocess<PreprocessData> = (source, pat
     contents += TAG_OPEN;
 
     let templateContent = source.slice(startTagEnd, endTagOffset);
-    let escapedContent = templateContent.replaceAll('${{', '\\${{').replaceAll('`', '\\`');
+    // Escape backslashes FIRST: template content is raw text, so a `\` in it
+    // (e.g. `{{t 'you\'ve'}}`) is a literal character, but inside the wrapped
+    // JS template literal it would start an escape sequence. The transform
+    // reads the literal's *cooked* text back out (see
+    // `transform/template/inlining/tagged-strings.ts`), which would interpret
+    // that sequence: `\'` cooks to `'` (breaking the template parse) and any
+    // multi-character escape shifts every downstream source-map offset.
+    // Doubling each backslash makes cooking restore the original text exactly.
+    let escapedContent = templateContent
+      .replaceAll('\\', '\\\\')
+      .replaceAll('${{', '\\${{')
+      .replaceAll('`', '\\`');
     contents += escapedContent;
     contents += TAG_CLOSE;
     let transformedEnd = contents.length;

--- a/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
+++ b/test-packages/package-test-core/__tests__/transform/rewrite.test.ts
@@ -770,6 +770,112 @@ describe('Transform: rewriteModule', () => {
       `);
     });
 
+    test('backslash escapes in template string literals', () => {
+      // The .gts preprocessor wraps template content in a JS template literal
+      // and the transform reads the cooked text back out, so user backslashes
+      // must be doubled on the way in or `\'` cooks to `'` and the template
+      // fails to parse.
+      let env = GlintEnvironment.load({});
+      let script = {
+        filename: 'foo.gts',
+        contents: stripIndent`
+          const fm = (s: string): string => s;
+
+          <template>
+            {{fm 'you\\'ve arrived'}}
+            {{fm "say \\"hi\\" now"}}
+          </template>
+        `,
+      };
+
+      expect(rewriteModule(ts, { script }, env)?.toDebugString()).toMatchInlineSnapshot(`
+        "TransformedModule
+
+        | Mapping: TemplateEmbedding
+        |  hbs(38:113):  <template>\\n  {{fm 'you\\'ve arrived'}}\\n  {{fm "say \\"hi\\" now"}}\\n</template>
+        |  ts(38:379):   export default ({} as typeof import("@glint/ember-tsc/-private/dsl")).templateExpression((__glintRef__, __glintDSL__: typeof import("@glint/ember-tsc/-private/dsl")) => {\\n__glintDSL__.emitContent(__glintDSL__.resolve(fm)("you've arrived"));\\n__glintDSL__.emitContent(__glintDSL__.resolve(fm)("say \\"hi\\" now"));\\n__glintRef__; __glintDSL__;\\n})
+        |
+        | | Mapping: Template
+        | |  hbs(48:102):  {{fm 'you\\'ve arrived'}}\\n  {{fm "say \\"hi\\" now"}}
+        | |  ts(74:105):   "@glint/ember-tsc/-private/dsl"
+        | |
+        | | Mapping: Template
+        | |  hbs(48:102):  {{fm 'you\\'ve arrived'}}\\n  {{fm "say \\"hi\\" now"}}
+        | |  ts(209:349):  __glintDSL__.emitContent(__glintDSL__.resolve(fm)("you've arrived"));\\n__glintDSL__.emitContent(__glintDSL__.resolve(fm)("say \\"hi\\" now"));
+        | |
+        | | | Mapping: TextContent
+        | | |  hbs(48:51):
+        | | |  ts(209:209):
+        | | |
+        | | | Mapping: MustacheStatement
+        | | |  hbs(51:75):   {{fm 'you\\'ve arrived'}}
+        | | |  ts(209:277):  __glintDSL__.emitContent(__glintDSL__.resolve(fm)("you've arrived"))
+        | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(51:75):   {{fm 'you\\'ve arrived'}}
+        | | | |  ts(234:276):  __glintDSL__.resolve(fm)("you've arrived")
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(53:55):   fm
+        | | | | |  ts(234:258):  __glintDSL__.resolve(fm)
+        | | | | |
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(53:55):   fm
+        | | | | | |  ts(255:257):  fm
+        | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(53:55):   fm
+        | | | | | | |  ts(255:257):  fm
+        | | | | | | |
+        | | | | | |
+        | | | | |
+        | | | | | Mapping: StringLiteral
+        | | | | |  hbs(56:73):   'you\\'ve arrived'
+        | | | | |  ts(259:275):  "you've arrived"
+        | | | | |
+        | | | |
+        | | |
+        | | | Mapping: TextContent
+        | | |  hbs(75:78):
+        | | |  ts(279:279):
+        | | |
+        | | | Mapping: MustacheStatement
+        | | |  hbs(78:101):  {{fm "say \\"hi\\" now"}}
+        | | |  ts(279:347):  __glintDSL__.emitContent(__glintDSL__.resolve(fm)("say \\"hi\\" now"))
+        | | |
+        | | | | Mapping: MustacheStatement
+        | | | |  hbs(78:101):  {{fm "say \\"hi\\" now"}}
+        | | | |  ts(304:346):  __glintDSL__.resolve(fm)("say \\"hi\\" now")
+        | | | |
+        | | | | | Mapping: PathExpression
+        | | | | |  hbs(80:82):   fm
+        | | | | |  ts(304:328):  __glintDSL__.resolve(fm)
+        | | | | |
+        | | | | | | Mapping: PathExpression
+        | | | | | |  hbs(80:82):   fm
+        | | | | | |  ts(325:327):  fm
+        | | | | | |
+        | | | | | | | Mapping: Identifier
+        | | | | | | |  hbs(80:82):   fm
+        | | | | | | |  ts(325:327):  fm
+        | | | | | | |
+        | | | | | |
+        | | | | |
+        | | | | | Mapping: StringLiteral
+        | | | | |  hbs(83:99):   "say \\"hi\\" now"
+        | | | | |  ts(329:345):  "say \\"hi\\" now"
+        | | | | |
+        | | | |
+        | | |
+        | | | Mapping: TextContent
+        | | |  hbs(101:102):
+        | | |  ts(349:349):
+        | | |
+        | |
+        |"
+      `);
+    });
+
     test('with imported special forms', () => {
       let env = GlintEnvironment.load({});
       let script = {

--- a/test-packages/package-test-core/__tests__/type-tests/escaped-strings.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/escaped-strings.test.gts
@@ -1,6 +1,6 @@
 // Backslash escapes inside template string literals are raw text to the
 // preprocessor, not JS escapes: `\'` and `\"` must survive the tagged-template
-// round-trip intact or the template fails to parse (typed-ember/glint#1238).
+// round-trip intact or the template fails to parse (typed-ember/glint#1239).
 const fm = (s: string): string => s;
 
 <template>

--- a/test-packages/package-test-core/__tests__/type-tests/escaped-strings.test.gts
+++ b/test-packages/package-test-core/__tests__/type-tests/escaped-strings.test.gts
@@ -1,0 +1,9 @@
+// Backslash escapes inside template string literals are raw text to the
+// preprocessor, not JS escapes: `\'` and `\"` must survive the tagged-template
+// round-trip intact or the template fails to parse (typed-ember/glint#1238).
+const fm = (s: string): string => s;
+
+<template>
+  {{fm 'you\'ve arrived'}}
+  {{fm "say \"hi\" now"}}
+</template>


### PR DESCRIPTION
> [!NOTE]
> This PR was made with Claude (via Claude Code). Apologies in advance if it misses something — happy to adjust.

Found while bumping optro-frontend from ember-tsc 1.10.0 to 1.11.3: four components failed `ember-tsc --noEmit` with handlebars parse errors that 1.10 accepted. Minimal repro:

```gts
const fm = (s: string): string => s;

<template>
  {{fm 'you\'ve arrived'}}
</template>
```

```
probe.gts(4,12): error TS0: Parse error on line 2:
	{{fm 'you've arrived'}}
--------------^
```

Note the printed template: **the backslash is already gone** before handlebars sees it.

## Mechanism

Since 1.11, `preprocess.ts` wraps template content in a `___T`-tagged JS template literal, escaping only backticks and `${{`, and `tagged-strings.ts` deliberately reads the literal's **cooked** text back out (so those two added escapes reverse and offsets stay 1:1). But cooking also interprets *user* backslashes, which are raw text in a `<template>`:

- `\'` / `\"` (legal handlebars string escapes) cook to bare quotes → the template no longer parses;
- any multi-character escape (`\n`, `\t`, `…`…) cooks to fewer characters → silently shifts every downstream source-map offset in the template, even when parsing succeeds.

## Fix

Double each backslash before adding the wrapper's own escapes, so cooking restores the original text exactly (length-preserving, order-safe with the existing `${{`/backtick replacements).

## Tests

- `rewrite.test.ts` — a template with `\'` and `\"` in mustache string literals; the debug snapshot pins the backslashes surviving on the hbs side, `StringLiteral` mappings at exact ranges, and the correctly-cooked values in the emitted TS.
- `type-tests/escaped-strings.test.gts` — the same content as a real `.gts` through `ember-tsc --noEmit` (the exact path that regressed; this file fails to parse without the fix).

`pnpm test` (320 passed in package-test-core), `pnpm test:typecheck`, and `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
