### PR TITLE
VS Code extension: stand down when TypeScript 7 is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,30 @@ jobs:
           cache: pnpm
       - run: pnpm reset
       - name: Use TypeScript ${{ matrix.typescript }}.x
-        run: pnpm up -r "typescript@${{ matrix.typescript }}" && pnpm build && pnpm sync
-      - run: "pnpm --filter '*' run test:typecheck"
-      - run: "pnpm --filter '*' run test:tsc"
+        # ts7-content-mapper-app pins a TypeScript 7 nightly and is covered by the TS 7 job below
+        run: pnpm up -r --filter '!ts7-content-mapper-app' "typescript@${{ matrix.typescript }}" && pnpm build && pnpm sync
+      - run: "pnpm --filter '*' --filter '!ts7-content-mapper-app' run test:typecheck"
+      - run: "pnpm --filter '*' --filter '!ts7-content-mapper-app' run test:tsc"
+
+  type-tests-ts7:
+    name: "Type Tests (TS 7: ${{ matrix.typescript }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typescript:
+          - "next"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+      - run: pnpm reset
+      - name: Use TypeScript ${{ matrix.typescript }}
+        run: pnpm --filter ts7-content-mapper-app up "typescript@${{ matrix.typescript }}" && pnpm build && pnpm sync
+      - run: pnpm --filter ts7-content-mapper-app run test:typecheck
+      - run: pnpm --filter ts7-content-mapper-app run test:tsc
 
   test:
     name: "Test (TS ${{ matrix.typescript }})"
@@ -70,7 +91,8 @@ jobs:
           cache: "pnpm"
       - run: pnpm reset
       - name: Use TypeScript ${{ matrix.typescript }}.x
-        run: pnpm up -r "typescript@${{ matrix.typescript }}" && pnpm build && pnpm sync
+        # ts7-content-mapper-app pins a TypeScript 7 nightly; don't downgrade it
+        run: pnpm up -r --filter '!ts7-content-mapper-app' "typescript@${{ matrix.typescript }}" && pnpm build && pnpm sync
       - name: Run Tests
         uses: coactions/setup-xvfb@v1
         with:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
       ],
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
-        "--extensionDevelopmentPath=${env:HOME}/.vscode/extensions/lifeart.vscode-glimmer-syntax-1.0.47",
+        // "--extensionDevelopmentPath=${env:HOME}/.vscode/extensions/lifeart.vscode-glimmer-syntax-1.0.47",
         // Disable v1 vscode glint
         "--disable-extension",
         "typed-ember.glint-vscode",
@@ -48,7 +48,7 @@
       ],
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
-        "--extensionDevelopmentPath=${env:HOME}/.vscode/extensions/lifeart.vscode-glimmer-syntax-1.0.47",
+        // "--extensionDevelopmentPath=${env:HOME}/.vscode/extensions/lifeart.vscode-glimmer-syntax-1.0.47",
         // Both marketplace builds would run beside the development build.
         // `--disable-extensions` is not used because it would also disable
         // the TypeScript 7 and TypeScript 7 Nightly extensions.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,7 @@
       // through ember-content-mapper. The extension must stand down here: no
       // language server, no status bar item, only registering the file
       // extensions with TypeScriptTeam.native-preview. That extension must be
-      // installed, and the app's .vscode/settings.json turns TypeScript 7 on.
+      // installed. The app's .vscode/settings.json turns TypeScript 7 on.
       // Same prerequisites as above: `tsc --build --watch` at the root and
       // `pnpm bundle:watch` in packages/vscode.
       "name": "Debug Extension (TypeScript 7, content mapper)",
@@ -51,7 +51,7 @@
         "typed-ember.glint-vscode",
         "--disable-extension",
         "typed-ember.glint2-vscode",
-        "${input:typescript7App}"
+        "${workspaceFolder}/test-packages/ts7-content-mapper-app"
       ]
     },
     {
@@ -65,13 +65,5 @@
         "!**/node_modules/**"
       ],
     }
-    ],
-  "inputs": [
-    {
-      "id": "typescript7App",
-      "type": "promptString",
-      "description": "Path to a TypeScript 7 app that uses ember-content-mapper",
-      "default": "${env:HOME}/Development/NullVoxPopuli/ember-content-mapper/examples/nvp-app"
-    }
-  ]
+    ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,8 +29,11 @@
       // Runs the extension against a TypeScript 7 app that type-checks .gts/.gjs
       // through ember-content-mapper. The extension must stand down here: no
       // language server, no status bar item, only registering the file
-      // extensions with TypeScriptTeam.native-preview. That extension must be
-      // installed. The app's .vscode/settings.json turns TypeScript 7 on.
+      // extensions with the TypeScript 7 extension. Two extensions must be
+      // installed: TypeScriptTeam.native-preview (TypeScript 7) and
+      // TypeScriptTeam.vscode-typescript-nightly (TypeScript 7 Nightly), whose
+      // nightly build is what supports content mappers. The app's
+      // .vscode/settings.json turns TypeScript 7 on.
       // Same prerequisites as above: `tsc --build --watch` at the root and
       // `pnpm bundle:watch` in packages/vscode.
       "name": "Debug Extension (TypeScript 7, content mapper)",
@@ -46,7 +49,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
         // Both marketplace builds would run beside the development build.
         // `--disable-extensions` is not used because it would also disable
-        // TypeScriptTeam.native-preview.
+        // the TypeScript 7 and TypeScript 7 Nightly extensions.
         "--disable-extension",
         "typed-ember.glint-vscode",
         "--disable-extension",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
       ],
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
+        "--extensionDevelopmentPath=${env:HOME}/.vscode/extensions/lifeart.vscode-glimmer-syntax-1.0.47",
         // Disable v1 vscode glint
         "--disable-extension",
         "typed-ember.glint-vscode",
@@ -47,6 +48,7 @@
       ],
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
+        "--extensionDevelopmentPath=${env:HOME}/.vscode/extensions/lifeart.vscode-glimmer-syntax-1.0.47",
         // Both marketplace builds would run beside the development build.
         // `--disable-extensions` is not used because it would also disable
         // the TypeScript 7 and TypeScript 7 Nightly extensions.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,35 @@
       ]
     },
     {
+      // Runs the extension against a TypeScript 7 app that type-checks .gts/.gjs
+      // through ember-content-mapper. The extension must stand down here: no
+      // language server, no status bar item, only registering the file
+      // extensions with TypeScriptTeam.native-preview. That extension must be
+      // installed, and the app's .vscode/settings.json turns TypeScript 7 on.
+      // Same prerequisites as above: `tsc --build --watch` at the root and
+      // `pnpm bundle:watch` in packages/vscode.
+      "name": "Debug Extension (TypeScript 7, content mapper)",
+      "type": "extensionHost",
+      "request": "launch",
+      "autoAttachChildProcesses": true,
+      "runtimeExecutable": "${execPath}",
+      "outFiles": [
+        "${workspaceFolder}/**/*.js",
+        "!**/node_modules/**"
+      ],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
+        // Both marketplace builds would run beside the development build.
+        // `--disable-extensions` is not used because it would also disable
+        // TypeScriptTeam.native-preview.
+        "--disable-extension",
+        "typed-ember.glint-vscode",
+        "--disable-extension",
+        "typed-ember.glint2-vscode",
+        "${input:typescript7App}"
+      ]
+    },
+    {
       "name": "Attach to TS Server",
       "type": "node",
       "request": "attach",
@@ -35,6 +64,14 @@
         "${workspaceFolder}/**/*.js",
         "!**/node_modules/**"
       ],
+    }
+    ],
+  "inputs": [
+    {
+      "id": "typescript7App",
+      "type": "promptString",
+      "description": "Path to a TypeScript 7 app that uses ember-content-mapper",
+      "default": "${env:HOME}/Development/NullVoxPopuli/ember-content-mapper/examples/nvp-app"
     }
   ]
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -516,9 +516,10 @@ function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | und
   }
 }
 
-const NATIVE_PREVIEW_EXTENSION_ID = 'TypeScriptTeam.native-preview';
+const TYPESCRIPT_7_EXTENSION_ID = 'TypeScriptTeam.native-preview';
+const TYPESCRIPT_7_NIGHTLY_EXTENSION_ID = 'TypeScriptTeam.vscode-typescript-nightly';
 
-interface NativePreviewApi {
+interface TypeScript7Api {
   registerContentMappers?: (
     contributorId: string,
     contributions: ReadonlyArray<{ extensions: ReadonlyArray<string> }>,
@@ -531,31 +532,45 @@ interface NativePreviewApi {
  * content-mapped `.gts` file never reaches the server and gets no hover,
  * completions, or diagnostics in the editor. Registering also lets the server
  * discover the project's tsconfig from a `.gts` file alone.
+ *
+ * The registration API belongs to the TypeScript 7 extension. The TypeScript 7
+ * Nightly extension has no code of its own: it only ships a nightly build that
+ * the TypeScript 7 extension runs instead of its bundled one. Content mappers
+ * need that nightly build, so Glint requires the Nightly to be installed and
+ * registers through the TypeScript 7 extension's API.
  */
 async function registerContentMapperContribution(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,
 ): Promise<void> {
-  const nativePreview = vscode.extensions.getExtension<NativePreviewApi | undefined>(
-    NATIVE_PREVIEW_EXTENSION_ID,
+  const typeScript7 = vscode.extensions.getExtension<TypeScript7Api | undefined>(
+    TYPESCRIPT_7_EXTENSION_ID,
   );
-  if (!nativePreview) {
+  if (!typeScript7) {
     outputChannel.appendLine(
-      `[Activation] The TypeScript (Native Preview) extension (${NATIVE_PREVIEW_EXTENSION_ID}) is not installed, ` +
+      `[Activation] The TypeScript 7 extension (${TYPESCRIPT_7_EXTENSION_ID}) is not installed, ` +
         `so .gts and .gjs files will not get TypeScript 7 language features.`,
     );
     return;
   }
 
+  if (!vscode.extensions.getExtension(TYPESCRIPT_7_NIGHTLY_EXTENSION_ID)) {
+    outputChannel.appendLine(
+      `[Activation] The TypeScript 7 Nightly extension (${TYPESCRIPT_7_NIGHTLY_EXTENSION_ID}) is not installed. ` +
+        `Content mappers need its nightly build, so .gts and .gjs files will not get TypeScript 7 language features.`,
+    );
+    return;
+  }
+
   try {
-    const api = await nativePreview.activate();
+    const api = await typeScript7.activate();
     const registration = api?.registerContentMappers?.(V2_EXTENSION_ID, [
       { extensions: ['.gts', '.gjs'] },
     ]);
 
     if (!registration) {
       outputChannel.appendLine(
-        `[Activation] The installed TypeScript (Native Preview) build does not support content mapper ` +
+        `[Activation] The installed TypeScript 7 extension does not support content mapper ` +
           `registration; a build newer than 2026-08-19 is required for .gts and .gjs language features.`,
       );
       return;
@@ -563,11 +578,11 @@ async function registerContentMapperContribution(
 
     context.subscriptions.push(registration);
     outputChannel.appendLine(
-      '[Activation] Registered .gts and .gjs with TypeScript (Native Preview) for content mapper support.',
+      '[Activation] Registered .gts and .gjs with TypeScript 7 for content mapper support.',
     );
   } catch (error) {
     outputChannel.appendLine(
-      `[Activation] Registering with TypeScript (Native Preview) failed: ${
+      `[Activation] Registering with TypeScript 7 failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -62,6 +62,7 @@ const languageIds = ['glimmer-js', 'glimmer-ts'];
 const TS_PLUGIN_NAME = 'glint-tsserver-plugin-pack';
 const EMBER_TSC_SOURCE_SETTING = 'glint2.emberTscSource';
 const SELECT_EMBER_TSC_COMMAND = 'glint2.select-ember-tsc-source';
+const TYPESCRIPT_7_SHOW_MENU_COMMAND = 'typescript.native-preview.showMenu';
 
 type EmberTscSource = 'auto' | 'workspace' | 'bundled';
 
@@ -88,6 +89,7 @@ export const { activate, deactivate } = defineExtension(() => {
         `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
         `in tsconfig.json and run tsc with --runExternalCode.`,
     );
+    registerTypeScript7LanguageStatus(context);
     void registerContentMapperContribution(context, outputChannel);
     return;
   }
@@ -524,6 +526,92 @@ interface TypeScript7Api {
     contributorId: string,
     contributions: ReadonlyArray<{ extensions: ReadonlyArray<string> }>,
   ) => vscode.Disposable;
+}
+
+function registerTypeScript7LanguageStatus(context: vscode.ExtensionContext): void {
+  const status = vscode.languages.createLanguageStatusItem(
+    'glint2.typescript7.status',
+    languageIds,
+  );
+  status.name = 'TypeScript 7';
+  status.text = 'TypeScript 7';
+  status.detail = 'TypeScript Language Server';
+  status.command = {
+    title: 'Show Menu',
+    command: TYPESCRIPT_7_SHOW_MENU_COMMAND,
+  };
+
+  context.subscriptions.push(status);
+
+  const projectStatus = vscode.languages.createLanguageStatusItem(
+    'glint2.typescript7.projectStatus',
+    languageIds,
+  );
+  projectStatus.name = 'TypeScript 7 Project Status';
+  projectStatus.detail = 'TypeScript Language Server';
+
+  const updateProjectStatus = (): void => {
+    const document = vscode.window.activeTextEditor?.document;
+    if (!document || !languageIds.includes(document.languageId)) {
+      return;
+    }
+
+    const configFile = findNearestTypeScriptConfig(document.uri);
+    if (configFile) {
+      projectStatus.text = vscode.workspace.asRelativePath(configFile);
+      projectStatus.command = {
+        title: 'Open Config File',
+        command: 'vscode.open',
+        arguments: [vscode.Uri.file(configFile)],
+      };
+    } else {
+      projectStatus.text = document.languageId === 'glimmer-ts' ? 'No tsconfig' : 'No jsconfig';
+      projectStatus.command = undefined;
+    }
+  };
+
+  updateProjectStatus();
+  context.subscriptions.push(
+    projectStatus,
+    vscode.window.onDidChangeActiveTextEditor(updateProjectStatus),
+    vscode.workspace.onDidChangeWorkspaceFolders(updateProjectStatus),
+  );
+}
+
+function findNearestTypeScriptConfig(resource: vscode.Uri): string | undefined {
+  if (resource.scheme !== 'file') {
+    return undefined;
+  }
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(resource);
+  if (!workspaceFolder) {
+    return undefined;
+  }
+
+  const workspaceRoot = workspaceFolder.uri.fsPath;
+  let currentDirectory = path.dirname(resource.fsPath);
+
+  while (isInDirectory(currentDirectory, workspaceRoot)) {
+    for (const configFileName of ['tsconfig.json', 'jsconfig.json']) {
+      const configFile = path.join(currentDirectory, configFileName);
+      if (fs.existsSync(configFile)) {
+        return configFile;
+      }
+    }
+
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      break;
+    }
+    currentDirectory = parentDirectory;
+  }
+
+  return undefined;
+}
+
+function isInDirectory(pathToCheck: string, directory: string): boolean {
+  const relativePath = path.relative(directory, pathToCheck);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }
 
 /**

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -71,30 +71,34 @@ export const { activate, deactivate } = defineExtension(() => {
   }
 
   const context = extensionContext.value!;
-  const volarLabs = createLabsInfo(languageServerProtocol);
-  const activeTextEditor = useActiveTextEditor();
-  const visibleTextEditors = useVisibleTextEditors();
   const outputChannel = useOutputChannel('Glint2 Language Server');
-  let pendingRestart = false;
-  let lastActivationReason: string | undefined;
 
   // Glint's language server and tsserver plugin require the TypeScript 5/6
-  // JS API, which the TypeScript 7 package does not ship. On a TS 7 workspace
+  // JS API, which TypeScript 7 does not ship. When TypeScript 7 is in play,
   // they would only produce broken diagnostics, so Glint stands down entirely:
   // template type-checking comes from a content mapper run by TypeScript
-  // itself instead.
-  const workspaceTypeScriptVersion = detectWorkspaceTypeScriptVersion(getLibraryPathSetting());
-  if (workspaceTypeScriptVersion && parseInt(workspaceTypeScriptVersion, 10) >= 7) {
+  // itself instead. The only work left is telling the native server about
+  // the file extensions.
+  const typeScript7Reason = detectTypeScript7(getLibraryPathSetting());
+  if (typeScript7Reason) {
     outputChannel.appendLine(
-      `[Activation] TypeScript ${workspaceTypeScriptVersion} is installed in this workspace. ` +
+      `[Activation] ${typeScript7Reason} ` +
         `Glint requires TypeScript 5 or 6, so the Glint language server and tsserver plugin will not start. ` +
         `With TypeScript 7, template type-checking comes from a content mapper instead: add ` +
         `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
         `in tsconfig.json and run tsc with --runExternalCode.`,
     );
     void registerContentMapperContribution(context, outputChannel);
-    return volarLabs.extensionExports;
+    return;
   }
+
+  prepareBuiltinTypeScriptExtension();
+
+  const volarLabs = createLabsInfo(languageServerProtocol);
+  const activeTextEditor = useActiveTextEditor();
+  const visibleTextEditors = useVisibleTextEditors();
+  let pendingRestart = false;
+  let lastActivationReason: string | undefined;
 
   const emberTscStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   emberTscStatus.command = SELECT_EMBER_TSC_COMMAND;
@@ -571,6 +575,57 @@ async function registerContentMapperContribution(
 }
 
 /**
+ * Why Glint must stand down for TypeScript 7, or `undefined` when it must run.
+ *
+ * TypeScript 7 is in play in either of two situations. The user turned on the
+ * native preview in VS Code. That replaces the built-in tsserver that Glint
+ * hooks into, whatever `typescript` package the workspace installs. Or the
+ * workspace installs the TypeScript 7 package, whose JS API Glint cannot load.
+ */
+function detectTypeScript7(libraryPath: string): string | undefined {
+  const useTsgo = getUseTsgoSetting();
+  if (useTsgo) {
+    return `TypeScript 7 is enabled in VS Code via "${useTsgo}".`;
+  }
+
+  const workspaceTypeScriptVersion = detectWorkspaceTypeScriptVersion(libraryPath);
+  if (workspaceTypeScriptVersion && parseInt(workspaceTypeScriptVersion, 10) >= 7) {
+    return `TypeScript ${workspaceTypeScriptVersion} is installed in this workspace.`;
+  }
+
+  return undefined;
+}
+
+const USE_TSGO_SETTINGS = ['js/ts.experimental.useTsgo', 'typescript.experimental.useTsgo'];
+const CONFIGURATION_SCOPES = ['workspaceFolderValue', 'workspaceValue', 'globalValue'] as const;
+
+/**
+ * The name of the setting that turns on TypeScript 7 in VS Code, or
+ * `undefined` when TypeScript 7 is off. The native preview extension only
+ * honors explicitly set values, lets the most specific scope win, and prefers
+ * the `js/ts` name over the deprecated `typescript` name within a scope. This
+ * resolves the two names the same way so Glint and the native preview agree.
+ */
+function getUseTsgoSetting(): string | undefined {
+  const configuration = vscode.workspace.getConfiguration();
+  const inspections = USE_TSGO_SETTINGS.map((setting) => ({
+    setting,
+    inspection: configuration.inspect<boolean>(setting),
+  }));
+
+  for (const scope of CONFIGURATION_SCOPES) {
+    for (const { setting, inspection } of inspections) {
+      const value = inspection?.[scope];
+      if (value !== undefined) {
+        return value ? setting : undefined;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * The version of the `typescript` package installed in the workspace, or
  * `undefined` when there is no workspace folder or no resolvable typescript.
  * Both the TypeScript 5/6 and 7 packages export their package.json, so this
@@ -610,13 +665,25 @@ function resolveBundledEmberTscServerPath(): string | undefined {
   }
 }
 
-// We need to activate the default VSCode TypeScript extension so that our
-// TS Plugin kicks in. We do this because the TS extension is (obviously) not
-// configured to activate for, say, .gts files:
-// https://github.com/microsoft/vscode/blob/878af07/extensions/typescript-language-features/package.json#L62..L75
-const tsExtension = vscode.extensions.getExtension('vscode.typescript-language-features');
+/**
+ * Hooks Glint into the built-in VS Code TypeScript extension
+ * (vscode.typescript-language-features). Glint's language features ride on
+ * that extension's tsserver, so it must be activated even though it is not
+ * configured to activate for .gts files:
+ * https://github.com/microsoft/vscode/blob/878af07/extensions/typescript-language-features/package.json#L62..L75
+ *
+ * Before activating it, its bundle is monkeypatched so that features like Find
+ * File References and Go to Source Definition treat .gts/.gjs as TypeScript.
+ * The patch must be in place before the bundle is read, so it comes first.
+ */
+function prepareBuiltinTypeScriptExtension(): void {
+  const tsExtension = vscode.extensions.getExtension('vscode.typescript-language-features');
+  if (!tsExtension) {
+    return;
+  }
 
-if (tsExtension) {
+  patchBuiltinTypeScriptExtension(tsExtension);
+
   const activationPromise = tsExtension.activate();
   if (activationPromise && typeof activationPromise.then === 'function') {
     activationPromise.then(
@@ -642,26 +709,25 @@ if (tsExtension) {
   }
 }
 
-if (!v1ExtensionPresent) {
-  // The code below contains hacks lifted from the Vue extension to monkeypatch
-  // portions of official VSCode TS extension (vscode.typescript-language-features)
-  // to add some missing features that make the tooling more seamless.
-  //
-  // Note that these hacks should ABSOLUTELY be upstreamed to VSCode but it is unclear
-  // whether our efforts will be successful.
-  //
-  // https://github.com/vuejs/language-tools/blob/master/extensions/vscode/src/nodeClientMain.ts#L135-L195
-  //
-  // It is important for us (for the time being) to manually follow along with changes made to the
-  // Vue extension within the above file. Ideally Volar should extract this logic into a shared library.
-  //
-  // Specifically these hacks make things like Find File References, Go to Source Definition, etc.
-  // work in .gts files.
-  //
-  // https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20isSupportedLanguageMode&type=code
+// The code below contains hacks lifted from the Vue extension to monkeypatch
+// portions of official VSCode TS extension (vscode.typescript-language-features)
+// to add some missing features that make the tooling more seamless.
+//
+// Note that these hacks should ABSOLUTELY be upstreamed to VSCode but it is unclear
+// whether our efforts will be successful.
+//
+// https://github.com/vuejs/language-tools/blob/master/extensions/vscode/src/nodeClientMain.ts#L135-L195
+//
+// It is important for us (for the time being) to manually follow along with changes made to the
+// Vue extension within the above file. Ideally Volar should extract this logic into a shared library.
+//
+// Specifically these hacks make things like Find File References, Go to Source Definition, etc.
+// work in .gts files.
+//
+// https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20isSupportedLanguageMode&type=code
+function patchBuiltinTypeScriptExtension(tsExtension: vscode.Extension<unknown>): void {
   try {
     const fs = require('node:fs');
-    const tsExtension = vscode.extensions.getExtension('vscode.typescript-language-features')!;
     const readFileSync = fs.readFileSync;
     const extensionJsPath = require.resolve('./dist/extension.js', {
       paths: [tsExtension.extensionPath],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,7 +796,7 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: workspace:*
-        version: file:packages/ember-tsc(76f748bc605be374e1fa74391ff76234)
+        version: file:packages/ember-tsc(c9dd54e8152b5c137a477967501a030f)
       '@glint/template':
         specifier: workspace:*
         version: file:packages/template
@@ -808,7 +808,7 @@ importers:
         version: 2.4.0
       ember-content-mapper:
         specifier: 0.3.1
-        version: 0.3.1(76f748bc605be374e1fa74391ff76234)
+        version: 0.3.1(c9dd54e8152b5c137a477967501a030f)
       ember-modifier:
         specifier: ^4.3.0
         version: 4.3.0
@@ -825,8 +825,8 @@ importers:
         specifier: 3.5.0
         version: 3.5.0
       typescript:
-        specifier: 7.1.0-dev.20260821.1
-        version: 7.1.0-dev.20260821.1
+        specifier: 7.1.0-dev.20260901.1
+        version: 7.1.0-dev.20260901.1
       vite:
         specifier: 8.2.2
         version: 8.2.2
@@ -3325,44 +3325,44 @@ packages:
   '@typescript/server-harness@0.3.5':
     resolution: {integrity: sha512-YT9oe27zm7HdGXYad5SZrdJzVe9eavG3F6YplsWvAraowGtuDeY7FHPVuQPtQj6GxG097Us4JDkA8n5I4iQovQ==}
 
-  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-kSoefqC9cAFf1Ui14Gn3XmMDRn2SSEy/V4D9/N/dfhJM4/yfoadBiyeaC88o7LmyJEJQTS4zQjTGRu1q29bbhA==}
+  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-2vhjvcF8hshvIT4dPN8bfA6KI81CsZPpMvA0YrCkGan42n46DSIz0T2Jp/hSv4CdHoihhIYViTx0gR8a/CGhQQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/typescript-darwin-x64@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-RJ+NOn3OZ+EYGQE7wiPDcWQkKY5OjOMBk/bhGIfmxKWVJhWYW2Me+4YmacXq+NenzZgOUVhHikFfibMQDvhOtw==}
+  '@typescript/typescript-darwin-x64@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-UhzELABon1ezC9+RsOIioZL3ztx8se+9MYOBUGmo2UqeNVMTPvGuhbtZ3RdJ3idrwpDsavRc1tygCStnnxg/jg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/typescript-linux-arm64@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-o3xxprsmQ0AKHMUNMgU+QRG+XpRMfswzXUOu+a4ayrQ5AnctYB7IGfdMqOSr3Oc9e/bsOwVY37aZdPcsNAfprg==}
+  '@typescript/typescript-linux-arm64@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-BQa5kgwYdwWmtm3UyWLmHedC6V0UMHHwogAy+IettGBpimKhBoyeUF02cgGI7ITLv39JIy+NOfrwwN1JX3rTAA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/typescript-linux-arm@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-75ryeQNJLg6vyM67JxGBxP6s6dTccg/lvMSQFJARdgAd+WPilxmfzLzobSwlBHZuc5u5gxh9y42kZTpsn0Yq5Q==}
+  '@typescript/typescript-linux-arm@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-WZt0gZLqSkqqSfnr0mOiqF7fqjy+J3JSj5nHRugvBTG2lseV73RppGfjwOl+RtEy8zRb2KpKbMr37OPNvhplEQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/typescript-linux-x64@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-m2NY6lwHyjLsTOp0f6GrjvS/b1cIRxQbFxO/z7XtnsO17Gu0GTC9XhXiCuiPhyeipeERWK+SOigmEhY1S3QCcg==}
+  '@typescript/typescript-linux-x64@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-0ObxW8yMFlfhVuUcV0A4pBq1IHf9iQgoKUkukTaxCMJDrlYSfzYKSzBzFjFSyh4t3Ctf9+VGp2IryntamYtUsw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/typescript-win32-arm64@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-610sBfx98SyaXpRpPJ5B3gsceM8QqhqQaHDdNoG7HsTlbc/F9KEq5slJ2ZbgL2FJ6cc2UimsIbwu6XfLKkBaug==}
+  '@typescript/typescript-win32-arm64@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-8MKD/h5KE1niyFCQNrNzm18vtUL3zMbIuRj0tycC0FJZGVJUqC+r0t3rUbW0udYADr/235Lz3COB0tcCQ3SW5Q==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/typescript-win32-x64@7.1.0-dev.20260821.1':
-    resolution: {integrity: sha512-gTVCj7ecihltJj8ljlNxyR6/8H5ZEnsQSALdmysyufbyqagKkRcI9iCEa1p9CK/FY3g4wX9GT8a0V3Qr1vZUEQ==}
+  '@typescript/typescript-win32-x64@7.1.0-dev.20260901.1':
+    resolution: {integrity: sha512-D0mY2AZd20cLR3FPLRWcivt2mu1qJc9a7LfO8JRcX97fo3CCHHMDqu1Ez5ffycoZzpSk48OZIwxMPALMLa8Iiw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
@@ -8410,8 +8410,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@7.1.0-dev.20260821.1:
-    resolution: {integrity: sha512-fSbYbC5XWI68TLeO+W0ZEZAJMSuVYlyREG3Z1+zw1vn1Ka6T8rgihYEhm3jNa0Z7PiEyD3NsR1Ux9z2t1viU9g==}
+  typescript@7.1.0-dev.20260901.1:
+    resolution: {integrity: sha512-EdwHzF3udir04ubeFHOL05NbldTcukHk6v+LWHcX8VU6xy564y9n9JY/2swf4YMbWFt3rptVCGnQSX9bxjc+vQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -12127,11 +12127,11 @@ snapshots:
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
-  '@glint/ember-tsc@1.11.4(76f748bc605be374e1fa74391ff76234)':
+  '@glint/ember-tsc@1.11.4(c9dd54e8152b5c137a477967501a030f)':
     dependencies:
       '@glimmer/syntax': 0.95.0
       '@glint/template': 1.9.0
-      '@volar/kit': 2.4.28(typescript@7.1.0-dev.20260821.1)
+      '@volar/kit': 2.4.28(typescript@7.1.0-dev.20260901.1)
       '@volar/language-core': 2.4.28
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
@@ -12141,7 +12141,7 @@ snapshots:
       content-tag: 4.2.0
       ember-estree: 0.8.0
       silent-error: 1.1.1
-      typescript: 7.1.0-dev.20260821.1
+      typescript: 7.1.0-dev.20260901.1
       volar-service-html: 0.0.71(@volar/language-service@2.4.28)
       volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
       vscode-languageserver-protocol: 3.17.5
@@ -12202,31 +12202,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@glint/ember-tsc@file:packages/ember-tsc(76f748bc605be374e1fa74391ff76234)':
-    dependencies:
-      '@glimmer/syntax': 0.95.0
-      '@glint/template': link:packages/template
-      '@volar/kit': 2.4.28(typescript@7.1.0-dev.20260821.1)
-      '@volar/language-core': 2.4.28
-      '@volar/language-server': 2.4.28
-      '@volar/language-service': 2.4.28
-      '@volar/source-map': 2.4.28
-      '@volar/test-utils': 2.4.28
-      '@volar/typescript': 2.4.28
-      content-tag: 4.2.0
-      ember-estree: 0.8.0
-      silent-error: 1.1.1
-      typescript: 7.1.0-dev.20260821.1
-      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
-      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
-      vscode-languageserver-protocol: 3.17.5
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
-    optionalDependencies:
-      ember-source: 7.2.0(@glimmer/component@2.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@glint/ember-tsc@file:packages/ember-tsc(91652049ac13c218639ae99fedb76041)':
     dependencies:
       '@glimmer/syntax': 0.95.0
@@ -12249,6 +12224,31 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       ember-source: 6.7.0(@glimmer/component@2.0.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@glint/ember-tsc@file:packages/ember-tsc(c9dd54e8152b5c137a477967501a030f)':
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@glint/template': link:packages/template
+      '@volar/kit': 2.4.28(typescript@7.1.0-dev.20260901.1)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/source-map': 2.4.28
+      '@volar/test-utils': 2.4.28
+      '@volar/typescript': 2.4.28
+      content-tag: 4.2.0
+      ember-estree: 0.8.0
+      silent-error: 1.1.1
+      typescript: 7.1.0-dev.20260901.1
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13204,25 +13204,25 @@ snapshots:
 
   '@typescript/server-harness@0.3.5': {}
 
-  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260821.1':
+  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260901.1':
     optional: true
 
-  '@typescript/typescript-darwin-x64@7.1.0-dev.20260821.1':
+  '@typescript/typescript-darwin-x64@7.1.0-dev.20260901.1':
     optional: true
 
-  '@typescript/typescript-linux-arm64@7.1.0-dev.20260821.1':
+  '@typescript/typescript-linux-arm64@7.1.0-dev.20260901.1':
     optional: true
 
-  '@typescript/typescript-linux-arm@7.1.0-dev.20260821.1':
+  '@typescript/typescript-linux-arm@7.1.0-dev.20260901.1':
     optional: true
 
-  '@typescript/typescript-linux-x64@7.1.0-dev.20260821.1':
+  '@typescript/typescript-linux-x64@7.1.0-dev.20260901.1':
     optional: true
 
-  '@typescript/typescript-win32-arm64@7.1.0-dev.20260821.1':
+  '@typescript/typescript-win32-arm64@7.1.0-dev.20260901.1':
     optional: true
 
-  '@typescript/typescript-win32-x64@7.1.0-dev.20260821.1':
+  '@typescript/typescript-win32-x64@7.1.0-dev.20260901.1':
     optional: true
 
   '@typespec/ts-http-runtime@0.3.2':
@@ -13312,12 +13312,12 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  '@volar/kit@2.4.28(typescript@7.1.0-dev.20260821.1)':
+  '@volar/kit@2.4.28(typescript@7.1.0-dev.20260901.1)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: 7.1.0-dev.20260821.1
+      typescript: 7.1.0-dev.20260901.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -15210,9 +15210,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-content-mapper@0.3.1(76f748bc605be374e1fa74391ff76234):
+  ember-content-mapper@0.3.1(c9dd54e8152b5c137a477967501a030f):
     dependencies:
-      '@glint/ember-tsc': 1.11.4(76f748bc605be374e1fa74391ff76234)
+      '@glint/ember-tsc': 1.11.4(c9dd54e8152b5c137a477967501a030f)
       tinypool: 2.1.2
       vscode-jsonrpc: 9.0.2
     transitivePeerDependencies:
@@ -19992,15 +19992,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@7.1.0-dev.20260821.1:
+  typescript@7.1.0-dev.20260901.1:
     optionalDependencies:
-      '@typescript/typescript-darwin-arm64': 7.1.0-dev.20260821.1
-      '@typescript/typescript-darwin-x64': 7.1.0-dev.20260821.1
-      '@typescript/typescript-linux-arm': 7.1.0-dev.20260821.1
-      '@typescript/typescript-linux-arm64': 7.1.0-dev.20260821.1
-      '@typescript/typescript-linux-x64': 7.1.0-dev.20260821.1
-      '@typescript/typescript-win32-arm64': 7.1.0-dev.20260821.1
-      '@typescript/typescript-win32-x64': 7.1.0-dev.20260821.1
+      '@typescript/typescript-darwin-arm64': 7.1.0-dev.20260901.1
+      '@typescript/typescript-darwin-x64': 7.1.0-dev.20260901.1
+      '@typescript/typescript-linux-arm': 7.1.0-dev.20260901.1
+      '@typescript/typescript-linux-arm64': 7.1.0-dev.20260901.1
+      '@typescript/typescript-linux-x64': 7.1.0-dev.20260901.1
+      '@typescript/typescript-win32-arm64': 7.1.0-dev.20260901.1
+      '@typescript/typescript-win32-x64': 7.1.0-dev.20260901.1
 
   uc.micro@2.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,71 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  test-packages/ts7-content-mapper-app:
+    dependenciesMeta:
+      '@glint/ember-tsc':
+        injected: true
+      '@glint/template':
+        injected: true
+    devDependencies:
+      '@ember/app-tsconfig':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@ember/test-helpers':
+        specifier: 5.4.3
+        version: 5.4.3
+      '@ember/test-waiters':
+        specifier: 4.1.2
+        version: 4.1.2
+      '@embroider/core':
+        specifier: 4.6.3
+        version: 4.6.3(@glint/template@file:packages/template)
+      '@embroider/macros':
+        specifier: 1.20.6
+        version: 1.20.6(@glint/template@file:packages/template)
+      '@embroider/router':
+        specifier: 3.0.6
+        version: 3.0.6(5efae9c4260e56a2d8b8924425eb4b3b)
+      '@glimmer/component':
+        specifier: 2.1.1
+        version: 2.1.1
+      '@glint/ember-tsc':
+        specifier: workspace:*
+        version: file:packages/ember-tsc(76f748bc605be374e1fa74391ff76234)
+      '@glint/template':
+        specifier: workspace:*
+        version: file:packages/template
+      '@types/qunit':
+        specifier: 2.19.14
+        version: 2.19.14
+      decorator-transforms:
+        specifier: 2.4.0
+        version: 2.4.0
+      ember-content-mapper:
+        specifier: 0.3.1
+        version: 0.3.1(76f748bc605be374e1fa74391ff76234)
+      ember-modifier:
+        specifier: ^4.3.0
+        version: 4.3.0
+      ember-qunit:
+        specifier: 9.1.0
+        version: 9.1.0(@ember/test-helpers@5.4.3)(qunit@2.26.0)
+      ember-source:
+        specifier: 7.2.0
+        version: 7.2.0(@glimmer/component@2.1.1)
+      qunit:
+        specifier: 2.26.0
+        version: 2.26.0
+      qunit-dom:
+        specifier: 3.5.0
+        version: 3.5.0
+      typescript:
+        specifier: 7.1.0-dev.20260821.1
+        version: 7.1.0-dev.20260821.1
+      vite:
+        specifier: 8.2.2
+        version: 8.2.2
+
   test-packages/v2-ts-ember-addon:
     dependencies:
       '@embroider/addon-shim':
@@ -1678,6 +1743,9 @@ packages:
   '@ember/app-tsconfig@1.0.3':
     resolution: {integrity: sha512-dw+/F68xvBw8JYLpyFmAcnF5d/vZqlP6GkEde+XIuPPPn6PIakrh0jtP0/tPxBw8tVuc6eD+H+8CWSsSFrGuiA==}
 
+  '@ember/app-tsconfig@2.0.0':
+    resolution: {integrity: sha512-NmD1OZFtCF49k4WDaPdhGP4OKoRbPaXpTBO3AsJe0okIJeCVUiEiC8YUpfTJmld9EJOEa9mW/p0tJQS70GktOA==}
+
   '@ember/edition-utils@1.2.0':
     resolution: {integrity: sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==}
 
@@ -1687,8 +1755,14 @@ packages:
   '@ember/test-helpers@5.3.0':
     resolution: {integrity: sha512-CG3Iiap0vbrjtOzRg4cN0fd7fMUVhFK5gURkc8yQGJtKT3LwXLLtCLkMG/A55sMTIYHlYRETuJXqv9slO90RKw==}
 
+  '@ember/test-helpers@5.4.3':
+    resolution: {integrity: sha512-WeNABJsXBidEXP87AH5gaI/KAyb0zEUYJxWa31A/Us5lqg85E3tPlHjBwCrlReOrJbSgvvArMnrdCwt7TRpjPQ==}
+
   '@ember/test-waiters@4.1.1':
     resolution: {integrity: sha512-HbK70JYCDJcGI0CrwcbjeL2QHAn0HLwa3oGep7mr6l/yO95U7JYA8VN+/9VTsWJTmKueLtWayUqEmGS3a3mVOg==}
+
+  '@ember/test-waiters@4.1.2':
+    resolution: {integrity: sha512-zJwFaHLHjJn6mKoXYVM1SEyMT+U1JpaaSKg3JBmxHJwiIoJRI5djJ/CE33Z7N09mk5JfXd2xdhbd9LBWdlvAzg==}
 
   '@embroider/addon-dev@8.1.0':
     resolution: {integrity: sha512-bOsEqvpAH7pLphjDUMRQTjy6TTrvocvownIlUUFrIy6JCdfIpiirgrz55MJRxy6IIUtKR4jGBh2LxEZrRbL6PQ==}
@@ -1722,6 +1796,11 @@ packages:
     resolution: {integrity: sha512-T1JIKt3h4VkpCsLfyBhAJYsGbNLoug/PP4a4bU+bnOzEcmLxRMAuECIiw7ngxlWFHH+OrWEqN5sIQ11IuOMAfw==}
     engines: {node: 12.* || 14.* || >= 16}
 
+  '@embroider/core@4.6.3':
+    resolution: {integrity: sha512-BdUDoifoB6YDJz30H+GNvQcEAB6a8/3OQinS+5wP3LlTCfPQjHChtZxdMwqvzReOSU1qVi2WGDx4xJh/0OREjg==}
+    version: 4.6.3
+    engines: {node: '>= 20.19.*'}
+
   '@embroider/macros@1.19.1':
     resolution: {integrity: sha512-KgPan7fiyoDGfr6SMdMELhcgUXK6pU/QICSK0yFFzsXVBJYM2fHAXCic5WCBETtv7xsvi4byziahSz5HpqYs/A==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -1731,8 +1810,29 @@ packages:
       '@glint/template':
         optional: true
 
+  '@embroider/macros@1.20.6':
+    resolution: {integrity: sha512-6XwqG4WepXzLtiMbs+mOLFjNzeCFg6hMi+02xQgtW7zsI86/mThAB+1nrhnrugg/Y4Hcl3y1/vLTWx0i8eLN5Q==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+
   '@embroider/reverse-exports@0.1.2':
     resolution: {integrity: sha512-TgjQalfB42RnwdRVApjcvHSVjBe+7MJfCZV0Cs1jv2QgnFGr/6f5X19PKvmF4FU4xbBf7yOsIWrVvYvidWnXlw==}
+
+  '@embroider/reverse-exports@0.2.0':
+    resolution: {integrity: sha512-WFsw8nQpHZiWGEDYpa/A79KEFfTisqteXbY+jg9eZiww1r1G+LZvsmdszDp86TkotUSCqrMbK/ewn0jR1CJmqg==}
+    engines: {node: 12.* || 14.* || >= 16}
+
+  '@embroider/router@3.0.6':
+    resolution: {integrity: sha512-D+Us/ZwE1q1W7VHuq3tNDTavv9/uewh8IUFkMocve3X3rPYRiVzaw5G5wooX+409ng1W1ApLl7bxOwZHhYU9uQ==}
+    peerDependencies:
+      '@embroider/core': ^2.0.0||^3.0.0||^4.0.0-alpha.0
+    peerDependenciesMeta:
+      '@embroider/core':
+        optional: true
 
   '@embroider/shared-internals@2.9.0':
     resolution: {integrity: sha512-8untWEvGy6av/oYibqZWMz/yB+LHsKxEOoUZiLvcpFwWj2Sipc0DcXeTJQZQZ++otNkLCWyDrDhOLrOkgjOPSg==}
@@ -1744,6 +1844,10 @@ packages:
 
   '@embroider/shared-internals@3.0.2':
     resolution: {integrity: sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+
+  '@embroider/shared-internals@3.1.1':
+    resolution: {integrity: sha512-IlxD8okTt9cRUFpJKD8gTuQUBuEflrhCUju1xZFdYvmGm5XVqHPfG4I6+bEdKb8NO92aqHxr9SYuYibDmpMM9w==}
     engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/vite@1.3.2':
@@ -2152,6 +2256,10 @@ packages:
     resolution: {integrity: sha512-eATSzBOUm0MZ9+YfJx7Y5p3gbwnaeMzLSSsCDn1ihDtUOIm5YYEV0ee0G7tXt/uKxowt8tXYn/EMbI9OlRF0CA==}
     engines: {node: '>= 18'}
 
+  '@glimmer/component@2.1.1':
+    resolution: {integrity: sha512-zFZFaMbWy+9WOcDg/kCgrkGgqkLT39EE4FgyFD0MIkQO5coQsrRZyLsiBu1tbchyM+8hT8jAv+EQVUd8u+MdSQ==}
+    engines: {node: '>= 18'}
+
   '@glimmer/debug@0.92.4':
     resolution: {integrity: sha512-waTBOdtp92MC3h/51mYbc4GRumO+Tsa5jbXLoewqALjE1S8bMu9qgkG7Cx635x3/XpjsD9xceMqagBvYhuI6tA==}
 
@@ -2299,6 +2407,16 @@ packages:
   '@glimmer/wire-format@0.94.8':
     resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
 
+  '@glint/ember-tsc@1.11.4':
+    resolution: {integrity: sha512-7lFRjaA+hv+G1usoP1IYdpcmxtNvm7uhhKjIpyuXaZG/J7kS3WaOUTvDXwL5y1dXQWqLgt/5Q54Q3Pgw1m/h8w==}
+    hasBin: true
+    peerDependencies:
+      ember-source: '>=3.28.0'
+      typescript: '>=5.6.0'
+    peerDependenciesMeta:
+      ember-source:
+        optional: true
+
   '@glint/ember-tsc@file:packages/ember-tsc':
     resolution: {directory: packages/ember-tsc, type: directory}
     hasBin: true
@@ -2308,6 +2426,9 @@ packages:
     peerDependenciesMeta:
       ember-source:
         optional: true
+
+  '@glint/template@1.9.0':
+    resolution: {integrity: sha512-AoLE/VeDcCI3vroIwP3uTjc33+44JYJbARbswRxe8/Jz7P+dWlhO+ycmigsT2WdVI051+HF9jZLsSwUXv0JxwQ==}
 
   '@glint/template@file:packages/template':
     resolution: {directory: packages/template, type: directory}
@@ -2633,6 +2754,9 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
+  '@oxc-project/types@0.147.0':
+    resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2654,6 +2778,99 @@ packages:
 
   '@reactive-vscode/reactivity@0.4.1':
     resolution: {integrity: sha512-ThNXTkTNK9LHvdlBcyzqSywlfF61FIQDlVDqv12+rkRQCCUjWsD+oilbIYYi5uAJkQ2h/yLyowx3f0YVEY1bxQ==}
+
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.6':
+    resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-babel@6.0.4':
     resolution: {integrity: sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==}
@@ -3001,6 +3218,9 @@ packages:
   '@types/qunit@2.19.13':
     resolution: {integrity: sha512-N4xp3v4s7f0jb2Oij6+6xw5QhH7/IgHCoGIFLCWtbEWoPkGYp8Te4mIwIP21qaurr6ed5JiPMiy2/ZoiGPkLIw==}
 
+  '@types/qunit@2.19.14':
+    resolution: {integrity: sha512-ou2RMtwyDnW1btrMnDMZeL6V5/yRRbuHKrRC6y8IuzDljjVzw6wPCVFb8p4qJD0NkUkf3BdZeJJIBzjK1BUUDQ==}
+
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
@@ -3104,6 +3324,48 @@ packages:
 
   '@typescript/server-harness@0.3.5':
     resolution: {integrity: sha512-YT9oe27zm7HdGXYad5SZrdJzVe9eavG3F6YplsWvAraowGtuDeY7FHPVuQPtQj6GxG097Us4JDkA8n5I4iQovQ==}
+
+  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-kSoefqC9cAFf1Ui14Gn3XmMDRn2SSEy/V4D9/N/dfhJM4/yfoadBiyeaC88o7LmyJEJQTS4zQjTGRu1q29bbhA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-RJ+NOn3OZ+EYGQE7wiPDcWQkKY5OjOMBk/bhGIfmxKWVJhWYW2Me+4YmacXq+NenzZgOUVhHikFfibMQDvhOtw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-linux-arm64@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-o3xxprsmQ0AKHMUNMgU+QRG+XpRMfswzXUOu+a4ayrQ5AnctYB7IGfdMqOSr3Oc9e/bsOwVY37aZdPcsNAfprg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-75ryeQNJLg6vyM67JxGBxP6s6dTccg/lvMSQFJARdgAd+WPilxmfzLzobSwlBHZuc5u5gxh9y42kZTpsn0Yq5Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-m2NY6lwHyjLsTOp0f6GrjvS/b1cIRxQbFxO/z7XtnsO17Gu0GTC9XhXiCuiPhyeipeERWK+SOigmEhY1S3QCcg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-win32-arm64@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-610sBfx98SyaXpRpPJ5B3gsceM8QqhqQaHDdNoG7HsTlbc/F9KEq5slJ2ZbgL2FJ6cc2UimsIbwu6XfLKkBaug==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.1.0-dev.20260821.1':
+    resolution: {integrity: sha512-gTVCj7ecihltJj8ljlNxyR6/8H5ZEnsQSALdmysyufbyqagKkRcI9iCEa1p9CK/FY3g4wX9GT8a0V3Qr1vZUEQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@typespec/ts-http-runtime@0.3.2':
     resolution: {integrity: sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==}
@@ -3528,6 +3790,10 @@ packages:
 
   babel-plugin-ember-template-compilation@3.0.1:
     resolution: {integrity: sha512-3fUgnv+azabsl2PMd+SpkV8E7vvp7oRLaXv+OJIe36G3niSVYDKJ+7n6WaPyh+z7gqeAKSBj7Bdc5dYbhEMsgQ==}
+    engines: {node: '>= 18.*'}
+
+  babel-plugin-ember-template-compilation@3.1.0:
+    resolution: {integrity: sha512-kk7cGyblE9n4MB98rqw2wuUW7YLD5FM+Tr97gNSYL4e8DBMQndLuWaWNx1wfd7o00NjFhhoTR+HZs2nj23g2Lw==}
     engines: {node: '>= 18.*'}
 
   babel-plugin-htmlbars-inline-precompile@5.3.1:
@@ -4329,6 +4595,11 @@ packages:
   decorator-transforms@2.3.0:
     resolution: {integrity: sha512-jo8c1ss9yFPudHuYYcrJ9jpkDZIoi+lOGvt+Uyp9B+dz32i50icRMx9Bfa8hEt7TnX1FyKWKkjV+cUdT/ep2kA==}
 
+  decorator-transforms@2.4.0:
+    resolution: {integrity: sha512-IB+0RqnJpuS7ndH4dVY5dfWTZsrCzN3avWFdjSiET0uT2U24jKywjpVEK97TflnZkZgiSRfmeqc1WfS+1CI23w==}
+    peerDependencies:
+      '@babel/core': ^7.23.0 || ^8.0.0
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -4518,6 +4789,10 @@ packages:
     resolution: {integrity: sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==}
     engines: {node: 10.* || >= 12.*}
 
+  ember-content-mapper@0.3.1:
+    resolution: {integrity: sha512-m46P1JIJiuMmYZc9PNWZA+KWBc7lkfTpTbtixOknxHoR9Nj5WDmLgWG011edUzqzzzFT22fvMvdukHnEYlTNgA==}
+    engines: {node: ^22.21.1 || >=24.10.0}
+
   ember-eslint-parser@0.5.13:
     resolution: {integrity: sha512-b6ALDaxs9Bb4v0uagWud/5lECb78qpXHFv7M340dUHFW4Y0RuhlsfA4Rb+765X1+6KHp8G7TaAs0UgggWUqD3g==}
     engines: {node: '>=16.0.0'}
@@ -4539,12 +4814,21 @@ packages:
       ember-source:
         optional: true
 
+  ember-modifier@4.3.0:
+    resolution: {integrity: sha512-O0rirSLQbGg0VJ/NqoQ4uN1bh2iAekZC/Ykma+FkjCM2ofrO38u+d8n3+AK6uVWeMJmogGX2KL+Is5fofoInJg==}
+
   ember-page-title@9.0.3:
     resolution: {integrity: sha512-fedRHUsvq8tIZgOii8jTrfAyeq+la/9H5eAzhNNwEyzo7nDMmqK2SxsyBUGXprd8fOacsPabLlzlucMi/4mUpA==}
     engines: {node: 16.* || >= 18}
 
   ember-qunit@9.0.4:
     resolution: {integrity: sha512-rv6gKvrdXdPBTdSZC5co82eIcDWWVR7RjafU/c+5TTz290oXhIHPoVuZbcO2F5RiAqkTW0jKzwkCP8y+2tCjFw==}
+    peerDependencies:
+      '@ember/test-helpers': '>=3.0.3'
+      qunit: ^2.13.0
+
+  ember-qunit@9.1.0:
+    resolution: {integrity: sha512-dE32lSODyv4em0ACBS8PDzrAIPKR75hhSpn/au0qFBlzbdmNA/VVsgv2aoFAVRdlQ0zYJ8EiNPFqsBFciIeXVA==}
     peerDependencies:
       '@ember/test-helpers': '>=3.0.3'
       qunit: ^2.13.0
@@ -4576,6 +4860,12 @@ packages:
 
   ember-source@7.1.0-beta.1:
     resolution: {integrity: sha512-G4fEzISgB8rK9fqvmSbm0PNwrEsC/KQduC/DKC9Lhl7+kNqv9ldCeZM5soe5rUXvlCK2mvCQHVqbYcq1j2peZg==}
+    engines: {node: '>= 20.19'}
+    peerDependencies:
+      '@glimmer/component': '>= 1.1.2'
+
+  ember-source@7.2.0:
+    resolution: {integrity: sha512-pWjYFeM76vAgiFvqrBacAsQh94vTIy8SC1X2S3goULJHJ5/tVWAZ2NtaLFx9oZd3/Lk0gGRdsCMla9rQY58vyw==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
@@ -6053,6 +6343,76 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   line-column@1.0.2:
     resolution: {integrity: sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==}
 
@@ -6437,6 +6797,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6859,6 +7224,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -6919,6 +7288,10 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -7042,6 +7415,11 @@ packages:
 
   qunit@2.24.1:
     resolution: {integrity: sha512-Eu0k/5JDjx0QnqxsE1WavnDNDgL1zgMZKsMw/AoAxnsl9p4RgyLODyo2N7abZY7CEAnvl5YUqFZdkImzbgXzSg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  qunit@2.26.0:
+    resolution: {integrity: sha512-KSv16YomcYmiK90qTOJl3Bm5IvTf2upqQDdBQWCvSQWe94FWobnUgKOpvpvZdG7VkDt3TJSI8k8g9+GGGEd7Fw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7259,6 +7637,11 @@ packages:
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
     engines: {node: 20 || >=22}
+    hasBin: true
+
+  rolldown@1.2.6:
+    resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rollup-plugin-copy-assets@2.0.3:
@@ -7867,6 +8250,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@2.1.2:
+    resolution: {integrity: sha512-9YodfrxS9g9IbFr/KOjE5bAeJ0p61n3bW6mqvy0jtoeKd1kTW1Cxm0oulm6KX2lyM9Gl6WIe8nEbY7LWv5ZJww==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -8021,6 +8408,11 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.1.0-dev.20260821.1:
+    resolution: {integrity: sha512-fSbYbC5XWI68TLeO+W0ZEZAJMSuVYlyREG3Z1+zw1vn1Ka6T8rgihYEhm3jNa0Z7PiEyD3NsR1Ux9z2t1viU9g==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -8207,6 +8599,49 @@ packages:
       yaml:
         optional: true
 
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitest@4.1.0:
     resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8266,6 +8701,10 @@ packages:
 
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-jsonrpc@9.0.2:
+    resolution: {integrity: sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==}
     engines: {node: '>=14.0.0'}
 
   vscode-languageclient@9.0.1:
@@ -8696,6 +9135,18 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.26.9':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.26.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.28.6
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.26.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -8704,7 +9155,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.10)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.26.10
+      '@babel/traverse': 7.28.6
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -8717,7 +9168,19 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.28.6)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.26.10
+      '@babel/traverse': 7.28.6
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.6
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -8748,6 +9211,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-regexp-features-plugin@7.26.3':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      regexpu-core: 6.2.0
+      semver: 6.3.1
+
   '@babel/helper-create-regexp-features-plugin@7.26.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -8761,6 +9230,16 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.2.0
       semver: 6.3.1
+
+  '@babel/helper-define-polyfill-provider@0.6.3':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-define-polyfill-provider@0.6.3(@babel/core@7.26.10)':
     dependencies:
@@ -8788,7 +9267,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.10
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -8814,6 +9293,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.26.0':
+    dependencies:
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.10
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -8829,6 +9316,14 @@ snapshots:
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
       '@babel/traverse': 7.26.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8862,6 +9357,14 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
+  '@babel/helper-remap-async-to-generator@7.25.9':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-wrap-function': 7.25.9
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -8880,12 +9383,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.26.5':
+    dependencies:
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@7.26.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.26.10
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8894,7 +9405,15 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.26.10
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.28.6':
+    dependencies:
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8918,7 +9437,7 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.10
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.27.0
     transitivePeerDependencies:
       - supports-color
@@ -8970,6 +9489,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.6
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -8986,6 +9512,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -8994,6 +9524,10 @@ snapshots:
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9(@babel/core@7.26.10)':
@@ -9005,6 +9539,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9021,6 +9563,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.28.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9053,6 +9602,14 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-decorators@7.25.9':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-decorators': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -9089,6 +9646,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2': {}
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.10)':
     dependencies:
@@ -9137,6 +9696,10 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-import-assertions@7.26.0':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9145,6 +9708,10 @@ snapshots:
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-attributes@7.26.0':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.10)':
@@ -9172,6 +9739,10 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-typescript@7.28.6':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9180,6 +9751,11 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
@@ -9194,6 +9770,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-arrow-functions@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9203,6 +9783,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-async-generator-functions@7.26.8':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-remap-async-to-generator': 7.25.9
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-async-generator-functions@7.26.8(@babel/core@7.26.10)':
     dependencies:
@@ -9219,6 +9807,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.28.6)
       '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-to-generator@7.25.9':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-remap-async-to-generator': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -9240,6 +9836,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-block-scoped-functions@7.26.5':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-block-scoped-functions@7.26.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9248,6 +9848,10 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.26.5(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-block-scoping@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.26.10)':
@@ -9259,6 +9863,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-class-properties@7.25.9':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9276,6 +9887,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-class-static-block@7.26.0':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.26.9
+      '@babel/helper-plugin-utils': 7.26.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-class-static-block@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9289,6 +9907,17 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-create-class-features-plugin': 7.26.9(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.26.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.25.9':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-replace-supers': 7.28.6
+      '@babel/traverse': 7.28.6
+      globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9316,6 +9945,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-computed-properties@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/template': 7.28.6
+
   '@babel/plugin-transform-computed-properties@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9328,6 +9962,10 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
 
+  '@babel/plugin-transform-destructuring@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9336,6 +9974,11 @@ snapshots:
   '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-dotall-regex@7.25.9':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dotall-regex@7.25.9(@babel/core@7.26.10)':
@@ -9350,6 +9993,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-duplicate-keys@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-duplicate-keys@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9358,6 +10005,11 @@ snapshots:
   '@babel/plugin-transform-duplicate-keys@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9(@babel/core@7.26.10)':
@@ -9372,6 +10024,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-dynamic-import@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-dynamic-import@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9380,6 +10036,10 @@ snapshots:
   '@babel/plugin-transform-dynamic-import@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-exponentiation-operator@7.26.3':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-exponentiation-operator@7.26.3(@babel/core@7.26.10)':
@@ -9392,6 +10052,10 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-export-namespace-from@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-export-namespace-from@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9401,6 +10065,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-for-of@7.26.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-for-of@7.26.9(@babel/core@7.26.10)':
     dependencies:
@@ -9415,6 +10086,14 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-function-name@7.25.9':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9436,6 +10115,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-json-strings@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-json-strings@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9444,6 +10127,10 @@ snapshots:
   '@babel/plugin-transform-json-strings@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-literals@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.25.9(@babel/core@7.26.10)':
@@ -9456,6 +10143,10 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-logical-assignment-operators@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-logical-assignment-operators@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9464,6 +10155,10 @@ snapshots:
   '@babel/plugin-transform-logical-assignment-operators@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-member-expression-literals@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.26.10)':
@@ -9475,6 +10170,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-modules-amd@7.25.9':
+    dependencies:
+      '@babel/helper-module-transforms': 7.26.0
+      '@babel/helper-plugin-utils': 7.26.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-modules-amd@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9492,6 +10194,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-commonjs@7.26.3':
+    dependencies:
+      '@babel/helper-module-transforms': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-commonjs@7.26.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9505,6 +10214,15 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.25.9':
+    dependencies:
+      '@babel/helper-module-transforms': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9528,6 +10246,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.25.9':
+    dependencies:
+      '@babel/helper-module-transforms': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-umd@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9544,6 +10269,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.25.9':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9556,6 +10286,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-new-target@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-new-target@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9564,6 +10298,10 @@ snapshots:
   '@babel/plugin-transform-new-target@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.26.6':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.26.6(@babel/core@7.26.10)':
@@ -9576,6 +10314,10 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-numeric-separator@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-numeric-separator@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9585,6 +10327,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-object-rest-spread@7.25.9':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-parameters': 7.25.9
 
   '@babel/plugin-transform-object-rest-spread@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9599,6 +10347,13 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.28.6)
+
+  '@babel/plugin-transform-object-super@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-replace-supers': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9616,6 +10371,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-optional-catch-binding@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-optional-catch-binding@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9625,6 +10384,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-optional-chaining@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9642,6 +10408,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-parameters@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-parameters@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9651,6 +10421,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-private-methods@7.25.9':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9664,6 +10441,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@7.25.9':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -9686,6 +10471,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-property-literals@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9695,6 +10484,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-regenerator@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      regenerator-transform: 0.15.2
 
   '@babel/plugin-transform-regenerator@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9708,6 +10502,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       regenerator-transform: 0.15.2
 
+  '@babel/plugin-transform-regexp-modifiers@7.26.0':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-regexp-modifiers@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9720,6 +10519,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-reserved-words@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-reserved-words@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9729,6 +10532,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-runtime@7.26.10':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      babel-plugin-polyfill-corejs2: 0.4.12
+      babel-plugin-polyfill-corejs3: 0.11.1
+      babel-plugin-polyfill-regenerator: 0.6.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-runtime@7.26.10(@babel/core@7.26.10)':
     dependencies:
@@ -9754,6 +10568,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-shorthand-properties@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9763,6 +10581,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-spread@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-spread@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9780,6 +10605,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-sticky-regex@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9788,6 +10617,10 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-template-literals@7.26.8':
+    dependencies:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-template-literals@7.26.8(@babel/core@7.26.10)':
@@ -9800,6 +10633,10 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-typeof-symbol@7.26.7':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-typeof-symbol@7.26.7(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9809,6 +10646,16 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.26.10)':
     dependencies:
@@ -9832,6 +10679,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-unicode-escapes@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9840,6 +10691,11 @@ snapshots:
   '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-unicode-property-regex@7.25.9':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-property-regex@7.25.9(@babel/core@7.26.10)':
@@ -9854,6 +10710,11 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-unicode-regex@7.25.9':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-unicode-regex@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -9864,6 +10725,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-unicode-sets-regex@7.25.9':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.26.3
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-sets-regex@7.25.9(@babel/core@7.26.10)':
@@ -9882,6 +10748,80 @@ snapshots:
     dependencies:
       core-js: 2.6.12
       regenerator-runtime: 0.13.11
+
+  '@babel/preset-env@7.26.9':
+    dependencies:
+      '@babel/compat-data': 7.28.6
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.9
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.9
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.9
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.25.9
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2
+      '@babel/plugin-syntax-import-assertions': 7.26.0
+      '@babel/plugin-syntax-import-attributes': 7.26.0
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6
+      '@babel/plugin-transform-arrow-functions': 7.25.9
+      '@babel/plugin-transform-async-generator-functions': 7.26.8
+      '@babel/plugin-transform-async-to-generator': 7.25.9
+      '@babel/plugin-transform-block-scoped-functions': 7.26.5
+      '@babel/plugin-transform-block-scoping': 7.25.9
+      '@babel/plugin-transform-class-properties': 7.25.9
+      '@babel/plugin-transform-class-static-block': 7.26.0
+      '@babel/plugin-transform-classes': 7.25.9
+      '@babel/plugin-transform-computed-properties': 7.25.9
+      '@babel/plugin-transform-destructuring': 7.25.9
+      '@babel/plugin-transform-dotall-regex': 7.25.9
+      '@babel/plugin-transform-duplicate-keys': 7.25.9
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.9
+      '@babel/plugin-transform-dynamic-import': 7.25.9
+      '@babel/plugin-transform-exponentiation-operator': 7.26.3
+      '@babel/plugin-transform-export-namespace-from': 7.25.9
+      '@babel/plugin-transform-for-of': 7.26.9
+      '@babel/plugin-transform-function-name': 7.25.9
+      '@babel/plugin-transform-json-strings': 7.25.9
+      '@babel/plugin-transform-literals': 7.25.9
+      '@babel/plugin-transform-logical-assignment-operators': 7.25.9
+      '@babel/plugin-transform-member-expression-literals': 7.25.9
+      '@babel/plugin-transform-modules-amd': 7.25.9
+      '@babel/plugin-transform-modules-commonjs': 7.26.3
+      '@babel/plugin-transform-modules-systemjs': 7.25.9
+      '@babel/plugin-transform-modules-umd': 7.25.9
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.9
+      '@babel/plugin-transform-new-target': 7.25.9
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.26.6
+      '@babel/plugin-transform-numeric-separator': 7.25.9
+      '@babel/plugin-transform-object-rest-spread': 7.25.9
+      '@babel/plugin-transform-object-super': 7.25.9
+      '@babel/plugin-transform-optional-catch-binding': 7.25.9
+      '@babel/plugin-transform-optional-chaining': 7.25.9
+      '@babel/plugin-transform-parameters': 7.25.9
+      '@babel/plugin-transform-private-methods': 7.25.9
+      '@babel/plugin-transform-private-property-in-object': 7.25.9
+      '@babel/plugin-transform-property-literals': 7.25.9
+      '@babel/plugin-transform-regenerator': 7.25.9
+      '@babel/plugin-transform-regexp-modifiers': 7.26.0
+      '@babel/plugin-transform-reserved-words': 7.25.9
+      '@babel/plugin-transform-shorthand-properties': 7.25.9
+      '@babel/plugin-transform-spread': 7.25.9
+      '@babel/plugin-transform-sticky-regex': 7.25.9
+      '@babel/plugin-transform-template-literals': 7.26.8
+      '@babel/plugin-transform-typeof-symbol': 7.26.7
+      '@babel/plugin-transform-unicode-escapes': 7.25.9
+      '@babel/plugin-transform-unicode-property-regex': 7.25.9
+      '@babel/plugin-transform-unicode-regex': 7.25.9
+      '@babel/plugin-transform-unicode-sets-regex': 7.25.9
+      '@babel/preset-modules': 0.1.6-no-external-plugins
+      babel-plugin-polyfill-corejs2: 0.4.12
+      babel-plugin-polyfill-corejs3: 0.11.1
+      babel-plugin-polyfill-regenerator: 0.6.3
+      core-js-compat: 3.41.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/preset-env@7.26.9(@babel/core@7.26.10)':
     dependencies:
@@ -10033,6 +10973,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-modules@0.1.6-no-external-plugins':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/types': 7.28.6
+      esutils: 2.0.3
+
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -10138,6 +11084,8 @@ snapshots:
 
   '@ember/app-tsconfig@1.0.3': {}
 
+  '@ember/app-tsconfig@2.0.0': {}
+
   '@ember/edition-utils@1.2.0': {}
 
   '@ember/library-tsconfig@1.1.3': {}
@@ -10155,12 +11103,29 @@ snapshots:
       - '@glint/template'
       - supports-color
 
+  '@ember/test-helpers@5.4.3':
+    dependencies:
+      '@ember/test-waiters': 4.1.2
+      '@embroider/addon-shim': 1.10.2
+      '@simple-dom/interface': 1.4.0
+      decorator-transforms: 2.4.0
+      dom-element-descriptors: 0.5.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@ember/test-waiters@4.1.1(@glint/template@packages+template)':
     dependencies:
       '@embroider/addon-shim': 1.10.0
       '@embroider/macros': 1.19.1(@glint/template@packages+template)
     transitivePeerDependencies:
       - '@glint/template'
+      - supports-color
+
+  '@ember/test-waiters@4.1.2':
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+    transitivePeerDependencies:
       - supports-color
 
   '@embroider/addon-dev@8.1.0(9e3d0fb54a873aed07e5f44674cb67a4)':
@@ -10299,33 +11264,41 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/macros@1.19.1':
+  '@embroider/core@4.6.3(@glint/template@file:packages/template)':
     dependencies:
-      '@embroider/shared-internals': 3.0.1
+      '@babel/core': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/traverse': 7.28.6
+      '@embroider/macros': 1.20.6(b3f2b8920a568640f5632a83f56a6bcb)
+      '@embroider/reverse-exports': 0.2.0
+      '@embroider/shared-internals': 3.1.1
       assert-never: 1.4.0
-      babel-import-util: 3.0.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
+      babel-plugin-ember-template-compilation: 3.1.0
+      broccoli-node-api: 1.7.0
+      broccoli-persistent-filter: 3.1.3
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      fast-sourcemap-concat: 2.1.1
+      fs-extra: 9.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      js-string-escape: 1.0.1
+      jsdom: 25.0.1
+      lodash: 4.17.23
       resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
       semver: 7.8.5
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
     transitivePeerDependencies:
+      - '@glint/template'
+      - bufferutil
+      - canvas
       - supports-color
-
-  '@embroider/macros@1.19.1(@glint/template@file:packages/template)':
-    dependencies:
-      '@embroider/shared-internals': 3.0.1
-      assert-never: 1.4.0
-      babel-import-util: 3.0.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.10
-      semver: 7.8.5
-    optionalDependencies:
-      '@glint/template': file:packages/template
-    transitivePeerDependencies:
-      - supports-color
+      - utf-8-validate
 
   '@embroider/macros@1.19.1(@glint/template@packages+template)':
     dependencies:
@@ -10342,10 +11315,102 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@embroider/macros@1.20.6(0fbd543995f97d93859ca234aa6d2f37)':
+    dependencies:
+      '@embroider/shared-internals': 3.1.1
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 8.3.1(@babel/core@7.26.10)
+      find-up: 5.0.0
+      lodash: 4.17.23
+      resolve: 1.22.10
+      semver: 7.8.5
+    optionalDependencies:
+      '@glint/template': file:packages/template
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@embroider/macros@1.20.6(@babel/core@7.26.10)':
+    dependencies:
+      '@embroider/shared-internals': 3.1.1
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 8.3.1(@babel/core@7.26.10)
+      find-up: 5.0.0
+      lodash: 4.17.23
+      resolve: 1.22.10
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@embroider/macros@1.20.6(@glint/template@file:packages/template)':
+    dependencies:
+      '@embroider/shared-internals': 3.1.1
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 8.3.1
+      find-up: 5.0.0
+      lodash: 4.17.23
+      resolve: 1.22.10
+      semver: 7.8.5
+    optionalDependencies:
+      '@glint/template': file:packages/template
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@embroider/macros@1.20.6(b3f2b8920a568640f5632a83f56a6bcb)':
+    dependencies:
+      '@embroider/shared-internals': 3.1.1
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 8.3.1(@babel/core@7.28.6)
+      find-up: 5.0.0
+      lodash: 4.17.23
+      resolve: 1.22.10
+      semver: 7.8.5
+    optionalDependencies:
+      '@glint/template': file:packages/template
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@embroider/macros@1.20.6(e84d370b2f8745b06341fc1f73c125b1)':
+    dependencies:
+      '@embroider/shared-internals': 3.1.1
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 8.3.1(@babel/core@7.26.10)
+      find-up: 5.0.0
+      lodash: 4.17.23
+      resolve: 1.22.10
+      semver: 7.8.5
+    optionalDependencies:
+      '@glint/template': link:packages/template
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@embroider/reverse-exports@0.1.2':
     dependencies:
       mem: 8.1.1
       resolve.exports: 2.0.3
+
+  '@embroider/reverse-exports@0.2.0':
+    dependencies:
+      mem: 8.1.1
+      resolve.exports: 2.0.3
+
+  '@embroider/router@3.0.6(5efae9c4260e56a2d8b8924425eb4b3b)':
+    dependencies:
+      '@ember/test-waiters': 4.1.2
+      '@embroider/addon-shim': 1.10.2
+    optionalDependencies:
+      '@embroider/core': 4.6.3(@glint/template@file:packages/template)
+    transitivePeerDependencies:
+      - supports-color
 
   '@embroider/shared-internals@2.9.0':
     dependencies:
@@ -10383,6 +11448,24 @@ snapshots:
       - supports-color
 
   '@embroider/shared-internals@3.0.2':
+    dependencies:
+      babel-import-util: 3.0.1
+      debug: 4.4.3
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.23
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.1
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
+      semver: 7.8.5
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/shared-internals@3.1.1':
     dependencies:
       babel-import-util: 3.0.1
       debug: 4.4.3
@@ -10703,6 +11786,13 @@ snapshots:
       '@glimmer/wire-format': 0.94.8
 
   '@glimmer/component@2.0.0':
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      '@glimmer/env': 0.1.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@glimmer/component@2.1.1':
     dependencies:
       '@embroider/addon-shim': 1.10.2
       '@glimmer/env': 0.1.7
@@ -11037,6 +12127,31 @@ snapshots:
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
+  '@glint/ember-tsc@1.11.4(76f748bc605be374e1fa74391ff76234)':
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@glint/template': 1.9.0
+      '@volar/kit': 2.4.28(typescript@7.1.0-dev.20260821.1)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/source-map': 2.4.28
+      '@volar/test-utils': 2.4.28
+      '@volar/typescript': 2.4.28
+      content-tag: 4.2.0
+      ember-estree: 0.8.0
+      silent-error: 1.1.1
+      typescript: 7.1.0-dev.20260821.1
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@glint/ember-tsc@file:packages/ember-tsc(35d90b3a038db2fe676d5738100e0bcb)':
     dependencies:
       '@glimmer/syntax': 0.95.0
@@ -11049,6 +12164,7 @@ snapshots:
       '@volar/test-utils': 2.4.28
       '@volar/typescript': 2.4.28
       content-tag: 4.2.0
+      ember-estree: 0.8.0
       silent-error: 1.1.1
       typescript: 5.9.3
       volar-service-html: 0.0.71(@volar/language-service@2.4.28)
@@ -11073,6 +12189,7 @@ snapshots:
       '@volar/test-utils': 2.4.28
       '@volar/typescript': 2.4.28
       content-tag: 4.2.0
+      ember-estree: 0.8.0
       silent-error: 1.1.1
       typescript: 5.9.3
       volar-service-html: 0.0.71(@volar/language-service@2.4.28)
@@ -11082,6 +12199,31 @@ snapshots:
       vscode-uri: 3.1.0
     optionalDependencies:
       ember-source: 7.1.0-beta.1(@glimmer/component@2.0.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@glint/ember-tsc@file:packages/ember-tsc(76f748bc605be374e1fa74391ff76234)':
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@glint/template': link:packages/template
+      '@volar/kit': 2.4.28(typescript@7.1.0-dev.20260821.1)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/source-map': 2.4.28
+      '@volar/test-utils': 2.4.28
+      '@volar/typescript': 2.4.28
+      content-tag: 4.2.0
+      ember-estree: 0.8.0
+      silent-error: 1.1.1
+      typescript: 7.1.0-dev.20260821.1
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11097,6 +12239,7 @@ snapshots:
       '@volar/test-utils': 2.4.28
       '@volar/typescript': 2.4.28
       content-tag: 4.2.0
+      ember-estree: 0.8.0
       silent-error: 1.1.1
       typescript: 5.9.3
       volar-service-html: 0.0.71(@volar/language-service@2.4.28)
@@ -11121,6 +12264,7 @@ snapshots:
       '@volar/test-utils': 2.4.28
       '@volar/typescript': 2.4.28
       content-tag: 4.2.0
+      ember-estree: 0.8.0
       silent-error: 1.1.1
       typescript: 5.9.3
       volar-service-html: 0.0.71(@volar/language-service@2.4.28)
@@ -11145,6 +12289,7 @@ snapshots:
       '@volar/test-utils': 2.4.28
       '@volar/typescript': 2.4.28
       content-tag: 4.2.0
+      ember-estree: 0.8.0
       silent-error: 1.1.1
       typescript: 5.9.3
       volar-service-html: 0.0.71(@volar/language-service@2.4.28)
@@ -11154,6 +12299,8 @@ snapshots:
       vscode-uri: 3.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@glint/template@1.9.0': {}
 
   '@glint/template@file:packages/template': {}
 
@@ -11470,6 +12617,8 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
+  '@oxc-project/types@0.147.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -11488,6 +12637,53 @@ snapshots:
   '@polka/url@1.0.0-next.28': {}
 
   '@reactive-vscode/reactivity@0.4.1': {}
+
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.6':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.6':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-babel@6.0.4(@babel/core@7.28.6)(rollup@4.59.0)':
     dependencies:
@@ -11820,6 +13016,8 @@ snapshots:
 
   '@types/qunit@2.19.13': {}
 
+  '@types/qunit@2.19.14': {}
+
   '@types/range-parser@1.2.7': {}
 
   '@types/rimraf@2.0.5':
@@ -12006,6 +13204,27 @@ snapshots:
 
   '@typescript/server-harness@0.3.5': {}
 
+  '@typescript/typescript-darwin-arm64@7.1.0-dev.20260821.1':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.1.0-dev.20260821.1':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.1.0-dev.20260821.1':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.1.0-dev.20260821.1':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.1.0-dev.20260821.1':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.1.0-dev.20260821.1':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.1.0-dev.20260821.1':
+    optional: true
+
   '@typespec/ts-http-runtime@0.3.2':
     dependencies:
       http-proxy-agent: 7.0.2
@@ -12090,6 +13309,15 @@ snapshots:
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
       typescript: 5.9.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/kit@2.4.28(typescript@7.1.0-dev.20260821.1)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 7.1.0-dev.20260821.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -12491,6 +13719,10 @@ snapshots:
       make-dir: 3.1.0
       schema-utils: 2.7.1
 
+  babel-plugin-debug-macros@0.3.4:
+    dependencies:
+      semver: 5.7.2
+
   babel-plugin-debug-macros@0.3.4(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
@@ -12531,6 +13763,12 @@ snapshots:
       babel-import-util: 3.0.1
       import-meta-resolve: 4.2.0
 
+  babel-plugin-ember-template-compilation@3.1.0:
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      babel-import-util: 3.0.1
+      import-meta-resolve: 4.2.0
+
   babel-plugin-htmlbars-inline-precompile@5.3.1:
     dependencies:
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -12555,6 +13793,14 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.10
 
+  babel-plugin-polyfill-corejs2@0.4.12:
+    dependencies:
+      '@babel/compat-data': 7.28.6
+      '@babel/helper-define-polyfill-provider': 0.6.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.26.10):
     dependencies:
       '@babel/compat-data': 7.28.6
@@ -12573,6 +13819,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs3@0.11.1:
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.6.3
+      core-js-compat: 3.41.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.11.1(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
@@ -12586,6 +13839,12 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.28.6)
       core-js-compat: 3.41.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.3:
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12728,6 +13987,19 @@ snapshots:
       json-stable-stringify: 1.2.1
       rsvp: 4.8.5
       workerpool: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  broccoli-babel-transpiler@8.0.0:
+    dependencies:
+      broccoli-persistent-filter: 3.1.3
+      clone: 2.1.2
+      hash-for-dep: 1.5.1
+      heimdalljs: 0.2.6
+      heimdalljs-logger: 0.1.10
+      json-stable-stringify: 1.2.1
+      rsvp: 4.8.5
+      workerpool: 6.5.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13335,7 +14607,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.8)
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
-      semver: 7.7.1
+      semver: 7.8.5
 
   css-select@5.2.2:
     dependencies:
@@ -13419,19 +14691,16 @@ snapshots:
       mimic-response: 3.1.0
     optional: true
 
-  decorator-transforms@2.3.0:
-    dependencies:
-      '@babel/plugin-syntax-decorators': 7.25.9
-      babel-import-util: 3.0.1
-    transitivePeerDependencies:
-      - '@babel/core'
-
   decorator-transforms@2.3.0(@babel/core@7.28.6):
     dependencies:
       '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.28.6)
       babel-import-util: 3.0.1
     transitivePeerDependencies:
       - '@babel/core'
+
+  decorator-transforms@2.4.0:
+    dependencies:
+      babel-import-util: 3.0.1
 
   deep-extend@0.6.0: {}
 
@@ -13487,8 +14756,7 @@ snapshots:
 
   detect-file@1.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   diff-sequences@29.6.3: {}
 
@@ -13564,7 +14832,7 @@ snapshots:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.10)
       '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.10)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
-      '@embroider/macros': 1.19.1
+      '@embroider/macros': 1.20.6(@babel/core@7.26.10)
       '@embroider/shared-internals': 2.9.0
       babel-loader: 8.4.1(@babel/core@7.26.10)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -13607,7 +14875,7 @@ snapshots:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.10)
       '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.10)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
-      '@embroider/macros': 1.19.1(@glint/template@file:packages/template)
+      '@embroider/macros': 1.20.6(0fbd543995f97d93859ca234aa6d2f37)
       '@embroider/shared-internals': 2.9.0
       babel-loader: 8.4.1(@babel/core@7.26.10)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -13650,7 +14918,7 @@ snapshots:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.10)
       '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.10)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
-      '@embroider/macros': 1.19.1(@glint/template@packages+template)
+      '@embroider/macros': 1.20.6(e84d370b2f8745b06341fc1f73c125b1)
       '@embroider/shared-internals': 2.9.0
       babel-loader: 8.4.1(@babel/core@7.26.10)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -13788,6 +15056,71 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-cli-babel@8.3.1:
+    dependencies:
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/plugin-proposal-decorators': 7.25.9
+      '@babel/plugin-transform-class-properties': 7.25.9
+      '@babel/plugin-transform-class-static-block': 7.26.0
+      '@babel/plugin-transform-modules-amd': 7.25.9
+      '@babel/plugin-transform-private-methods': 7.25.9
+      '@babel/plugin-transform-private-property-in-object': 7.25.9
+      '@babel/plugin-transform-runtime': 7.26.10
+      '@babel/plugin-transform-typescript': 7.28.6
+      '@babel/preset-env': 7.26.9
+      '@babel/runtime': 7.12.18
+      amd-name-resolver: 1.3.1
+      babel-plugin-debug-macros: 0.3.4
+      babel-plugin-ember-data-packages-polyfill: 0.1.2
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-module-resolver: 5.0.2
+      broccoli-babel-transpiler: 8.0.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-source: 3.0.1
+      calculate-cache-key-for-tree: 2.0.0
+      clone: 2.1.2
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-cli-version-checker: 5.1.2
+      ensure-posix-path: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-cli-babel@8.3.1(@babel/core@7.26.10):
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-amd': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-private-methods': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-private-property-in-object': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-runtime': 7.26.10(@babel/core@7.26.10)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.26.10)
+      '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
+      '@babel/runtime': 7.12.18
+      amd-name-resolver: 1.3.1
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.26.10)
+      babel-plugin-ember-data-packages-polyfill: 0.1.2
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-module-resolver: 5.0.2
+      broccoli-babel-transpiler: 8.0.0(@babel/core@7.26.10)
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-source: 3.0.1
+      calculate-cache-key-for-tree: 2.0.0
+      clone: 2.1.2
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-cli-version-checker: 5.1.2
+      ensure-posix-path: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
   ember-cli-babel@8.3.1(@babel/core@7.28.6):
     dependencies:
       '@babel/core': 7.28.6
@@ -13877,6 +15210,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-content-mapper@0.3.1(76f748bc605be374e1fa74391ff76234):
+    dependencies:
+      '@glint/ember-tsc': 1.11.4(76f748bc605be374e1fa74391ff76234)
+      tinypool: 2.1.2
+      vscode-jsonrpc: 9.0.2
+    transitivePeerDependencies:
+      - ember-source
+      - supports-color
+      - typescript
+
   ember-eslint-parser@0.5.13(974c5cf7abc9e3e2becf0a73ca85ed45):
     dependencies:
       '@babel/core': 7.28.6
@@ -13901,8 +15244,8 @@ snapshots:
 
   ember-modifier@4.2.0(23852ec33942378a099928ec3a8cfa5f):
     dependencies:
-      '@embroider/addon-shim': 1.9.0
-      decorator-transforms: 2.3.0
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.4.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
     optionalDependencies:
@@ -13913,8 +15256,8 @@ snapshots:
 
   ember-modifier@4.2.0(330956e1962cbbbd59b8187278b971da):
     dependencies:
-      '@embroider/addon-shim': 1.9.0
-      decorator-transforms: 2.3.0
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.4.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
     optionalDependencies:
@@ -13925,12 +15268,20 @@ snapshots:
 
   ember-modifier@4.2.0(bf9a32874a386a74ea54ee4d49caf0ab):
     dependencies:
-      '@embroider/addon-shim': 1.9.0
-      decorator-transforms: 2.3.0
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.4.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
     optionalDependencies:
       ember-source: 6.2.0(14129e9552d5aee26d8ef546195a6cc9)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  ember-modifier@4.3.0:
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.4.0
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -13951,6 +15302,15 @@ snapshots:
       qunit-theme-ember: 1.0.0
     transitivePeerDependencies:
       - '@glint/template'
+      - supports-color
+
+  ember-qunit@9.1.0(@ember/test-helpers@5.4.3)(qunit@2.26.0):
+    dependencies:
+      '@ember/test-helpers': 5.4.3
+      '@embroider/addon-shim': 1.10.2
+      qunit: 2.26.0
+      qunit-theme-ember: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   ember-rfc176-data@0.3.18: {}
@@ -14261,6 +15621,30 @@ snapshots:
       '@babel/core': 7.28.6
       '@embroider/addon-shim': 1.10.2
       '@glimmer/component': 2.0.0
+      '@simple-dom/interface': 1.4.0
+      backburner.js: 2.8.0
+      broccoli-file-creator: 2.1.1
+      chalk: 4.1.2
+      ember-cli-babel: 8.3.1(@babel/core@7.28.6)
+      ember-cli-get-component-path-option: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0
+      ember-router-generator: 2.0.0
+      inflection: 2.0.1
+      route-recognizer: 0.3.4
+      semver: 7.8.5
+      silent-error: 1.1.1
+      simple-html-tokenizer: 0.5.11
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-source@7.2.0(@glimmer/component@2.1.1):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@embroider/addon-shim': 1.10.2
+      '@glimmer/component': 2.1.1
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
@@ -16237,6 +17621,55 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   line-column@1.0.2:
     dependencies:
       isarray: 1.0.0
@@ -16635,6 +18068,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.18: {}
 
   nanomatch@1.2.13:
     dependencies:
@@ -17077,6 +18512,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.7: {}
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -17126,6 +18563,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
@@ -17247,6 +18690,12 @@ snapshots:
   qunit-theme-ember@1.0.0: {}
 
   qunit@2.24.1:
+    dependencies:
+      commander: 7.2.0
+      node-watch: 0.7.3
+      tiny-glob: 0.2.9
+
+  qunit@2.26.0:
     dependencies:
       commander: 7.2.0
       node-watch: 0.7.3
@@ -17514,6 +18963,27 @@ snapshots:
     dependencies:
       glob: 11.1.0
       package-json-from-dist: 1.0.1
+
+  rolldown@1.2.6:
+    dependencies:
+      '@oxc-project/types': 0.147.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.6
+      '@rolldown/binding-android-arm64': 1.2.6
+      '@rolldown/binding-darwin-arm64': 1.2.6
+      '@rolldown/binding-darwin-x64': 1.2.6
+      '@rolldown/binding-freebsd-x64': 1.2.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.6
+      '@rolldown/binding-linux-arm64-gnu': 1.2.6
+      '@rolldown/binding-linux-arm64-musl': 1.2.6
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.6
+      '@rolldown/binding-linux-s390x-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-musl': 1.2.6
+      '@rolldown/binding-openharmony-arm64': 1.2.6
+      '@rolldown/binding-win32-arm64-msvc': 1.2.6
+      '@rolldown/binding-win32-x64-msvc': 1.2.6
 
   rollup-plugin-copy-assets@2.0.3(rollup@4.59.0):
     dependencies:
@@ -18342,6 +19812,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@2.1.2: {}
+
   tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
@@ -18520,6 +19992,16 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@7.1.0-dev.20260821.1:
+    optionalDependencies:
+      '@typescript/typescript-darwin-arm64': 7.1.0-dev.20260821.1
+      '@typescript/typescript-darwin-x64': 7.1.0-dev.20260821.1
+      '@typescript/typescript-linux-arm': 7.1.0-dev.20260821.1
+      '@typescript/typescript-linux-arm64': 7.1.0-dev.20260821.1
+      '@typescript/typescript-linux-x64': 7.1.0-dev.20260821.1
+      '@typescript/typescript-win32-arm64': 7.1.0-dev.20260821.1
+      '@typescript/typescript-win32-x64': 7.1.0-dev.20260821.1
+
   uc.micro@2.1.0: {}
 
   uglify-js@3.19.3:
@@ -18656,6 +20138,16 @@ snapshots:
       '@types/node': 18.19.81
       fsevents: 2.3.3
 
+  vite@8.2.2:
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rolldown: 1.2.6
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
   vitest@4.1.0(@types/node@18.19.81):
     dependencies:
       '@vitest/expect': 4.1.0
@@ -18763,6 +20255,8 @@ snapshots:
       vscode-uri: 3.1.0
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@9.0.2: {}
 
   vscode-languageclient@9.0.1:
     dependencies:

--- a/test-packages/ts7-content-mapper-app/.vscode/settings.json
+++ b/test-packages/ts7-content-mapper-app/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  // TypeScript 7 (the native preview extension) must serve this app, so that
-  // .gts and .gjs go through the content mapper instead of Glint.
+  // TypeScript 7 must serve this app, so that .gts and .gjs go through the
+  // content mapper instead of Glint. The TypeScript 7 Nightly extension must
+  // also be installed, because only its nightly build supports content mappers.
   "js/ts.experimental.useTsgo": true
 }

--- a/test-packages/ts7-content-mapper-app/.vscode/settings.json
+++ b/test-packages/ts7-content-mapper-app/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  // TypeScript 7 (the native preview extension) must serve this app, so that
+  // .gts and .gjs go through the content mapper instead of Glint.
+  "js/ts.experimental.useTsgo": true
+}

--- a/test-packages/ts7-content-mapper-app/app/app.ts
+++ b/test-packages/ts7-content-mapper-app/app/app.ts
@@ -1,0 +1,21 @@
+/**
+ * Looking for services that come from addons?
+ *
+ * See: https://github.com/embroider-build/embroider/issues/2659
+ *
+ * We currently don't support app-tree merging from libraries.
+ *
+ * For services, I highly recommend looking in to either of
+ * - https://github.com/chancancode/ember-polaris-service-
+ * - https://ember-primitives.pages.dev/6-utils/createService.md
+ *   - https://ember-primitives.pages.dev/6-utils/createAsyncService.md
+ */
+import Application from '@ember/application';
+
+export default class App extends Application {
+  modules = {
+    ...import.meta.glob('./router.*', { eager: true }),
+    ...import.meta.glob('./templates/**/*', { eager: true }),
+    ...import.meta.glob('./services/**/*', { eager: true }),
+  };
+}

--- a/test-packages/ts7-content-mapper-app/app/components/avatar.gjs
+++ b/test-packages/ts7-content-mapper-app/app/components/avatar.gjs
@@ -1,0 +1,13 @@
+function initials(name) {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("");
+}
+
+/** @type {import("@ember/component/template-only").TOC<{ Args: { name: string } }>} */
+const Avatar = <template>
+  <span class="avatar" aria-hidden="true">{{initials @name}}</span>
+</template>;
+
+export default Avatar;

--- a/test-packages/ts7-content-mapper-app/app/components/counter.gts
+++ b/test-packages/ts7-content-mapper-app/app/components/counter.gts
@@ -1,0 +1,45 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
+import { autofocus } from "#app/modifiers/autofocus.ts";
+import { formatCount } from "#utils/format.ts";
+
+export interface CounterSignature {
+  Args: {
+    initial?: number;
+    step?: number;
+  };
+  Blocks: {
+    default: [count: number];
+  };
+  Element: HTMLDivElement;
+}
+
+export default class Counter extends Component<CounterSignature> {
+  @tracked count = this.args.initial ?? 0;
+
+  get step(): number {
+    return this.args.step ?? 1;
+  }
+
+  increment = (): void => {
+    this.count += this.step;
+  };
+
+  decrement = (): void => {
+    this.count -= this.step;
+  };
+
+  <template>
+    <div ...attributes>
+      <output>{{formatCount this.count}}</output>
+      <button type="button" {{autofocus}} {{on "click" this.increment}}>
+        +{{this.step}}
+      </button>
+      <button type="button" {{on "click" this.decrement}}>
+        -{{this.step}}
+      </button>
+      {{yield this.count}}
+    </div>
+  </template>
+}

--- a/test-packages/ts7-content-mapper-app/app/components/greeting.gts
+++ b/test-packages/ts7-content-mapper-app/app/components/greeting.gts
@@ -1,0 +1,22 @@
+import type { TOC } from "@ember/component/template-only";
+
+import { shout } from "#utils/format.ts";
+
+export interface GreetingSignature {
+  Args: {
+    name: string;
+  };
+  Blocks: {
+    default?: [];
+  };
+  Element: HTMLParagraphElement;
+}
+
+export const Greeting: TOC<GreetingSignature> = <template>
+  <p ...attributes>
+    {{shout @name}}
+    {{yield}}
+  </p>
+</template>;
+
+export default Greeting;

--- a/test-packages/ts7-content-mapper-app/app/components/index.ts
+++ b/test-packages/ts7-content-mapper-app/app/components/index.ts
@@ -1,0 +1,6 @@
+// A plain TypeScript module importing .gts and .gjs modules: the content
+// mapper resolves these imports and types the .ts side of the boundary.
+export { default as Avatar } from './avatar.gjs';
+export { default as Counter } from './counter.gts';
+export { default as Greeting } from './greeting.gts';
+export { default as TodoList } from './todo-list.gts';

--- a/test-packages/ts7-content-mapper-app/app/components/todo-list.gts
+++ b/test-packages/ts7-content-mapper-app/app/components/todo-list.gts
@@ -1,0 +1,34 @@
+import Component from "@glimmer/component";
+import { trackedArray } from "@ember/reactive/collections";
+
+export default class TodoList extends Component {
+  items = trackedArray(["Type-check templates with tsc"]);
+
+  add = (event: SubmitEvent): void => {
+    event.preventDefault();
+    if (!(event.currentTarget instanceof HTMLFormElement)) {
+      return;
+    }
+
+    const title = new FormData(event.currentTarget).get("title");
+    if (typeof title === "string" && title.trim()) {
+      this.items.push(title.trim());
+      event.currentTarget.reset();
+    }
+  };
+
+  <template>
+    <form {{on "submit" this.add}}>
+      <label>
+        New item
+        <input name="title" type="text" />
+      </label>
+      <button type="submit">Add</button>
+    </form>
+    <ul>
+      {{#each this.items as |item|}}
+        <li>{{item}}</li>
+      {{/each}}
+    </ul>
+  </template>
+}

--- a/test-packages/ts7-content-mapper-app/app/config.ts
+++ b/test-packages/ts7-content-mapper-app/app/config.ts
@@ -1,0 +1,17 @@
+interface Config {
+  environment: 'development' | 'production';
+  locationType: 'history' | 'hash' | 'none' | 'auto';
+  rootURL: string;
+  EmberENV?: Record<string, unknown>;
+  APP: Record<string, unknown> & { rootElement?: string; autoboot?: boolean };
+}
+
+const ENV: Config = {
+  environment: import.meta.env.DEV ? 'development' : 'production',
+  rootURL: '/',
+  locationType: 'history',
+  EmberENV: {},
+  APP: {},
+};
+
+export default ENV;

--- a/test-packages/ts7-content-mapper-app/app/modifiers/autofocus.ts
+++ b/test-packages/ts7-content-mapper-app/app/modifiers/autofocus.ts
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export const autofocus = modifier((element: HTMLElement) => {
+  element.focus();
+});

--- a/test-packages/ts7-content-mapper-app/app/router.ts
+++ b/test-packages/ts7-content-mapper-app/app/router.ts
@@ -1,0 +1,52 @@
+import EmbroiderRouter from '@embroider/router';
+
+import config from '#config';
+
+export default class Router extends EmbroiderRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+
+Router.map(function () {});
+
+/**
+ * Caveat:
+ * - https://github.com/embroider-build/embroider/issues/2521
+ *   We don't yet have a way to do this in a nice way
+ *
+ */
+// function bundle(name: string, loader: () => Promise<{ default: unknown }>[]) {
+//   return {
+//     names: [name],
+//     load: async () => {
+//       const [template, route, controller] = await Promise.all(loader());
+//       let slashName = name.replaceAll(".", "/");
+//       let results: Record<string, unknown> = {};
+
+//       if (template) results[`./templates/${slashName}`] = template.default;
+//       if (route) results[`./routes/${slashName}`] = route.default;
+//       if (controller) results[`./controllers/${slashName}`] = controller.default;
+
+//       return {
+//         default: results,
+//       };
+//     },
+//   };
+// }
+
+/**
+ * Examples from:
+ * - https://github.com/NullVoxPopuli/limber/blob/67e2f54bbe224052e38f9a9e566d704411e65e86/apps/repl/app/router.ts#L35
+ */
+// (window as any)._embroiderRouteBundles_ = [
+// bundle("docs", () => [import("./templates/docs.gts")]),
+// bundle("docs.repl-sdk", () => [import("./templates/docs/repl-sdk.gts")]),
+// bundle("docs.ember-repl", () => [import("./templates/docs/ember-repl.gts")]),
+// bundle("docs.embedding", () => [import("./templates/docs/embedding.gts")]),
+// bundle("docs.editor", () => [import("./templates/docs/editor.gts")]),
+// bundle("docs.whatever", () => [
+//   import("./the/template.gts"),
+//   import("./the/route.ts"),
+//   import("./the/controller.ts"),
+// ]),
+// ];

--- a/test-packages/ts7-content-mapper-app/app/templates/application.gts
+++ b/test-packages/ts7-content-mapper-app/app/templates/application.gts
@@ -1,0 +1,21 @@
+import { Avatar, Counter, Greeting, TodoList } from "#components/index.ts";
+
+<template>
+  <h1>Welcome to Ember</h1>
+
+  <Greeting @name="Ember" class="greeting">
+    (type-checked by TypeScript 7)
+  </Greeting>
+
+  <Avatar @name="Nully Vox Populi" />
+
+  <Counter @initial={{3}} @step={{2}} as |count|>
+    {{#if (gt count 9000)}}
+      <p>It's over 9000!</p>
+    {{/if}}
+  </Counter>
+
+  <TodoList />
+
+  {{outlet}}
+</template>

--- a/test-packages/ts7-content-mapper-app/app/utils/format.ts
+++ b/test-packages/ts7-content-mapper-app/app/utils/format.ts
@@ -1,0 +1,7 @@
+export function formatCount(count: number): string {
+  return new Intl.NumberFormat().format(count);
+}
+
+export function shout(text: string): string {
+  return `${text.toUpperCase()}!`;
+}

--- a/test-packages/ts7-content-mapper-app/package.json
+++ b/test-packages/ts7-content-mapper-app/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "ts7-content-mapper-app",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "imports": {
+    "#app/*": "./app/*",
+    "#config": "./app/config.ts",
+    "#components/*": "./app/components/*",
+    "#services/*": "./app/services/*",
+    "#test-helpers/*": "./tests/helpers/*",
+    "#utils/*": "./app/utils/*"
+  },
+  "exports": {
+    "./tests/*": "./tests/*",
+    "./*": "./app/*"
+  },
+  "scripts": {
+    "test": "echo 'no standalone test within this project'",
+    "test:typecheck": "tsc --noEmit --runExternalCode",
+    "test:tsc": "echo 'no standalone tsc within this project'"
+  },
+  "dependenciesMeta": {
+    "@glint/ember-tsc": {
+      "injected": true
+    },
+    "@glint/template": {
+      "injected": true
+    }
+  },
+  "devDependencies": {
+    "@ember/app-tsconfig": "2.0.0",
+    "@ember/test-helpers": "5.4.3",
+    "@ember/test-waiters": "4.1.2",
+    "@embroider/core": "4.6.3",
+    "@embroider/macros": "1.20.6",
+    "@embroider/router": "3.0.6",
+    "@glimmer/component": "2.1.1",
+    "@glint/ember-tsc": "workspace:*",
+    "@glint/template": "workspace:*",
+    "@types/qunit": "2.19.14",
+    "decorator-transforms": "2.4.0",
+    "ember-content-mapper": "0.3.1",
+    "ember-modifier": "^4.3.0",
+    "ember-qunit": "9.1.0",
+    "ember-source": "7.2.0",
+    "qunit": "2.26.0",
+    "qunit-dom": "3.5.0",
+    "typescript": "7.1.0-dev.20260821.1",
+    "vite": "8.2.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/test-packages/ts7-content-mapper-app/package.json
+++ b/test-packages/ts7-content-mapper-app/package.json
@@ -47,7 +47,7 @@
     "ember-source": "7.2.0",
     "qunit": "2.26.0",
     "qunit-dom": "3.5.0",
-    "typescript": "7.1.0-dev.20260821.1",
+    "typescript": "7.1.0-dev.20260901.1",
     "vite": "8.2.2"
   },
   "volta": {

--- a/test-packages/ts7-content-mapper-app/tests/rendering/counter-test.gts
+++ b/test-packages/ts7-content-mapper-app/tests/rendering/counter-test.gts
@@ -1,0 +1,26 @@
+import { click, render } from "@ember/test-helpers";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+import Counter from "#components/counter.gts";
+
+module("Rendering | counter", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders the initial count and increments by the step", async function (assert) {
+    await render(
+      <template>
+        <Counter @initial={{2}} @step={{3}} as |count|>
+          <span data-test-count>{{count}}</span>
+        </Counter>
+      </template>,
+    );
+
+    assert.dom("output").hasText("2");
+    assert.dom("[data-test-count]").hasText("2");
+
+    await click("button");
+
+    assert.dom("output").hasText("5");
+  });
+});

--- a/test-packages/ts7-content-mapper-app/tests/test-helper.ts
+++ b/test-packages/ts7-content-mapper-app/tests/test-helper.ts
@@ -1,0 +1,45 @@
+import { getOwner } from '@ember/owner';
+import {
+  currentRouteName,
+  currentURL,
+  getSettledState,
+  resetOnerror,
+  setApplication,
+  visit,
+} from '@ember/test-helpers';
+import { getPendingWaiterState } from '@ember/test-waiters';
+import * as QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+import { setupEmberOnerrorValidation, start as qunitStart } from 'ember-qunit';
+import { setTesting } from '@embroider/macros';
+import Application from '#app/app.ts';
+import config from '#config';
+Object.assign(window, {
+  visit,
+  getSettledState,
+  getPendingWaiterState,
+  currentURL,
+  currentRouteName,
+  getOwner,
+  snapshotTimers: (label?: string) => {
+    console.debug(
+      label ?? 'snapshotTimers',
+      JSON.parse(JSON.stringify({ settled: getSettledState(), waiters: getPendingWaiterState() })),
+    );
+  },
+});
+export function start(): void {
+  config.locationType = 'none';
+  config.APP.rootElement = '#ember-testing';
+  config.APP.autoboot = false;
+  setTesting(true);
+  setApplication(Application.create(config.APP));
+  setup(QUnit.assert);
+  setupEmberOnerrorValidation();
+  QUnit.moduleStart(({ name }) => console.group(name));
+  QUnit.testStart(({ name }) => console.group(name));
+  QUnit.testDone(() => console.groupEnd());
+  QUnit.moduleDone(() => console.groupEnd());
+  QUnit.testDone(resetOnerror);
+  qunitStart();
+}

--- a/test-packages/ts7-content-mapper-app/tests/unit/macros-test.ts
+++ b/test-packages/ts7-content-mapper-app/tests/unit/macros-test.ts
@@ -1,0 +1,26 @@
+import { assert as emberAssert } from '@ember/debug';
+import { module, test } from 'qunit';
+import { isTesting } from '@embroider/macros';
+
+module('@embroider/macros | runtime mode in tests', function () {
+  /**
+   * In compile-time mode `isTesting()` is inlined as `false` at build time,
+   * regardless of what the runtime global config says. Only when the test
+   * build runs the macros plugin in runtime mode (see babel.config.js +
+   * EMBER_ENV=test) does `isTesting()` reflect the value set by
+   * `setTesting(true)` in tests/test-helper.ts.
+   */
+  test('isTesting() is true', function (assert) {
+    assert.true(isTesting());
+  });
+
+  /**
+   * `@ember/debug`'s `assert(description, condition)` is only active when
+   * DEBUG is true (i.e. non-production builds). Assertions are stripped
+   * from production bundles, so this also doubles as a sanity check that
+   * the test build keeps DEBUG enabled.
+   */
+  test('@ember/debug assert throws when the condition is false', function (assert) {
+    assert.throws(() => emberAssert('string', false));
+  });
+});

--- a/test-packages/ts7-content-mapper-app/tsconfig.json
+++ b/test-packages/ts7-content-mapper-app/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "@ember/app-tsconfig",
+  "compilerOptions": {
+    "allowJs": true,
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "types": ["@embroider/core/virtual", "vite/client"],
+    // The injected `@glint/ember-tsc` augments these two packages, and in this
+    // monorepo it reaches them through pnpm's hoisted copies, which are
+    // different instances from the ones this app installs. TypeScript then
+    // sees two modules and the augmentations miss. A real app has one copy of
+    // each, so this only exists to make the fixture resolve like a real app.
+    "paths": {
+      "@glimmer/component": ["./node_modules/@glimmer/component/dist/index.d.ts"],
+      "ember-modifier": ["./node_modules/ember-modifier/declarations/index.d.ts"]
+    }
+  },
+  "contentMappers": [
+    {
+      "package": "ember-content-mapper",
+      "extensions": [".gts", ".gjs"]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

The extension only checked the workspace `typescript` version. The TypeScript 7 extension turns TypeScript 7 on through the `js/ts.experimental.useTsgo` setting. A TypeScript 5 workspace with that setting still started all of Glint, including the "Ember TSC" status bar item, against a tsserver that no longer runs.

## Change

- `detectTypeScript7` now also reads `js/ts.experimental.useTsgo` and the deprecated `typescript.experimental.useTsgo`. It resolves the two names with the same scope precedence as the TypeScript 7 extension. The workspace version check stays as a second trigger.
- The gate runs before Volar Labs info, editor watchers, and the status bar exist. On TypeScript 7 the extension only logs the reason and registers `.gts` and `.gjs` with the TypeScript 7 extension.
- Content mappers need a nightly TypeScript 7 build, so Glint requires the TypeScript 7 Nightly extension (`TypeScriptTeam.vscode-typescript-nightly`) to be installed. That extension has no code of its own: the TypeScript 7 extension (`TypeScriptTeam.native-preview`) runs its build and owns the registration API. Glint logs which of the two is missing.
- The module-level code that activated the built-in TypeScript extension, monkeypatched its bundle, and restarted the extension host moved into `prepareBuiltinTypeScriptExtension`. It only runs when Glint runs. The patch is now installed before the activate call.
- A new fixture, `test-packages/ts7-content-mapper-app`, is a copy of the `nvp-app` example from [ember-content-mapper](https://github.com/NullVoxPopuli/ember-content-mapper) without its build tooling. It installs TypeScript 7 and `ember-content-mapper`, and its `test:typecheck` runs `tsc --noEmit --runExternalCode` in CI. Its `.vscode/settings.json` turns TypeScript 7 on.
- A second launch configuration, "Debug Extension (TypeScript 7, content mapper)", opens that fixture in the Extension Development Host. Both TypeScript 7 extensions must be installed.

The fixture's tsconfig maps `@glimmer/component` and `ember-modifier` to its own copies with `paths`. The injected `@glint/ember-tsc` augments both packages and, in this monorepo, reaches them through pnpm's hoisted copies with different peer sets. TypeScript then sees two modules and the augmentations miss. A real app has one copy of each and does not need this.

## Not in this PR

The two `Glint V2:` commands still show in the command palette on TypeScript 7 and error with "command not found". Hiding them needs a `when` clause in `package.json`.

## Verification

`pnpm build`, the `glint2-vscode` esbuild bundle, eslint, and prettier pass. The fixture's `test:typecheck` passes on TypeScript 7.1.0-dev.20260821.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MzMboFWPpHzzHz6fPWbiM
