### PR TITLE
VS Code extension: discover the content mapper API and show the TypeScript version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,11 +30,10 @@
       // Runs the extension against a TypeScript 7 app that type-checks .gts/.gjs
       // through ember-content-mapper. The extension must stand down here: no
       // language server, no status bar item, only registering the file
-      // extensions with the TypeScript 7 extension. Two extensions must be
-      // installed: TypeScriptTeam.native-preview (TypeScript 7) and
-      // TypeScriptTeam.vscode-typescript-nightly (TypeScript 7 Nightly), whose
-      // nightly build is what supports content mappers. The app's
-      // .vscode/settings.json turns TypeScript 7 on.
+      // extensions with the TypeScript 7 extension. Install the TypeScript
+      // team's TypeScript 7 extension and, until TypeScript 7.1 is released,
+      // its nightly companion, whose build is what supports content mappers.
+      // The app's .vscode/settings.json turns TypeScript 7 on.
       // Same prerequisites as above: `tsc --build --watch` at the root and
       // `pnpm bundle:watch` in packages/vscode.
       "name": "Debug Extension (TypeScript 7, content mapper)",

--- a/packages/vscode/__tests__/helpers/async.ts
+++ b/packages/vscode/__tests__/helpers/async.ts
@@ -2,7 +2,10 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function waitUntil(callback: () => unknown, message?: string): Promise<void> {
+export async function waitUntil(
+  callback: () => unknown,
+  message?: string | (() => string),
+): Promise<void> {
   let start = Date.now();
   while (Date.now() - start < 15_000) {
     if (await callback()) {
@@ -12,5 +15,7 @@ export async function waitUntil(callback: () => unknown, message?: string): Prom
     await sleep(500);
   }
 
-  throw new Error(`waitUntil condition never came true (${message})`);
+  throw new Error(
+    `waitUntil condition never came true (${typeof message === 'function' ? message() : message})`,
+  );
 }

--- a/packages/vscode/__tests__/support/launch-from-cli.mts
+++ b/packages/vscode/__tests__/support/launch-from-cli.mts
@@ -1,7 +1,22 @@
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { runTests } from '@vscode/test-electron';
+import { spawnSync } from 'node:child_process';
+import {
+  downloadAndUnzipVSCode,
+  resolveCliArgsFromVSCodeExecutablePath,
+  runTests,
+} from '@vscode/test-electron';
 import * as fs from 'node:fs';
+
+// The TypeScript 7 run needs the TypeScript team's extensions installed in the
+// test instance. These ids are what the marketplace serves today; the nightly
+// carries the build that supports content mappers.
+const TYPESCRIPT_7_EXTENSION_IDS = [
+  'TypeScriptTeam.native-preview',
+  'TypeScriptTeam.vscode-typescript-nightly',
+];
+
+const ts7 = process.argv.includes('--ts7');
 
 const packageRoot = path.resolve(process.cwd());
 const emptyExtensionsDir = path.join(os.tmpdir(), `extensions-${Math.random()}`);
@@ -19,12 +34,37 @@ const userPreferences: Record<string, any> = {
 
 let disableExtensionArgs: string[] = [];
 
-let testRunner = 'lib/__tests__/support/vscode-runner-ts-plugin.js';
+const testRunner = ts7
+  ? 'lib/__tests__/support/vscode-runner-ts7.js'
+  : 'lib/__tests__/support/vscode-runner-ts-plugin.js';
+
+const workspace = ts7
+  ? path.resolve(packageRoot, '../../test-packages/ts7-content-mapper-app')
+  : `${packageRoot}/__fixtures__/ember-app`;
 
 fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify(userPreferences, null, 2));
 
 try {
-  runTests({
+  const vscodeExecutablePath = await downloadAndUnzipVSCode();
+
+  if (ts7) {
+    const cliArgs = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+    const installArgs = ['--extensions-dir', emptyExtensionsDir];
+    for (const id of TYPESCRIPT_7_EXTENSION_IDS) {
+      installArgs.push('--install-extension', id);
+    }
+    const result = spawnSync(cliArgs[0], cliArgs.slice(1).concat(installArgs), {
+      encoding: 'utf-8',
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    if (result.status !== 0) {
+      throw new Error(`Installing ${TYPESCRIPT_7_EXTENSION_IDS.join(', ')} failed`);
+    }
+  }
+
+  await runTests({
+    vscodeExecutablePath,
     extensionDevelopmentPath: packageRoot,
     extensionTestsPath: path.resolve(process.cwd(), testRunner),
     launchArgs: [
@@ -37,7 +77,7 @@ try {
       // Point at an empty directory so we don't have to contend with any local user preferences
       '--user-data-dir',
       emptyUserDataDir,
-      `${packageRoot}/__fixtures__/ember-app`,
+      workspace,
     ],
   });
 } catch (error) {

--- a/packages/vscode/__tests__/support/vscode-runner-ts7.ts
+++ b/packages/vscode/__tests__/support/vscode-runner-ts7.ts
@@ -1,0 +1,8 @@
+// This file is invoked by VSCode itself when configured to run extension
+// tests via the `--extensionTestsPath` flag.
+
+import { run as runShared } from './vscode-runner';
+
+export function run(runner: unknown, callback: (error: unknown, failures?: number) => void): void {
+  runShared(runner, callback, 'ts7-tests');
+}

--- a/packages/vscode/__tests__/support/vscode-runner.ts
+++ b/packages/vscode/__tests__/support/vscode-runner.ts
@@ -8,7 +8,7 @@ import Mocha = require('mocha');
 export function run(
   runner: unknown,
   callback: (error: unknown, failures?: number) => void,
-  testSubfolder: 'language-server-tests' | 'ts-plugin-tests',
+  testSubfolder: 'language-server-tests' | 'ts-plugin-tests' | 'ts7-tests',
 ): void {
   try {
     let mocha = new Mocha({ color: true, slow: 3_000, timeout: 30_000 });

--- a/packages/vscode/__tests__/ts7-tests/stand-down.test.ts
+++ b/packages/vscode/__tests__/ts7-tests/stand-down.test.ts
@@ -1,5 +1,6 @@
 import { commands, extensions, languages, Range, Uri, ViewColumn, window } from 'vscode';
 import type { Diagnostic } from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { describe, afterEach, before, test } from 'mocha';
 import { expect } from 'expect';
@@ -28,19 +29,60 @@ describe('TypeScript 7 stand-down (content mapper mode)', () => {
     expect(registered).not.toContain('glint2.restart-language-server');
   });
 
+  test('serves .gts through the tsdk the workspace points at', async () => {
+    const api = extensions.getExtension(GLINT_EXTENSION_ID)!.exports as {
+      typescript7: { version: Promise<string | undefined>; mode: Promise<string> };
+    };
+    const tsdkManifest = JSON.parse(
+      fs.readFileSync(`${rootDir}/node_modules/typescript/package.json`, 'utf8'),
+    ) as { version: string };
+
+    expect(await api.typescript7.version).toBe(tsdkManifest.version);
+    expect(await api.typescript7.mode).toBe('client');
+  });
+
+  test('the TypeScript 7 extension runs its server for .ts files', async () => {
+    await window.showTextDocument(Uri.file(`${rootDir}/app/utils/format.ts`));
+
+    const host = extensions.all.find(
+      (extension) =>
+        typeof (extension.packageJSON as { main?: unknown }).main === 'string' &&
+        typeof (extension.packageJSON as { bundledTypeScriptVersion?: unknown })
+          .bundledTypeScriptVersion === 'string',
+    );
+    expect(host).toBeDefined();
+    const api = (await host!.activate()) as {
+      initializeAPIConnection?: () => Promise<string>;
+    };
+    // Rejects with "Language server is not running." when it did not start.
+    await waitUntil(
+      () =>
+        api.initializeAPIConnection?.().then(
+          () => true,
+          () => false,
+        ),
+      'TypeScript 7 server running',
+    );
+  });
+
   test('the native server checks .gts templates and .ts files alike', async () => {
     const gtsUri = Uri.file(`${rootDir}/app/components/greeting.gts`);
     const gtsEditor = await window.showTextDocument(gtsUri, { viewColumn: ViewColumn.One });
 
     // `shout` takes a string; hand it a number inside the template.
+    const call = gtsEditor.document.getText().indexOf('{{shout @name}}');
+    expect(call).toBeGreaterThan(-1);
+    const argument = gtsEditor.document.positionAt(call + '{{shout '.length);
     await gtsEditor.edit((edit) => {
-      edit.replace(new Range(16, 12, 16, 17), '123');
+      edit.replace(new Range(argument, argument.translate(0, '@name'.length)), '123');
     });
     const gtsDiagnostic = await waitForDiagnostic(gtsUri, 2345);
     expect(gtsDiagnostic.message).toBe(
       "Argument of type 'number' is not assignable to parameter of type 'string'.",
     );
-    expect(gtsDiagnostic.range).toEqual(new Range(16, 12, 16, 15));
+    expect(gtsDiagnostic.range).toEqual(new Range(argument, argument.translate(0, 3)));
+    // One server, one report: a duplicate here means two clients serve the file.
+    expect(languages.getDiagnostics(gtsUri).filter((d) => d.code === 2345)).toHaveLength(1);
 
     const tsUri = Uri.file(`${rootDir}/app/utils/format.ts`);
     const tsEditor = await window.showTextDocument(tsUri, { viewColumn: ViewColumn.One });
@@ -58,6 +100,16 @@ describe('TypeScript 7 stand-down (content mapper mode)', () => {
 async function waitForDiagnostic(uri: Uri, code: number): Promise<Diagnostic> {
   const find = (): Diagnostic | undefined =>
     languages.getDiagnostics(uri).find((diagnostic) => diagnostic.code === code);
-  await waitUntil(find, `diagnostic ${code} for ${path.basename(uri.fsPath)}`);
+  await waitUntil(
+    find,
+    () =>
+      `diagnostic ${code} for ${path.basename(uri.fsPath)}; saw ${JSON.stringify(
+        languages.getDiagnostics(uri).map((diagnostic) => ({
+          code: diagnostic.code,
+          source: diagnostic.source,
+          message: diagnostic.message,
+        })),
+      )}`,
+  );
   return find()!;
 }

--- a/packages/vscode/__tests__/ts7-tests/stand-down.test.ts
+++ b/packages/vscode/__tests__/ts7-tests/stand-down.test.ts
@@ -1,0 +1,63 @@
+import { commands, extensions, languages, Range, Uri, ViewColumn, window } from 'vscode';
+import type { Diagnostic } from 'vscode';
+import * as path from 'path';
+import { describe, afterEach, before, test } from 'mocha';
+import { expect } from 'expect';
+import { waitUntil } from '../helpers/async';
+
+const GLINT_EXTENSION_ID = 'typed-ember.glint2-vscode';
+
+describe('TypeScript 7 stand-down (content mapper mode)', () => {
+  const rootDir = path.resolve(__dirname, '../../../../../test-packages/ts7-content-mapper-app');
+
+  before(async () => {
+    await window.showTextDocument(Uri.file(`${rootDir}/app/components/greeting.gts`));
+    await waitUntil(() => extensions.getExtension(GLINT_EXTENSION_ID)?.isActive, 'Glint activated');
+  });
+
+  afterEach(async () => {
+    while (window.activeTextEditor) {
+      await commands.executeCommand('workbench.action.files.revert');
+      await commands.executeCommand('workbench.action.closeActiveEditor');
+    }
+  });
+
+  test('registers its menu command and none of the language server commands', async () => {
+    const registered = await commands.getCommands(true);
+    expect(registered).toContain('glint2.typescript7.showMenu');
+    expect(registered).not.toContain('glint2.restart-language-server');
+  });
+
+  test('the native server checks .gts templates and .ts files alike', async () => {
+    const gtsUri = Uri.file(`${rootDir}/app/components/greeting.gts`);
+    const gtsEditor = await window.showTextDocument(gtsUri, { viewColumn: ViewColumn.One });
+
+    // `shout` takes a string; hand it a number inside the template.
+    await gtsEditor.edit((edit) => {
+      edit.replace(new Range(16, 12, 16, 17), '123');
+    });
+    const gtsDiagnostic = await waitForDiagnostic(gtsUri, 2345);
+    expect(gtsDiagnostic.message).toBe(
+      "Argument of type 'number' is not assignable to parameter of type 'string'.",
+    );
+    expect(gtsDiagnostic.range).toEqual(new Range(16, 12, 16, 15));
+
+    const tsUri = Uri.file(`${rootDir}/app/utils/format.ts`);
+    const tsEditor = await window.showTextDocument(tsUri, { viewColumn: ViewColumn.One });
+    await tsEditor.edit((edit) => {
+      edit.insert(tsEditor.document.positionAt(0), 'const n: number = "x";\n');
+    });
+    const tsDiagnostic = await waitForDiagnostic(tsUri, 2322);
+
+    // Both diagnostics must come from the same server, and never from Glint.
+    expect(gtsDiagnostic.source).toBe(tsDiagnostic.source);
+    expect(['glint', 'ts-plugin']).not.toContain(gtsDiagnostic.source);
+  });
+});
+
+async function waitForDiagnostic(uri: Uri, code: number): Promise<Diagnostic> {
+  const find = (): Diagnostic | undefined =>
+    languages.getDiagnostics(uri).find((diagnostic) => diagnostic.code === code);
+  await waitUntil(find, `diagnostic ${code} for ${path.basename(uri.fsPath)}`);
+  return find()!;
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -24,8 +24,9 @@
     "Linters"
   ],
   "scripts": {
-    "test": "pnpm build && pnpm test-ts-plugin",
+    "test": "pnpm build && pnpm test-ts-plugin && pnpm test-ts7",
     "test-ts-plugin": "node lib/__tests__/support/launch-from-cli.mjs",
+    "test-ts7": "node lib/__tests__/support/launch-from-cli.mjs --ts7",
     "test:typecheck": "echo 'no standalone typecheck within this project'",
     "test:tsc": "echo 'no standalone tsc within this project'",
     "build": "pnpm ext:gen && pnpm compile && pnpm bundle",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -6,6 +6,7 @@ import {
   middleware,
 } from '@volar/vscode';
 import * as lsp from '@volar/vscode/node';
+import { execFile } from 'node:child_process';
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
@@ -545,9 +546,13 @@ function registerTypeScript7LanguageStatus(
     'glint2.typescript7.status',
     languageIds,
   );
-  const version = resolveTypeScript7Version(libraryPath);
   status.name = 'TypeScript 7';
-  status.text = version ? `TypeScript ${version}` : 'TypeScript 7';
+  status.text = 'TypeScript 7';
+  void resolveTypeScript7Version(libraryPath).then((version) => {
+    if (version) {
+      status.text = `TypeScript ${version}`;
+    }
+  });
   status.detail = 'TypeScript Language Server';
   status.command = {
     title: 'Show Menu',
@@ -641,9 +646,10 @@ async function registerContentMapperContribution(
   const owner = await findContentMapperApi();
   if (!owner) {
     outputChannel.appendLine(
-      `[Activation] No installed extension exposes TypeScript's content mapper registration API, ` +
-        `so .gts and .gjs files will not get TypeScript 7 language features. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
+      `[Activation] No installed extension exposes TypeScript's content mapper registration API. ` +
+        `Glint will run the native TypeScript server for .gts and .gjs itself.`,
     );
+    await startNativeTypeScriptClient(context, outputChannel);
     return;
   }
 
@@ -659,6 +665,62 @@ async function registerContentMapperContribution(
   } catch (error) {
     outputChannel.appendLine(
       `[Activation] Registering .gts and .gjs with ${owner.id} failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+let nativeClient: lsp.LanguageClient | undefined;
+
+/**
+ * Runs the native TypeScript server for `.gts` and `.gjs` when no installed
+ * extension can be asked to. This speaks the same protocol the TypeScript 7
+ * extension's client does: `--lsp` over stdio, `runExternalCode` so the
+ * server may run the content mapper from tsconfig, and one custom request
+ * that names the extensions to serve. It uses the build the TypeScript 7
+ * extension would prefer, so `.ts` and `.gts` files see the same version.
+ */
+async function startNativeTypeScriptClient(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+): Promise<void> {
+  const host = preferredNativeTypeScriptHost();
+  if (!host) {
+    outputChannel.appendLine(
+      `[Activation] No installed extension ships a native TypeScript build, so .gts and .gjs files ` +
+        `will not get TypeScript 7 language features. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
+    );
+    return;
+  }
+
+  const server: lsp.ServerOptions = {
+    command: host.executable,
+    args: ['--lsp'],
+    transport: lsp.TransportKind.stdio,
+  };
+  const client = new lsp.LanguageClient('glint2-typescript7', 'TypeScript 7 (Glint)', server, {
+    documentSelector: languageIds.map((language) => ({ scheme: 'file', language })),
+    initializationOptions: { runExternalCode: true },
+    outputChannel,
+  });
+  nativeClient = client;
+  context.subscriptions.push(client);
+
+  try {
+    await client.start();
+    await client.sendRequest('custom/setContentMapperContributions', {
+      contributions: [{ extensions: ['.gts', '.gjs'] }],
+      openDocuments: vscode.workspace.textDocuments
+        .filter((document) => languageIds.includes(document.languageId))
+        .map((document) => ({ uri: document.uri.toString() })),
+    });
+    outputChannel.appendLine(
+      `[Activation] Started ${host.executable} for .gts and .gjs. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
+    );
+  } catch (error) {
+    outputChannel.appendLine(
+      `[Activation] Starting ${host.executable} for .gts and .gjs failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
@@ -748,12 +810,15 @@ async function showTypeScript7Menu(outputChannel: vscode.OutputChannel): Promise
     return;
   }
 
+  const restart = 'Restart TypeScript 7 for .gts and .gjs';
   const showOutput = 'Show Glint Output';
-  const selected = await vscode.window.showInformationMessage(
-    'No TypeScript 7 extension is running for this workspace, so its menu is not available.',
-    showOutput,
+  const selected = await vscode.window.showQuickPick(
+    nativeClient ? [restart, showOutput] : [showOutput],
+    { title: 'TypeScript 7 (Glint)' },
   );
-  if (selected === showOutput) {
+  if (selected === restart) {
+    await nativeClient?.restart();
+  } else if (selected === showOutput) {
     outputChannel.show();
   }
 }
@@ -763,34 +828,72 @@ async function showTypeScript7Menu(outputChannel: vscode.OutputChannel): Promise
  * status item, or `undefined` when it cannot be determined.
  *
  * This mirrors how the TypeScript 7 extension picks its executable. A
- * `js/ts.tsdk.path` setting wins. Otherwise, extensions that ship a build
- * declare it as `bundledTypeScriptVersion` in their manifest, and an extension
- * that only contributes a build (no entry point, like the nightly) is run in
- * preference to the bundled one. The workspace's typescript package is the
- * last resort.
+ * `js/ts.tsdk.path` setting wins. Otherwise, extensions that ship a native
+ * build under `lib/` are candidates, and one that only contributes a build
+ * (no entry point, like the nightly) is run in preference to the bundled one.
+ * Newer manifests declare the version as `bundledTypeScriptVersion`; older
+ * ones do not, so the executable is asked. The workspace's typescript package
+ * is the last resort.
  */
-function resolveTypeScript7Version(libraryPath: string): string | undefined {
+async function resolveTypeScript7Version(libraryPath: string): Promise<string | undefined> {
   const tsdkVersion = readTsdkPathVersion();
   if (tsdkVersion) {
     return tsdkVersion;
   }
 
-  let bundledVersion: string | undefined;
-  for (const extension of vscode.extensions.all) {
-    const manifest = extension.packageJSON as {
-      main?: unknown;
-      bundledTypeScriptVersion?: unknown;
-    };
-    if (typeof manifest.bundledTypeScriptVersion !== 'string') {
-      continue;
-    }
-    if (manifest.main === undefined) {
-      return manifest.bundledTypeScriptVersion;
-    }
-    bundledVersion ??= manifest.bundledTypeScriptVersion;
+  const preferred = preferredNativeTypeScriptHost();
+  if (preferred) {
+    return preferred.declaredVersion ?? (await readExecutableVersion(preferred.executable));
   }
 
-  return bundledVersion ?? detectWorkspaceTypeScriptVersion(libraryPath);
+  return detectWorkspaceTypeScriptVersion(libraryPath);
+}
+
+interface NativeTypeScriptHost {
+  executable: string;
+  declaredVersion?: string;
+  buildOnly: boolean;
+}
+
+function preferredNativeTypeScriptHost(): NativeTypeScriptHost | undefined {
+  const hosts = findNativeTypeScriptHosts();
+  return hosts.find((host) => host.buildOnly) ?? hosts[0];
+}
+
+function findNativeTypeScriptHosts(): NativeTypeScriptHost[] {
+  const suffix = process.platform === 'win32' ? '.exe' : '';
+  const hosts: NativeTypeScriptHost[] = [];
+  for (const extension of vscode.extensions.all) {
+    for (const baseName of ['tsgo', 'tsc']) {
+      const executable = path.join(extension.extensionPath, 'lib', baseName + suffix);
+      if (!fs.existsSync(executable)) {
+        continue;
+      }
+      const manifest = extension.packageJSON as {
+        main?: unknown;
+        bundledTypeScriptVersion?: unknown;
+      };
+      hosts.push({
+        executable,
+        declaredVersion:
+          typeof manifest.bundledTypeScriptVersion === 'string'
+            ? manifest.bundledTypeScriptVersion
+            : undefined,
+        buildOnly: manifest.main === undefined,
+      });
+      break;
+    }
+  }
+  return hosts;
+}
+
+function readExecutableVersion(executable: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    execFile(executable, ['--version'], { timeout: 5_000 }, (error, stdout) => {
+      const match = error ? undefined : /\d+\.\d+\.\d+\S*/.exec(stdout);
+      resolve(match?.[0]);
+    });
+  });
 }
 
 const TSDK_PATH_SETTINGS = ['js/ts.tsdk.path', 'typescript.native-preview.tsdk'];

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -890,29 +890,27 @@ function preferredNativeTypeScriptHost(): NativeTypeScriptHost | undefined {
   return hosts.find((host) => host.buildOnly) ?? hosts[0];
 }
 
+const NATIVE_TSC = 'tsc' + (process.platform === 'win32' ? '.exe' : '');
+
 function findNativeTypeScriptHosts(): NativeTypeScriptHost[] {
-  const suffix = process.platform === 'win32' ? '.exe' : '';
   const hosts: NativeTypeScriptHost[] = [];
   for (const extension of vscode.extensions.all) {
-    for (const baseName of ['tsgo', 'tsc']) {
-      const executable = path.join(extension.extensionPath, 'lib', baseName + suffix);
-      if (!fs.existsSync(executable)) {
-        continue;
-      }
-      const manifest = extension.packageJSON as {
-        main?: unknown;
-        bundledTypeScriptVersion?: unknown;
-      };
-      hosts.push({
-        executable,
-        declaredVersion:
-          typeof manifest.bundledTypeScriptVersion === 'string'
-            ? manifest.bundledTypeScriptVersion
-            : undefined,
-        buildOnly: manifest.main === undefined,
-      });
-      break;
+    const executable = path.join(extension.extensionPath, 'lib', NATIVE_TSC);
+    if (!fs.existsSync(executable)) {
+      continue;
     }
+    const manifest = extension.packageJSON as {
+      main?: unknown;
+      bundledTypeScriptVersion?: unknown;
+    };
+    hosts.push({
+      executable,
+      declaredVersion:
+        typeof manifest.bundledTypeScriptVersion === 'string'
+          ? manifest.bundledTypeScriptVersion
+          : undefined,
+      buildOnly: manifest.main === undefined,
+    });
   }
   return hosts;
 }
@@ -972,28 +970,22 @@ function resolveTsdkPackage(): TsdkPackage | undefined {
 }
 
 /**
- * The native executable inside the tsdk package, resolved the way the
- * package's own `lib/getExePath.js` does: the binary lives in a platform
- * package named after the package, the platform, and the architecture.
+ * The native `tsc` inside the tsdk package, resolved the way the package's
+ * own `lib/getExePath.js` does: the binary lives in a platform package named
+ * after the platform and the architecture. Only the `typescript` package
+ * qualifies; older native packages predate content mapper support.
  */
 function resolveTsdkExecutable(): string | undefined {
   const tsdk = resolveTsdkPackage();
-  if (!tsdk) {
+  if (tsdk?.name !== 'typescript') {
     return undefined;
   }
 
-  const baseName = tsdk.name.startsWith('@') ? tsdk.name.split('/')[1] : tsdk.name;
-  const binName = baseName === 'typescript' ? 'tsc' : 'tsgo';
-  const platformPackage = `@typescript/${baseName}-${process.platform}-${process.arch}`;
   try {
     const platformPackageJson = createRequire(tsdk.packageJsonPath).resolve(
-      `${platformPackage}/package.json`,
+      `@typescript/typescript-${process.platform}-${process.arch}/package.json`,
     );
-    const executable = path.join(
-      path.dirname(platformPackageJson),
-      'lib',
-      binName + (process.platform === 'win32' ? '.exe' : ''),
-    );
+    const executable = path.join(path.dirname(platformPackageJson), 'lib', NATIVE_TSC);
     return fs.existsSync(executable) ? executable : undefined;
   } catch {
     return undefined;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -62,7 +62,7 @@ const languageIds = ['glimmer-js', 'glimmer-ts'];
 const TS_PLUGIN_NAME = 'glint-tsserver-plugin-pack';
 const EMBER_TSC_SOURCE_SETTING = 'glint2.emberTscSource';
 const SELECT_EMBER_TSC_COMMAND = 'glint2.select-ember-tsc-source';
-const TYPESCRIPT_7_SHOW_MENU_COMMAND = 'typescript.native-preview.showMenu';
+const TYPESCRIPT_7_SHOW_MENU_COMMAND = 'glint2.typescript7.showMenu';
 
 type EmberTscSource = 'auto' | 'workspace' | 'bundled';
 
@@ -89,7 +89,7 @@ export const { activate, deactivate } = defineExtension(() => {
         `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
         `in tsconfig.json and run tsc with --runExternalCode.`,
     );
-    registerTypeScript7LanguageStatus(context, getLibraryPathSetting());
+    registerTypeScript7LanguageStatus(context, outputChannel, getLibraryPathSetting());
     void registerContentMapperContribution(context, outputChannel);
     return;
   }
@@ -525,15 +525,22 @@ interface ContentMapperApi {
   ) => vscode.Disposable;
 }
 
-const CONTENT_MAPPER_BUILD_DATE = '2026-08-19';
 const CONTENT_MAPPER_INSTALL_ADVICE =
-  `Until TypeScript 7.1 is released, install TypeScript 7 Nightly (TypeScriptTeam.vscode-typescript-nightly) ` +
-  `next to TypeScript 7 (TypeScriptTeam.native-preview). From TypeScript 7.1 on, TypeScript 7 alone is enough.`;
+  `Content mappers need a TypeScript 7 build newer than 2026-08-19. Until TypeScript 7.1 is released, ` +
+  `install the TypeScript team's nightly TypeScript 7 extension; from TypeScript 7.1 on, the TypeScript 7 ` +
+  `extension alone is enough.`;
 
 function registerTypeScript7LanguageStatus(
   context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
   libraryPath: string,
 ): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(TYPESCRIPT_7_SHOW_MENU_COMMAND, () =>
+      showTypeScript7Menu(outputChannel),
+    ),
+  );
+
   const status = vscode.languages.createLanguageStatusItem(
     'glint2.typescript7.status',
     languageIds,
@@ -647,7 +654,7 @@ async function registerContentMapperContribution(
     context.subscriptions.push(registration);
     outputChannel.appendLine(
       `[Activation] Registered .gts and .gjs with ${owner.id} for content mapper support. ` +
-        `Content mappers need a TypeScript build newer than ${CONTENT_MAPPER_BUILD_DATE}. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
+        CONTENT_MAPPER_INSTALL_ADVICE,
     );
   } catch (error) {
     outputChannel.appendLine(
@@ -661,16 +668,21 @@ async function registerContentMapperContribution(
 /**
  * The extension that exposes `registerContentMappers`, if any is installed.
  *
- * Which extension owns the API is not stable: today it is the TypeScript 7
- * extension, the build it runs may come from a separate nightly extension, and
- * the built-in TypeScript extension may absorb it later. So rather than
- * requiring particular extension ids, this activates the TypeScript team's
- * extensions plus the built-in one and takes whichever exports the API.
+ * Which extension owns the API is not stable, and its id has changed before,
+ * so no id is assumed. An already active extension that exports the API wins.
+ * Otherwise every extension that looks like a TypeScript 7 host by its
+ * manifest is activated and checked. The built-in TypeScript extension is
+ * left alone: activating it spawns a tsserver that Glint stands down from.
  */
 async function findContentMapperApi(): Promise<{ id: string; api: ContentMapperApi } | undefined> {
   for (const extension of vscode.extensions.all) {
-    const id = extension.id.toLowerCase();
-    if (!id.startsWith('typescriptteam.') && id !== 'vscode.typescript-language-features') {
+    if (extension.isActive && hasContentMapperApi(extension.exports)) {
+      return { id: extension.id, api: extension.exports };
+    }
+  }
+
+  for (const extension of vscode.extensions.all) {
+    if (extension.isActive || !looksLikeTypeScript7Extension(extension)) {
       continue;
     }
 
@@ -687,12 +699,63 @@ async function findContentMapperApi(): Promise<{ id: string; api: ContentMapperA
   return undefined;
 }
 
+/**
+ * Whether an extension's manifest marks it as a TypeScript 7 host. Extensions
+ * that ship a native TypeScript build declare `bundledTypeScriptVersion`, and
+ * the one that runs it contributes the `experimental.useTsgo` setting.
+ */
+function looksLikeTypeScript7Extension(extension: vscode.Extension<unknown>): boolean {
+  const manifest = extension.packageJSON as {
+    bundledTypeScriptVersion?: unknown;
+    contributes?: { configuration?: unknown };
+  };
+  if (typeof manifest.bundledTypeScriptVersion === 'string') {
+    return true;
+  }
+
+  const configuration = manifest.contributes?.configuration;
+  const sections = Array.isArray(configuration) ? configuration : [configuration];
+  return sections.some((section) => {
+    const properties = (section as { properties?: Record<string, unknown> } | undefined)
+      ?.properties;
+    return (
+      properties !== undefined &&
+      Object.keys(properties).some((key) => key.endsWith('.experimental.useTsgo'))
+    );
+  });
+}
+
 function hasContentMapperApi(api: unknown): api is ContentMapperApi {
   return (
     typeof api === 'object' &&
     api !== null &&
     typeof (api as { registerContentMappers?: unknown }).registerContentMappers === 'function'
   );
+}
+
+/**
+ * Opens the TypeScript 7 extension's menu from Glint's language status item.
+ * That menu command is registered at runtime by whichever extension hosts
+ * TypeScript 7, so it is looked up when clicked rather than assumed by id.
+ */
+async function showTypeScript7Menu(outputChannel: vscode.OutputChannel): Promise<void> {
+  await findContentMapperApi();
+
+  const commands = await vscode.commands.getCommands(true);
+  const menuCommand = commands.find((command) => /^typescript\.(?:.+\.)?showMenu$/.test(command));
+  if (menuCommand) {
+    await vscode.commands.executeCommand(menuCommand);
+    return;
+  }
+
+  const showOutput = 'Show Glint Output';
+  const selected = await vscode.window.showInformationMessage(
+    'No TypeScript 7 extension is running for this workspace, so its menu is not available.',
+    showOutput,
+  );
+  if (selected === showOutput) {
+    outputChannel.show();
+  }
 }
 
 /**

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -89,7 +89,7 @@ export const { activate, deactivate } = defineExtension(() => {
         `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
         `in tsconfig.json and run tsc with --runExternalCode.`,
     );
-    registerTypeScript7LanguageStatus(context);
+    registerTypeScript7LanguageStatus(context, getLibraryPathSetting());
     void registerContentMapperContribution(context, outputChannel);
     return;
   }
@@ -518,23 +518,29 @@ function resolveWorkspaceEmberTscServerPath(resolutionDir: string): string | und
   }
 }
 
-const TYPESCRIPT_7_EXTENSION_ID = 'TypeScriptTeam.native-preview';
-const TYPESCRIPT_7_NIGHTLY_EXTENSION_ID = 'TypeScriptTeam.vscode-typescript-nightly';
-
-interface TypeScript7Api {
-  registerContentMappers?: (
+interface ContentMapperApi {
+  registerContentMappers: (
     contributorId: string,
     contributions: ReadonlyArray<{ extensions: ReadonlyArray<string> }>,
   ) => vscode.Disposable;
 }
 
-function registerTypeScript7LanguageStatus(context: vscode.ExtensionContext): void {
+const CONTENT_MAPPER_BUILD_DATE = '2026-08-19';
+const CONTENT_MAPPER_INSTALL_ADVICE =
+  `Until TypeScript 7.1 is released, install TypeScript 7 Nightly (TypeScriptTeam.vscode-typescript-nightly) ` +
+  `next to TypeScript 7 (TypeScriptTeam.native-preview). From TypeScript 7.1 on, TypeScript 7 alone is enough.`;
+
+function registerTypeScript7LanguageStatus(
+  context: vscode.ExtensionContext,
+  libraryPath: string,
+): void {
   const status = vscode.languages.createLanguageStatusItem(
     'glint2.typescript7.status',
     languageIds,
   );
+  const version = resolveTypeScript7Version(libraryPath);
   status.name = 'TypeScript 7';
-  status.text = 'TypeScript 7';
+  status.text = version ? `TypeScript ${version}` : 'TypeScript 7';
   status.detail = 'TypeScript Language Server';
   status.command = {
     title: 'Show Menu',
@@ -620,61 +626,143 @@ function isInDirectory(pathToCheck: string, directory: string): boolean {
  * content-mapped `.gts` file never reaches the server and gets no hover,
  * completions, or diagnostics in the editor. Registering also lets the server
  * discover the project's tsconfig from a `.gts` file alone.
- *
- * The registration API belongs to the TypeScript 7 extension. The TypeScript 7
- * Nightly extension has no code of its own: it only ships a nightly build that
- * the TypeScript 7 extension runs instead of its bundled one. Content mappers
- * need that nightly build, so Glint requires the Nightly to be installed and
- * registers through the TypeScript 7 extension's API.
  */
 async function registerContentMapperContribution(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,
 ): Promise<void> {
-  const typeScript7 = vscode.extensions.getExtension<TypeScript7Api | undefined>(
-    TYPESCRIPT_7_EXTENSION_ID,
-  );
-  if (!typeScript7) {
+  const owner = await findContentMapperApi();
+  if (!owner) {
     outputChannel.appendLine(
-      `[Activation] The TypeScript 7 extension (${TYPESCRIPT_7_EXTENSION_ID}) is not installed, ` +
-        `so .gts and .gjs files will not get TypeScript 7 language features.`,
-    );
-    return;
-  }
-
-  if (!vscode.extensions.getExtension(TYPESCRIPT_7_NIGHTLY_EXTENSION_ID)) {
-    outputChannel.appendLine(
-      `[Activation] The TypeScript 7 Nightly extension (${TYPESCRIPT_7_NIGHTLY_EXTENSION_ID}) is not installed. ` +
-        `Content mappers need its nightly build, so .gts and .gjs files will not get TypeScript 7 language features.`,
+      `[Activation] No installed extension exposes TypeScript's content mapper registration API, ` +
+        `so .gts and .gjs files will not get TypeScript 7 language features. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
     );
     return;
   }
 
   try {
-    const api = await typeScript7.activate();
-    const registration = api?.registerContentMappers?.(V2_EXTENSION_ID, [
+    const registration = owner.api.registerContentMappers(V2_EXTENSION_ID, [
       { extensions: ['.gts', '.gjs'] },
     ]);
-
-    if (!registration) {
-      outputChannel.appendLine(
-        `[Activation] The installed TypeScript 7 extension does not support content mapper ` +
-          `registration; a build newer than 2026-08-19 is required for .gts and .gjs language features.`,
-      );
-      return;
-    }
-
     context.subscriptions.push(registration);
     outputChannel.appendLine(
-      '[Activation] Registered .gts and .gjs with TypeScript 7 for content mapper support.',
+      `[Activation] Registered .gts and .gjs with ${owner.id} for content mapper support. ` +
+        `Content mappers need a TypeScript build newer than ${CONTENT_MAPPER_BUILD_DATE}. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
     );
   } catch (error) {
     outputChannel.appendLine(
-      `[Activation] Registering with TypeScript 7 failed: ${
+      `[Activation] Registering .gts and .gjs with ${owner.id} failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
   }
+}
+
+/**
+ * The extension that exposes `registerContentMappers`, if any is installed.
+ *
+ * Which extension owns the API is not stable: today it is the TypeScript 7
+ * extension, the build it runs may come from a separate nightly extension, and
+ * the built-in TypeScript extension may absorb it later. So rather than
+ * requiring particular extension ids, this activates the TypeScript team's
+ * extensions plus the built-in one and takes whichever exports the API.
+ */
+async function findContentMapperApi(): Promise<{ id: string; api: ContentMapperApi } | undefined> {
+  for (const extension of vscode.extensions.all) {
+    const id = extension.id.toLowerCase();
+    if (!id.startsWith('typescriptteam.') && id !== 'vscode.typescript-language-features') {
+      continue;
+    }
+
+    try {
+      const api: unknown = await extension.activate();
+      if (hasContentMapperApi(api)) {
+        return { id: extension.id, api };
+      }
+    } catch {
+      // An extension that fails to activate cannot own the API.
+    }
+  }
+
+  return undefined;
+}
+
+function hasContentMapperApi(api: unknown): api is ContentMapperApi {
+  return (
+    typeof api === 'object' &&
+    api !== null &&
+    typeof (api as { registerContentMappers?: unknown }).registerContentMappers === 'function'
+  );
+}
+
+/**
+ * The TypeScript version the native language server runs, for the language
+ * status item, or `undefined` when it cannot be determined.
+ *
+ * This mirrors how the TypeScript 7 extension picks its executable. A
+ * `js/ts.tsdk.path` setting wins. Otherwise, extensions that ship a build
+ * declare it as `bundledTypeScriptVersion` in their manifest, and an extension
+ * that only contributes a build (no entry point, like the nightly) is run in
+ * preference to the bundled one. The workspace's typescript package is the
+ * last resort.
+ */
+function resolveTypeScript7Version(libraryPath: string): string | undefined {
+  const tsdkVersion = readTsdkPathVersion();
+  if (tsdkVersion) {
+    return tsdkVersion;
+  }
+
+  let bundledVersion: string | undefined;
+  for (const extension of vscode.extensions.all) {
+    const manifest = extension.packageJSON as {
+      main?: unknown;
+      bundledTypeScriptVersion?: unknown;
+    };
+    if (typeof manifest.bundledTypeScriptVersion !== 'string') {
+      continue;
+    }
+    if (manifest.main === undefined) {
+      return manifest.bundledTypeScriptVersion;
+    }
+    bundledVersion ??= manifest.bundledTypeScriptVersion;
+  }
+
+  return bundledVersion ?? detectWorkspaceTypeScriptVersion(libraryPath);
+}
+
+const TSDK_PATH_SETTINGS = ['js/ts.tsdk.path', 'typescript.native-preview.tsdk'];
+
+/**
+ * The version of a TypeScript package the user pointed the native server at
+ * through a tsdk path setting. The setting may name the package directory or
+ * its `lib` directory, so the package manifest is looked for in both.
+ */
+function readTsdkPathVersion(): string | undefined {
+  const configuration = vscode.workspace.getConfiguration();
+  for (const setting of TSDK_PATH_SETTINGS) {
+    const value = configuration.get<string>(setting);
+    if (!value) {
+      continue;
+    }
+
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const tsdkPath =
+      path.isAbsolute(value) || !workspaceRoot ? value : path.resolve(workspaceRoot, value);
+    for (const directory of [tsdkPath, path.dirname(tsdkPath)]) {
+      try {
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(directory, 'package.json'), 'utf8'),
+        ) as { version?: unknown };
+        if (typeof manifest.version === 'string') {
+          return manifest.version;
+        }
+      } catch {
+        // Not a package directory; try the parent.
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -90,9 +90,13 @@ export const { activate, deactivate } = defineExtension(() => {
         `ember-content-mapper (https://github.com/NullVoxPopuli/ember-content-mapper) to "contentMappers" ` +
         `in tsconfig.json and run tsc with --runExternalCode.`,
     );
-    registerTypeScript7LanguageStatus(context, outputChannel, getLibraryPathSetting());
-    void registerContentMapperContribution(context, outputChannel);
-    return;
+    const version = registerTypeScript7LanguageStatus(
+      context,
+      outputChannel,
+      getLibraryPathSetting(),
+    );
+    const mode = registerContentMapperContribution(context, outputChannel);
+    return { typescript7: { version, mode } };
   }
 
   prepareBuiltinTypeScriptExtension();
@@ -535,7 +539,7 @@ function registerTypeScript7LanguageStatus(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,
   libraryPath: string,
-): void {
+): Promise<string | undefined> {
   context.subscriptions.push(
     vscode.commands.registerCommand(TYPESCRIPT_7_SHOW_MENU_COMMAND, () =>
       showTypeScript7Menu(outputChannel),
@@ -548,9 +552,10 @@ function registerTypeScript7LanguageStatus(
   );
   status.name = 'TypeScript 7';
   status.text = 'TypeScript 7';
-  void resolveTypeScript7Version(libraryPath).then((version) => {
-    if (version) {
-      status.text = `TypeScript ${version}`;
+  const version = resolveTypeScript7Version(libraryPath);
+  void version.then((resolved) => {
+    if (resolved) {
+      status.text = `TypeScript ${resolved}`;
     }
   });
   status.detail = 'TypeScript Language Server';
@@ -594,6 +599,8 @@ function registerTypeScript7LanguageStatus(
     vscode.window.onDidChangeActiveTextEditor(updateProjectStatus),
     vscode.workspace.onDidChangeWorkspaceFolders(updateProjectStatus),
   );
+
+  return version;
 }
 
 function findNearestTypeScriptConfig(resource: vscode.Uri): string | undefined {
@@ -639,18 +646,20 @@ function isInDirectory(pathToCheck: string, directory: string): boolean {
  * completions, or diagnostics in the editor. Registering also lets the server
  * discover the project's tsconfig from a `.gts` file alone.
  */
+/** How `.gts` and `.gjs` reach the native TypeScript server, if at all. */
+type TypeScript7Mode = 'registered' | 'client' | 'none';
+
 async function registerContentMapperContribution(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,
-): Promise<void> {
+): Promise<TypeScript7Mode> {
   const owner = await findContentMapperApi();
   if (!owner) {
     outputChannel.appendLine(
       `[Activation] No installed extension exposes TypeScript's content mapper registration API. ` +
         `Glint will run the native TypeScript server for .gts and .gjs itself.`,
     );
-    await startNativeTypeScriptClient(context, outputChannel);
-    return;
+    return startNativeTypeScriptClient(context, outputChannel);
   }
 
   try {
@@ -662,12 +671,14 @@ async function registerContentMapperContribution(
       `[Activation] Registered .gts and .gjs with ${owner.id} for content mapper support. ` +
         CONTENT_MAPPER_INSTALL_ADVICE,
     );
+    return 'registered';
   } catch (error) {
     outputChannel.appendLine(
       `[Activation] Registering .gts and .gjs with ${owner.id} failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    return 'none';
   }
 }
 
@@ -684,23 +695,28 @@ let nativeClient: lsp.LanguageClient | undefined;
 async function startNativeTypeScriptClient(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,
-): Promise<void> {
-  const host = preferredNativeTypeScriptHost();
-  if (!host) {
+): Promise<TypeScript7Mode> {
+  const executable = resolveTsdkExecutable() ?? preferredNativeTypeScriptHost()?.executable;
+  if (!executable) {
     outputChannel.appendLine(
-      `[Activation] No installed extension ships a native TypeScript build, so .gts and .gjs files ` +
-        `will not get TypeScript 7 language features. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
+      `[Activation] No tsdk path setting resolves to a native TypeScript build and no installed ` +
+        `extension ships one, so .gts and .gjs files will not get TypeScript 7 language features. ` +
+        CONTENT_MAPPER_INSTALL_ADVICE,
     );
-    return;
+    return 'none';
   }
 
   const server: lsp.ServerOptions = {
-    command: host.executable,
+    command: executable,
     args: ['--lsp'],
     transport: lsp.TransportKind.stdio,
   };
+  // No static document selector: once it learns the extensions, the server
+  // registers document sync, diagnostics, hover, and the rest for them itself.
+  // A static selector on top would register each of those twice, so every
+  // edit would reach the server twice and corrupt its copy of the document.
   const client = new lsp.LanguageClient('glint2-typescript7', 'TypeScript 7 (Glint)', server, {
-    documentSelector: languageIds.map((language) => ({ scheme: 'file', language })),
+    documentSelector: [],
     initializationOptions: { runExternalCode: true },
     outputChannel,
   });
@@ -709,22 +725,34 @@ async function startNativeTypeScriptClient(
 
   try {
     await client.start();
+  } catch (error) {
+    outputChannel.appendLine(
+      `[Activation] Starting ${executable} for .gts and .gjs failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return 'none';
+  }
+
+  try {
     await client.sendRequest('custom/setContentMapperContributions', {
-      contributions: [{ extensions: ['.gts', '.gjs'] }],
+      contributions: [{ contributorId: V2_EXTENSION_ID, extensions: ['.gts', '.gjs'] }],
       openDocuments: vscode.workspace.textDocuments
         .filter((document) => languageIds.includes(document.languageId))
         .map((document) => ({ uri: document.uri.toString() })),
     });
-    outputChannel.appendLine(
-      `[Activation] Started ${host.executable} for .gts and .gjs. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
-    );
   } catch (error) {
     outputChannel.appendLine(
-      `[Activation] Starting ${host.executable} for .gts and .gjs failed: ${
+      `[Activation] ${executable} rejected the content mapper contribution: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
   }
+
+  outputChannel.appendLine(
+    `[Activation] Started ${executable} for .gts and .gjs. ${CONTENT_MAPPER_INSTALL_ADVICE}`,
+  );
+  return 'client';
 }
 
 /**
@@ -803,24 +831,26 @@ function hasContentMapperApi(api: unknown): api is ContentMapperApi {
 async function showTypeScript7Menu(outputChannel: vscode.OutputChannel): Promise<void> {
   await findContentMapperApi();
 
-  const commands = await vscode.commands.getCommands(true);
-  const menuCommand = commands.find((command) => /^typescript\.(?:.+\.)?showMenu$/.test(command));
-  if (menuCommand) {
-    await vscode.commands.executeCommand(menuCommand);
-    return;
-  }
-
-  const restart = 'Restart TypeScript 7 for .gts and .gjs';
-  const showOutput = 'Show Glint Output';
-  const selected = await vscode.window.showQuickPick(
-    nativeClient ? [restart, showOutput] : [showOutput],
-    { title: 'TypeScript 7 (Glint)' },
+  const extensionMenu = (await vscode.commands.getCommands(true)).find((command) =>
+    /^typescript\.(?:.+\.)?showMenu$/.test(command),
   );
-  if (selected === restart) {
-    await nativeClient?.restart();
-  } else if (selected === showOutput) {
-    outputChannel.show();
+  const items: Array<{ label: string; run: () => Thenable<unknown> }> = [];
+  if (extensionMenu) {
+    items.push({
+      label: 'TypeScript 7 extension menu',
+      run: () => vscode.commands.executeCommand(extensionMenu),
+    });
   }
+  if (nativeClient) {
+    items.push({
+      label: 'Restart TypeScript 7 for .gts and .gjs',
+      run: () => nativeClient!.restart(),
+    });
+  }
+  items.push({ label: 'Show Glint output', run: () => Promise.resolve(outputChannel.show()) });
+
+  const selected = await vscode.window.showQuickPick(items, { title: 'TypeScript 7 (Glint)' });
+  await selected?.run();
 }
 
 /**
@@ -836,9 +866,9 @@ async function showTypeScript7Menu(outputChannel: vscode.OutputChannel): Promise
  * is the last resort.
  */
 async function resolveTypeScript7Version(libraryPath: string): Promise<string | undefined> {
-  const tsdkVersion = readTsdkPathVersion();
-  if (tsdkVersion) {
-    return tsdkVersion;
+  const tsdk = resolveTsdkPackage();
+  if (tsdk) {
+    return tsdk.version;
   }
 
   const preferred = preferredNativeTypeScriptHost();
@@ -898,12 +928,20 @@ function readExecutableVersion(executable: string): Promise<string | undefined> 
 
 const TSDK_PATH_SETTINGS = ['js/ts.tsdk.path', 'typescript.native-preview.tsdk'];
 
+interface TsdkPackage {
+  packageJsonPath: string;
+  name: string;
+  version: string;
+}
+
 /**
- * The version of a TypeScript package the user pointed the native server at
- * through a tsdk path setting. The setting may name the package directory or
- * its `lib` directory, so the package manifest is looked for in both.
+ * The TypeScript package the user pointed the native server at through a
+ * tsdk path setting, or `undefined` when none is set or none resolves. The
+ * setting names the package directory; its `lib` directory is accepted too.
+ * The path is made real first, because under pnpm the package directory is a
+ * symlink and its platform package only resolves from the real location.
  */
-function readTsdkPathVersion(): string | undefined {
+function resolveTsdkPackage(): TsdkPackage | undefined {
   const configuration = vscode.workspace.getConfiguration();
   for (const setting of TSDK_PATH_SETTINGS) {
     const value = configuration.get<string>(setting);
@@ -916,11 +954,13 @@ function readTsdkPathVersion(): string | undefined {
       path.isAbsolute(value) || !workspaceRoot ? value : path.resolve(workspaceRoot, value);
     for (const directory of [tsdkPath, path.dirname(tsdkPath)]) {
       try {
-        const manifest = JSON.parse(
-          fs.readFileSync(path.join(directory, 'package.json'), 'utf8'),
-        ) as { version?: unknown };
-        if (typeof manifest.version === 'string') {
-          return manifest.version;
+        const packageJsonPath = fs.realpathSync(path.join(directory, 'package.json'));
+        const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+          name?: unknown;
+          version?: unknown;
+        };
+        if (typeof manifest.name === 'string' && typeof manifest.version === 'string') {
+          return { packageJsonPath, name: manifest.name, version: manifest.version };
         }
       } catch {
         // Not a package directory; try the parent.
@@ -929,6 +969,35 @@ function readTsdkPathVersion(): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * The native executable inside the tsdk package, resolved the way the
+ * package's own `lib/getExePath.js` does: the binary lives in a platform
+ * package named after the package, the platform, and the architecture.
+ */
+function resolveTsdkExecutable(): string | undefined {
+  const tsdk = resolveTsdkPackage();
+  if (!tsdk) {
+    return undefined;
+  }
+
+  const baseName = tsdk.name.startsWith('@') ? tsdk.name.split('/')[1] : tsdk.name;
+  const binName = baseName === 'typescript' ? 'tsc' : 'tsgo';
+  const platformPackage = `@typescript/${baseName}-${process.platform}-${process.arch}`;
+  try {
+    const platformPackageJson = createRequire(tsdk.packageJsonPath).resolve(
+      `${platformPackage}/package.json`,
+    );
+    const executable = path.join(
+      path.dirname(platformPackageJson),
+      'lib',
+      binName + (process.platform === 'win32' ? '.exe' : ''),
+    );
+    return fs.existsSync(executable) ? executable : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/test-packages/ts7-content-mapper-app/.vscode/settings.json
+++ b/test-packages/ts7-content-mapper-app/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   // TypeScript 7 must serve this app, so that .gts and .gjs go through the
-  // content mapper instead of Glint. The TypeScript 7 Nightly extension must
-  // also be installed, because only its nightly build supports content mappers.
+  // content mapper instead of Glint. Until TypeScript 7.1 is released, the
+  // TypeScript team's nightly extension must also be installed, because only
+  // its build supports content mappers.
   "js/ts.experimental.useTsgo": true
 }

--- a/test-packages/ts7-content-mapper-app/.vscode/settings.json
+++ b/test-packages/ts7-content-mapper-app/.vscode/settings.json
@@ -8,5 +8,5 @@
   // `typescript` one, and without it their built-in extension starts its own
   // tsserver beside the native one.
   "js/ts.experimental.useTsgo": true,
-  "js/ts.tsdk.path": "./node_modules/typescript-7"
+  "js/ts.tsdk.path": "./node_modules/typescript"
 }

--- a/test-packages/ts7-content-mapper-app/.vscode/settings.json
+++ b/test-packages/ts7-content-mapper-app/.vscode/settings.json
@@ -8,5 +8,5 @@
   // `typescript` one, and without it their built-in extension starts its own
   // tsserver beside the native one.
   "js/ts.experimental.useTsgo": true,
-  "typescript.experimental.useTsgo": true
+  "js/ts.tsdk.path": "./node_modules/typescript-7"
 }

--- a/test-packages/ts7-content-mapper-app/.vscode/settings.json
+++ b/test-packages/ts7-content-mapper-app/.vscode/settings.json
@@ -3,5 +3,10 @@
   // content mapper instead of Glint. Until TypeScript 7.1 is released, the
   // TypeScript team's nightly extension must also be installed, because only
   // its build supports content mappers.
-  "js/ts.experimental.useTsgo": true
+  //
+  // Both setting names are set: older VS Code builds read only the
+  // `typescript` one, and without it their built-in extension starts its own
+  // tsserver beside the native one.
+  "js/ts.experimental.useTsgo": true,
+  "typescript.experimental.useTsgo": true
 }


### PR DESCRIPTION
## Problems

1. The TypeScript 7 stand-down path required fixed extension ids before it registered `.gts` and `.gjs`.
2. With the marketplace extensions installed, `.gts` files got nothing. The released TypeScript 7 extension is from July and has no `registerContentMappers`; the nightly extension only ships a build.
3. The language status item showed a fixed "TypeScript 7" label, and its "Show Menu" did nothing while the TypeScript 7 extension's server was not running.
4. In the fixture, `js/ts.tsdk.path` pointed at a directory that does not exist.

## Change

- Glint finds the content mapper API without ids: an active extension exporting it, else extensions whose manifest marks them as a TypeScript 7 host. The built-in TypeScript extension is never activated.
- When no extension exposes the API, Glint runs the native server for `.gts` and `.gjs` itself. It honors `js/ts.tsdk.path` the way the package's own `getExePath.js` does (platform package, after realpath for pnpm), else the build an installed extension ships, nightly first. It speaks the extension client's protocol: `--lsp` over stdio, `runExternalCode`, and `custom/setContentMapperContributions` with a `contributorId`. It has no static document selector, because the server registers sync, diagnostics, hover, and the rest for the content-mapped extensions itself; a static selector on top delivered each edit twice.
- The status item shows `TypeScript <version>` from the same resolution, so `.ts` and `.gts` agree. Its menu is Glint's own quick pick: the extension's menu when present, a restart of Glint's client, and Glint's output.
- The advice in log lines names no extension ids.
- The fixture's `js/ts.tsdk.path` is `./node_modules/typescript`.
- Activation on the TypeScript 7 path exports `{ typescript7: { version, mode } }`.

## Test

`pnpm --filter glint2-vscode test-ts7` installs the two marketplace TypeScript 7 extensions into a fresh VS Code and opens the fixture. It checks that Glint's language server commands are absent, that the exported version equals the fixture's `typescript` package version and the mode is `client`, that the TypeScript 7 extension's server runs for `.ts`, and that a template type error in `.gts` and a type error in `.ts` come from the same server with exactly one diagnostic. Passes locally on VS Code 1.135.0, as do the TypeScript 5 plugin tests.

## Not Glint's

"Falling back to legacy node.js based file watching" and "Could not load the TypeScript version at this path" come from VS Code's built-in TypeScript extension. Its "Select TypeScript Version" picker cannot load a TypeScript 7 package; use the TypeScript 7 extension's own version command instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MzMboFWPpHzzHz6fPWbiM
